### PR TITLE
Adds support for "as" usage in var declarations

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using OpenDreamShared.Dream;
 using DereferenceType = OpenDreamShared.Compiler.DM.DMASTDereference.DereferenceType;
@@ -75,6 +75,11 @@ namespace OpenDreamShared.Compiler.DM {
                             }
                         } else {
                             if (path.Path.FindElement("var") != -1) {
+                                if (Check(TokenType.DM_As))
+                                {
+                                    Whitespace();
+                                    Consume(TokenType.DM_Identifier, "Expected as identifier");
+                                }
                                 return new DMASTObjectVarDefinition(path, new DMASTConstantNull());
                             } else {
                                 return new DMASTObjectDefinition(path, null);

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -75,11 +75,8 @@ namespace OpenDreamShared.Compiler.DM {
                             }
                         } else {
                             if (path.Path.FindElement("var") != -1) {
-                                if (Check(TokenType.DM_As))
-                                {
-                                    Whitespace();
-                                    Consume(TokenType.DM_Identifier, "Expected as identifier");
-                                }
+                                Whitespace();
+                                AsTypes();
                                 return new DMASTObjectVarDefinition(path, new DMASTConstantNull());
                             } else {
                                 return new DMASTObjectDefinition(path, null);


### PR DESCRIPTION
Fixes #9 

AFAIK the BYOND compiler just ignores this.