### PR TITLE
Fixes lexing multiline strings that contain whitespace

### DIFF
--- a/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -193,13 +193,12 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
             if (current == '\\') {
                 if (_source[_currentPosition] == '\n') { //Skip a newline if it comes after a backslash
                     base.Advance();
-
+                    
+                    current = Advance();
                     while (current == ' ' || current == '\t' || current == '\n')
                     {
                         current = Advance();
                     }
-                    
-                    current = Advance();
                 }
             }
 

--- a/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -194,6 +194,11 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
                 if (_source[_currentPosition] == '\n') { //Skip a newline if it comes after a backslash
                     base.Advance();
 
+                    while (current == ' ' || current == '\t')
+                    {
+                        current = Advance();
+                    }
+                    
                     current = Advance();
                 }
             }
@@ -212,7 +217,7 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
             Queue<Token> stringTokens = new();
 
             Advance();
-            while (!AtEndOfSource) {
+            while (!(!isLong && GetCurrent() == '\n') && !AtEndOfSource) {
                 char stringC = GetCurrent();
 
                 textBuilder.Append(stringC);
@@ -239,21 +244,6 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
                     textBuilder.Append(GetCurrent());
                     
                     Advance();
-                } else if (stringC == '\n' && !isLong) {
-                    Advance();
-                    if (GetCurrent() == '\t')
-                    {
-                        while (!AtEndOfSource && GetCurrent() == '\t')
-                        {
-                            textBuilder.Append('\t');
-                            Advance();
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
-                    
                 } else if (stringC == terminator) {
                     if (isLong) {
                         stringC = Advance();

--- a/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -194,7 +194,7 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
                 if (_source[_currentPosition] == '\n') { //Skip a newline if it comes after a backslash
                     base.Advance();
 
-                    while (current == ' ' || current == '\t')
+                    while (current == ' ' || current == '\t' || current == '\n')
                     {
                         current = Advance();
                     }

--- a/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -204,7 +204,7 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
             Queue<Token> stringTokens = new();
 
             Advance();
-            while (!(!isLong && GetCurrent() == '\n') && !AtEndOfSource) {
+            while (!AtEndOfSource) {
                 char stringC = GetCurrent();
 
                 textBuilder.Append(stringC);
@@ -229,7 +229,23 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
                 } else if (stringC == '\\') {
                     Advance();
                     textBuilder.Append(GetCurrent());
+                    
                     Advance();
+                } else if (stringC == '\n' && !isLong) {
+                    Advance();
+                    if (GetCurrent() == '\t')
+                    {
+                        while (!AtEndOfSource && GetCurrent() == '\t')
+                        {
+                            textBuilder.Append('\t');
+                            Advance();
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    
                 } else if (stringC == terminator) {
                     if (isLong) {
                         stringC = Advance();


### PR DESCRIPTION
**Disclaimer: I am not 100% sure this works as intended**

String parsing is still a bit above my paygrade, but I _think_ this fixes #10 

The main thing I'm iffy on is whether or not `textBuilder.Append('\t');` is needed.