### PR TITLE
Adds support for as()

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -356,8 +356,6 @@ namespace OpenDreamShared.Compiler.DM {
                 if (procStatement == null) procStatement = While();
                 if (procStatement == null) procStatement = DoWhile();
                 if (procStatement == null) procStatement = Switch();
-                Whitespace();
-                Check(TokenType.Skip);
 
                 if (procStatement != null)
                 {

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -1633,8 +1633,13 @@ namespace OpenDreamShared.Compiler.DM {
             DMValueType type = DMValueType.Anything;
 
             if (Check(TokenType.DM_As)) {
+                if (Check(TokenType.DM_LeftParenthesis) && Check(TokenType.DM_RightParenthesis))
+                {
+                    return DMValueType.Anything;
+                }
+                
                 Whitespace();
-
+                
                 do {
                     Token typeToken = Current();
 

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -356,6 +356,8 @@ namespace OpenDreamShared.Compiler.DM {
                 if (procStatement == null) procStatement = While();
                 if (procStatement == null) procStatement = DoWhile();
                 if (procStatement == null) procStatement = Switch();
+                Whitespace();
+                Check(TokenType.Skip);
 
                 return procStatement;
             }

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -1641,15 +1641,21 @@ namespace OpenDreamShared.Compiler.DM {
             DMValueType type = DMValueType.Anything;
 
             if (Check(TokenType.DM_As)) {
-                if (Check(TokenType.DM_LeftParenthesis) && Check(TokenType.DM_RightParenthesis))
-                {
-                    return DMValueType.Anything;
-                }
                 
                 Whitespace();
+                bool parenthetical = Check(TokenType.DM_LeftParenthesis);
+                bool closed = false;
+                Whitespace();
+                
                 do {
                     Token typeToken = Current();
 
+                    if (parenthetical)
+                    {
+                        closed = Check(TokenType.DM_RightParenthesis);
+                        if (closed) break;
+                    }
+                    
                     Consume(new TokenType[] { TokenType.DM_Identifier, TokenType.DM_Null }, "Expected value type");
                     switch (typeToken.Text) {
                         case "anything": type |= DMValueType.Anything; break;
@@ -1666,6 +1672,11 @@ namespace OpenDreamShared.Compiler.DM {
                         default: Error("Invalid value type '" + typeToken.Text + "'"); break;
                     }
                 } while (Check(TokenType.DM_Bar));
+                
+                if (parenthetical && !closed) { 
+                    Whitespace();
+                    Consume(TokenType.DM_RightParenthesis, "Expected closing parenthesis");
+                }
             }
 
             return type;


### PR DESCRIPTION
Doing 
```
for(var/item/thing/T as() in some_list)
``` 
is the same as 
```
for(var/item/thing/T as anything in some_list)
```

Both define a loop without internal typechecking.