### PR TITLE
Throws exception when lexer can't find a source file

### DIFF
--- a/OpenDreamShared/Compiler/Lexer.cs
+++ b/OpenDreamShared/Compiler/Lexer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace OpenDreamShared.Compiler {
     class Lexer<SourceType> {
@@ -17,6 +18,8 @@ namespace OpenDreamShared.Compiler {
         public Lexer(string sourceName, IEnumerable<SourceType> source) {
             SourceName = sourceName;
             Source = source;
+            if (source == null)
+                throw new FileNotFoundException("Source file could not be read: " + sourceName);
             _sourceEnumerator = Source.GetEnumerator();
         }
 


### PR DESCRIPTION
title

it fails in the `interfaceResource.ReadAsString()` and passes the null down the chain:

https://github.com/ZeWaka/OpenDream/blob/c86ab7441ac03349b6e5194180651d5675a93974/OpenDreamServer/Program.cs#L152