### PR TITLE
Add Rider dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 /DMCompiler/Properties
 /packages/System.Net.Sockets.4.3.0
 /TestGame/environment.json
+
+# JetBrains Rider
+.idea/
+*.sln.iml


### PR DESCRIPTION
The Rider IDE creates some user-specific files in the project directory. This gitignores them to make using Rider with OpenDream slightly less of a pain.