### PR TITLE
Server tweaks

### DIFF
--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -103,9 +103,8 @@ namespace OpenDreamServer.Dream {
         public object GetValueExpectingType(DreamValueType type) {
             if (IsType(type)) {
                 return Value;
-            } else {
-                throw new Exception("Value " + this + " was not the expected type of " + type + "");
             }
+            throw new Exception("Value " + this + " was not the expected type of " + type + "");
         }
 
         public string GetValueAsString() {
@@ -282,9 +281,8 @@ namespace OpenDreamServer.Dream {
         public override int GetHashCode() {
             if (Value != null) {
                 return Value.GetHashCode();
-            } else {
-                return 0;
             }
+            return 0;
         }
 
         public static bool operator ==(DreamValue a, DreamValue b) {

--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -70,36 +70,28 @@ namespace OpenDreamServer.Dream {
         public DreamValue(object value) {
             Value = value;
 
-            if (value is string) {
-                Type = DreamValueType.String;
-            } else if (value is int) {
-                Type = DreamValueType.Integer;
-            } else if (value is float) {
-                Type = DreamValueType.Float;
-            } else if (value is DreamResource) {
-                Type = DreamValueType.DreamResource;
-            } else if (value is DreamObject) {
-                Type = DreamValueType.DreamObject;
-            } else if (value is DreamPath) {
-                Type = DreamValueType.DreamPath;
-            } else if (value is DreamProc) {
-                Type = DreamValueType.DreamProc;
-            } else {
-                throw new ArgumentException("Invalid DreamValue value (" + value + ")");
-            }
+            Type = value switch {
+                string => DreamValueType.String,
+                int => DreamValueType.Integer,
+                float => DreamValueType.Float,
+                DreamResource => DreamValueType.DreamResource,
+                DreamObject => DreamValueType.DreamObject,
+                DreamPath => DreamValueType.DreamPath,
+                DreamProc => DreamValueType.DreamProc,
+                _ => throw new ArgumentException("Invalid DreamValue value (" + value + ")")
+            };
         }
 
         public override string ToString() {
             string value;
             if (Value == null) {
                 value = "null";
-            } else if (Type == DreamValueType.String) {
-                value = "\"" + Value + "\"";
-            } else if (Type == DreamValueType.DreamResource) {
-                value = "'" + ((DreamResource)Value).ResourcePath + "'";
-            } else {
-                value = Value.ToString();
-            }
+            } else
+                value = Type switch {
+                    DreamValueType.String => "\"" + Value + "\"",
+                    DreamValueType.DreamResource => "'" + ((DreamResource)Value).ResourcePath + "'",
+                    _ => Value.ToString()
+                };
 
             return "DreamValue(" + Type + ", " + value + ")";
         }

--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -243,19 +243,20 @@ namespace OpenDreamServer.Dream {
         }
 
         public string Stringify() {
-            if (Type == DreamValueType.String) {
-                return GetValueAsString();
-            } else if (Type == DreamValueType.Integer) {
-                return GetValueAsInteger().ToString();
-            } else if (Type == DreamValueType.Float) {
-                return GetValueAsFloat().ToString();
-            } else if (Type == DreamValueType.DreamResource) {
-                return GetValueAsDreamResource().ResourcePath;
-            } else if (Type == DreamValueType.DreamPath) {
-                return GetValueAsPath().PathString;
-            } else if (Type == DreamValueType.DreamObject) {
-                if (Value == null) return "";
-                else {
+            switch (Type) {
+                case DreamValueType.String:
+                    return GetValueAsString();
+                case DreamValueType.Integer:
+                    return GetValueAsInteger().ToString();
+                case DreamValueType.Float:
+                    return GetValueAsFloat().ToString();
+                case DreamValueType.DreamResource:
+                    return GetValueAsDreamResource().ResourcePath;
+                case DreamValueType.DreamPath:
+                    return GetValueAsPath().PathString;
+                case DreamValueType.DreamObject when Value == null:
+                    return "";
+                case DreamValueType.DreamObject: {
                     DreamObject dreamObject = GetValueAsDreamObject();
 
                     if (dreamObject.IsSubtypeOf(DreamPath.Atom)) {
@@ -264,8 +265,8 @@ namespace OpenDreamServer.Dream {
                         return dreamObject.ObjectDefinition.Type.ToString();
                     }
                 }
-            } else {
-                throw new NotImplementedException("Cannot stringify " + this);
+                default:
+                    throw new NotImplementedException("Cannot stringify " + this);
             }
         }
 

--- a/OpenDreamServer/Dream/Objects/DreamList.cs
+++ b/OpenDreamServer/Dream/Objects/DreamList.cs
@@ -118,7 +118,7 @@ namespace OpenDreamServer.Dream.Objects {
             ValueAssigned?.Invoke(this, new DreamValue(_values.Count), value);
         }
 
-        public bool IsValidAssociativeKey(DreamValue key) {
+        public static bool IsValidAssociativeKey(DreamValue key) {
             return key.Value != null && key.IsType( DreamValue.DreamValueType.String |
                                                     DreamValue.DreamValueType.DreamPath |
                                                     DreamValue.DreamValueType.DreamObject |

--- a/OpenDreamServer/Dream/Objects/DreamList.cs
+++ b/OpenDreamServer/Dream/Objects/DreamList.cs
@@ -83,7 +83,7 @@ namespace OpenDreamServer.Dream.Objects {
         }
 
         public virtual void SetValue(DreamValue key, DreamValue value) {
-            if (ValueAssigned != null) ValueAssigned.Invoke(this, key, value);
+            ValueAssigned?.Invoke(this, key, value);
 
             lock (_listLock) {
                 if (IsValidAssociativeKey(key)) {
@@ -102,7 +102,7 @@ namespace OpenDreamServer.Dream.Objects {
             int valueIndex = _values.IndexOf(value);
 
             if (valueIndex != -1) {
-                if (BeforeValueRemoved != null) BeforeValueRemoved.Invoke(this, new DreamValue(valueIndex), _values[valueIndex]);
+                BeforeValueRemoved?.Invoke(this, new DreamValue(valueIndex), _values[valueIndex]);
 
                 lock (_listLock) {
                     _values.RemoveAt(valueIndex);
@@ -114,8 +114,8 @@ namespace OpenDreamServer.Dream.Objects {
             lock (_listLock) {
                 _values.Add(value);
             }
-            
-            if (ValueAssigned != null) ValueAssigned.Invoke(this, new DreamValue(_values.Count), value);
+
+            ValueAssigned?.Invoke(this, new DreamValue(_values.Count), value);
         }
 
         public bool IsValidAssociativeKey(DreamValue key) {

--- a/OpenDreamServer/Dream/Objects/DreamObject.cs
+++ b/OpenDreamServer/Dream/Objects/DreamObject.cs
@@ -18,11 +18,9 @@ namespace OpenDreamServer.Dream.Objects {
         public DreamObject(DreamObjectDefinition objectDefinition, DreamProcArguments creationArguments) {
             ObjectDefinition = objectDefinition;
 
-            if (ObjectDefinition.InitializionProc != null) {
-                ObjectDefinition.InitializionProc.Run(this, new DreamProcArguments(new(), new()));
-            }
+            ObjectDefinition.InitializionProc?.Run(this, new DreamProcArguments(new(), new()));
 
-            if (ObjectDefinition.MetaObject != null) ObjectDefinition.MetaObject.OnObjectCreated(this, creationArguments);
+            ObjectDefinition.MetaObject?.OnObjectCreated(this, creationArguments);
         }
 
         ~DreamObject() {
@@ -51,7 +49,7 @@ namespace OpenDreamServer.Dream.Objects {
 
         public void Delete() {
             if (Deleted) return;
-            if (ObjectDefinition.MetaObject != null) ObjectDefinition.MetaObject.OnObjectDeleted(this);
+            ObjectDefinition.MetaObject?.OnObjectDeleted(this);
 
             _referenceIDs.Remove(this);
             Deleted = true;

--- a/OpenDreamServer/Dream/Objects/DreamObjectTree.cs
+++ b/OpenDreamServer/Dream/Objects/DreamObjectTree.cs
@@ -150,41 +150,45 @@ namespace OpenDreamServer.Dream.Objects {
         }
 
         private DreamValue GetDreamValueFromJsonElement(JsonElement jsonElement) {
-            if (jsonElement.ValueKind == JsonValueKind.String) {
-                return new DreamValue(jsonElement.GetString());
-            } else if (jsonElement.ValueKind == JsonValueKind.Number) {
-                if (jsonElement.GetRawText().Contains(".")) {
+            switch (jsonElement.ValueKind) {
+                case JsonValueKind.String:
+                    return new DreamValue(jsonElement.GetString());
+                case JsonValueKind.Number when jsonElement.GetRawText().Contains("."):
                     return new DreamValue(jsonElement.GetSingle());
-                } else {
-                    int value;
-                    if (!jsonElement.TryGetInt32(out value)) value = Int32.MaxValue;
+                case JsonValueKind.Number: {
+                    if (!jsonElement.TryGetInt32(out int value)) value = Int32.MaxValue;
 
                     return new DreamValue(value);
                 }
-            } else if (jsonElement.ValueKind == JsonValueKind.Object) {
-                JsonVariableType variableType = (JsonVariableType)jsonElement.GetProperty("type").GetByte();
+                case JsonValueKind.Object: {
+                    JsonVariableType variableType = (JsonVariableType)jsonElement.GetProperty("type").GetByte();
 
-                if (variableType == JsonVariableType.Resource) {
-                    JsonElement resourcePathElement = jsonElement.GetProperty("resourcePath");
+                    switch (variableType) {
+                        case JsonVariableType.Resource: {
+                            JsonElement resourcePathElement = jsonElement.GetProperty("resourcePath");
 
-                    if (resourcePathElement.ValueKind == JsonValueKind.String) {
-                        DreamResource resource = Program.DreamResourceManager.LoadResource(resourcePathElement.GetString());
+                            switch (resourcePathElement.ValueKind) {
+                                case JsonValueKind.String: {
+                                    DreamResource resource = Program.DreamResourceManager.LoadResource(resourcePathElement.GetString());
 
-                        return new DreamValue(resource);
-                    } else if (resourcePathElement.ValueKind == JsonValueKind.Null) {
-                        return DreamValue.Null;
-                    } else {
-                        throw new Exception("Property 'resourcePath' must be a string or null");
+                                    return new DreamValue(resource);
+                                }
+                                case JsonValueKind.Null:
+                                    return DreamValue.Null;
+                                default:
+                                    throw new Exception("Property 'resourcePath' must be a string or null");
+                            }
+                        }
+                        case JsonVariableType.Null:
+                            return DreamValue.Null;
+                        case JsonVariableType.Path:
+                            return new DreamValue(new DreamPath(jsonElement.GetProperty("value").GetString()));
+                        default:
+                            throw new Exception("Invalid variable type (" + variableType + ")");
                     }
-                } else if (variableType == JsonVariableType.Null) {
-                    return DreamValue.Null;
-                } else if (variableType == JsonVariableType.Path) {
-                    return new DreamValue(new DreamPath(jsonElement.GetProperty("value").GetString()));
-                } else {
-                    throw new Exception("Invalid variable type (" + variableType + ")");
                 }
-            } else {
-                throw new Exception("Invalid value kind for dream value (" + jsonElement.ValueKind + ")");
+                default:
+                    throw new Exception("Invalid value kind for dream value (" + jsonElement.ValueKind + ")");
             }
         }
 

--- a/OpenDreamServer/Dream/Objects/DreamObjectTree.cs
+++ b/OpenDreamServer/Dream/Objects/DreamObjectTree.cs
@@ -218,7 +218,7 @@ namespace OpenDreamServer.Dream.Objects {
                 string procName = jsonProc.Key;
 
                 foreach (ProcDefinitionJson procDefinition in jsonProc.Value) {
-                    byte[] bytecode = procDefinition.Bytecode != null ? procDefinition.Bytecode : new byte[0];
+                    byte[] bytecode = procDefinition.Bytecode ?? Array.Empty<byte>();
                     List<string> argumentNames = new();
                     List<DMValueType> argumentTypes = new();
 

--- a/OpenDreamServer/Net/DreamConnection.cs
+++ b/OpenDreamServer/Net/DreamConnection.cs
@@ -220,15 +220,14 @@ namespace OpenDreamServer.Net {
 
         public void HandlePacketPromptResponse(PacketPromptResponse pPromptResponse) {
             if (_promptEvents.TryGetValue(pPromptResponse.PromptId, out Action<DreamValue> promptEvent)) {
-                DreamValue value;
 
-                switch (pPromptResponse.Type) {
-                    case DMValueType.Null: value = DreamValue.Null; break;
-                    case DMValueType.Text: value = new DreamValue((string)pPromptResponse.Value); break;
-                    case DMValueType.Num: value = new DreamValue((int)pPromptResponse.Value); break;
-                    case DMValueType.Message: value = new DreamValue((string)pPromptResponse.Value); break;
-                    default: throw new Exception("Invalid prompt response '" + pPromptResponse.Type + "'");
-                }
+                DreamValue value = pPromptResponse.Type switch {
+                    DMValueType.Null => DreamValue.Null,
+                    DMValueType.Text => new DreamValue((string)pPromptResponse.Value),
+                    DMValueType.Num => new DreamValue((int)pPromptResponse.Value),
+                    DMValueType.Message => new DreamValue((string)pPromptResponse.Value),
+                    _ => throw new Exception("Invalid prompt response '" + pPromptResponse.Type + "'")
+                };
 
                 promptEvent.Invoke(value);
                 _promptEvents[pPromptResponse.PromptId] = null;

--- a/OpenDreamServer/Net/DreamServer.cs
+++ b/OpenDreamServer/Net/DreamServer.cs
@@ -28,7 +28,7 @@ namespace OpenDreamServer.Net {
         }
 
         public void RegisterPacketCallback<PacketClass>(PacketID packetID, Action<DreamConnection, PacketClass> packetCallback) where PacketClass : IPacket, new() {
-            if (_packetIDToCallback.ContainsKey(packetID)) throw new Exception("Packet ID '" + packetID.ToString() + "' already has a callback");
+            if (_packetIDToCallback.ContainsKey(packetID)) throw new Exception("Packet ID '" + packetID + "' already has a callback");
 
             if (packetCallback != null) {
                 _packetIDToCallback[packetID] = (DreamConnection connection, IPacket packet) => {
@@ -80,11 +80,11 @@ namespace OpenDreamServer.Net {
                         try {
                             _packetIDToCallback[packet.PacketID]?.Invoke(dreamConnection, packet);
                         } catch (Exception e) {
-                            Console.Error.WriteLine("Error while handling received packet (" + packet.PacketID.ToString() + "): " + e.Message);
+                            Console.Error.WriteLine("Error while handling received packet (" + packet.PacketID + "): " + e.Message);
                         }
                     }
                 } catch (Exception e) {
-                    Console.Error.WriteLine("Error while processing recieved packet from user '" + dreamConnection.CKey + "': " + e.Message);
+                    Console.Error.WriteLine("Error while processing received packet from user '" + dreamConnection.CKey + "': " + e.Message);
                 }
             }
         }

--- a/OpenDreamServer/Resources/DMMParser.cs
+++ b/OpenDreamServer/Resources/DMMParser.cs
@@ -173,7 +173,7 @@ namespace OpenDreamShared.Compiler.DMM {
 
                 string blockString = (string)blockStringToken.Value;
                 List<string> lines = new(blockString.Split("\n"));
-                lines.RemoveAll(line => String.IsNullOrEmpty(line));
+                lines.RemoveAll(string.IsNullOrEmpty);
 
                 mapBlock.Height = lines.Count;
                 for (int y = 1; y <= mapBlock.Height; y++) {

--- a/OpenDreamServer/Resources/DreamResourceManager.cs
+++ b/OpenDreamServer/Resources/DreamResourceManager.cs
@@ -96,7 +96,7 @@ namespace OpenDreamServer.Resources {
             } else {
                 string directoryPath = Path.GetDirectoryName(path);
 
-                files = Directory.GetFiles(Path.Combine(RootPath, directoryPath), Path.GetFileName(path), SearchOption.AllDirectories);
+                files = Directory.GetFiles(Path.Combine(RootPath, directoryPath ?? string.Empty), Path.GetFileName(path), SearchOption.AllDirectories);
             }
 
             return files;


### PR DESCRIPTION
Described by the commit messages.

Mostly just switch/match statement conversion, and null propagation/coalescence.

Did do a thing `byte[] bytecode = procDefinition.Bytecode ?? Array.Empty<byte>();`, where we avoid an empty array allocation that was happening before with the `new byte[0]` pattern. Also null-coalesced there.