### PR TITLE
Adds support for implicit as types

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -1376,7 +1376,7 @@ namespace OpenDreamShared.Compiler.DM {
                             Whitespace();
 
                             if (identifier != null && identifier.Identifier == "input") {
-                                DMValueType types = AsTypes();
+                                DMValueType types = AsTypes(defaultType: DMValueType.Text);
                                 Whitespace();
                                 DMASTExpression list = null;
 
@@ -1635,7 +1635,7 @@ namespace OpenDreamShared.Compiler.DM {
             }
         }
 
-        private DMValueType AsTypes() {
+        private DMValueType AsTypes(DMValueType defaultType = DMValueType.Anything) {
             DMValueType type = DMValueType.Anything;
 
             if (Check(TokenType.DM_As)) {
@@ -1675,6 +1675,9 @@ namespace OpenDreamShared.Compiler.DM {
                     Whitespace();
                     Consume(TokenType.DM_RightParenthesis, "Expected closing parenthesis");
                 }
+            }
+            else {
+                return defaultType;
             }
 
             return type;


### PR DESCRIPTION
Should partially fix #36 

According to the docs, if Type is not specified then `input()` treats it as an implicit `text` type. So `AsTypes()` can now return a default type if there is no `as` token.