### PR TITLE
default value argument backend support for input()

### DIFF
--- a/OpenDreamClient/Interface/DreamInterface.cs
+++ b/OpenDreamClient/Interface/DreamInterface.cs
@@ -170,11 +170,11 @@ namespace OpenDreamClient.Interface {
             int promptTypeBitflag = (int)pPrompt.Types;
 
             if ((promptTypeBitflag & (int)DMValueType.Text) != 0) {
-                prompt = new TextPrompt(pPrompt.PromptId, pPrompt.Title, pPrompt.Message);
+                prompt = new TextPrompt(pPrompt.PromptId, pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue);
             } else if ((promptTypeBitflag & (int)DMValueType.Num) != 0) {
-                prompt = new NumberPrompt(pPrompt.PromptId, pPrompt.Title, pPrompt.Message);
+                prompt = new NumberPrompt(pPrompt.PromptId, pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue);
             } else if ((promptTypeBitflag & (int)DMValueType.Message) != 0) {
-                prompt = new MessagePrompt(pPrompt.PromptId, pPrompt.Title, pPrompt.Message);
+                prompt = new MessagePrompt(pPrompt.PromptId, pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue);
             }
 
             if (prompt != null) {

--- a/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
@@ -8,7 +8,7 @@ namespace OpenDreamClient.Interface.Prompts {
         public MessagePrompt(int promptId, String title, String message, String defaultValue) : base(promptId, title, message, defaultValue) { }
 
         protected override Control CreatePromptControl(String defaultValue) {
-            TextBox textBox = new() {
+            return new TextBox {
                 MinHeight = 100,
                 MaxWidth = 500,
                 MaxHeight = 400,
@@ -17,7 +17,6 @@ namespace OpenDreamClient.Interface.Prompts {
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
                 Text = defaultValue,
             };
-            return textBox;
         }
 
         protected override void OkButton_Click(object sender, RoutedEventArgs e) {

--- a/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
@@ -1,20 +1,22 @@
-﻿using OpenDreamShared.Dream.Procs;
+﻿using System;
+using OpenDreamShared.Dream.Procs;
 using System.Windows;
 using System.Windows.Controls;
 
 namespace OpenDreamClient.Interface.Prompts {
     class MessagePrompt : PromptWindow {
-        public MessagePrompt(int promptId, string title, string message) : base(promptId, title, message) { }
+        public MessagePrompt(int promptId, String title, String message, String defaultValue) : base(promptId, title, message, defaultValue) { }
 
-        protected override Control CreatePromptControl() {
-            TextBox textBox = new TextBox();
-
-            textBox.MinHeight = 100;
-            textBox.MaxWidth = 500;
-            textBox.MaxHeight = 400;
-            textBox.AcceptsReturn = true;
-            textBox.VerticalScrollBarVisibility = ScrollBarVisibility.Visible;
-            textBox.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
+        protected override Control CreatePromptControl(String defaultValue) {
+            TextBox textBox = new() {
+                MinHeight = 100,
+                MaxWidth = 500,
+                MaxHeight = 400,
+                AcceptsReturn = true,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Visible,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Text = defaultValue,
+            };
             return textBox;
         }
 

--- a/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
@@ -6,10 +6,12 @@ using System.Windows.Input;
 
 namespace OpenDreamClient.Interface.Prompts {
     class NumberPrompt : PromptWindow {
-        public NumberPrompt(int promptId, string title, string message) : base(promptId, title, message) { }
+        public NumberPrompt(int promptId, String title, String message, String defaultValue) : base(promptId, title, message, defaultValue) { }
 
-        protected override Control CreatePromptControl() {
-            TextBox numberInput = new TextBox();
+        protected override Control CreatePromptControl(String defaultValue) {
+            TextBox numberInput = new() {
+                Text = defaultValue
+            };
             numberInput.PreviewTextInput += NumberInput_PreviewTextInput;
 
             return numberInput;
@@ -27,7 +29,10 @@ namespace OpenDreamClient.Interface.Prompts {
         }
 
         protected override void OkButton_Click(object sender, RoutedEventArgs e) {
-            FinishPrompt(DMValueType.Num, Int32.Parse(((TextBox)PromptControl).Text));
+            if (!Int32.TryParse(((TextBox)PromptControl).Text, out Int32 num)) {
+                Console.Error.WriteLine("Error while trying to convert " + ((TextBox)PromptControl).Text + " to a number.");
+            }
+            FinishPrompt(DMValueType.Num, num);
         }
     }
 }

--- a/OpenDreamClient/Interface/Prompts/PromptWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/PromptWindow.cs
@@ -11,7 +11,7 @@ namespace OpenDreamClient.Interface.Prompts {
 
         private bool _responseSent = false;
 
-        public PromptWindow(int promptId, string title, string message) {
+        public PromptWindow(int promptId, String title, String message, String defaultValue) {
             PromptId = promptId;
 
             Title = !String.IsNullOrEmpty(title) ? title : "OpenDream";
@@ -20,7 +20,7 @@ namespace OpenDreamClient.Interface.Prompts {
             messageLabel.Margin = new Thickness(5);
             messageLabel.Content = message;
 
-            PromptControl = CreatePromptControl();
+            PromptControl = CreatePromptControl(defaultValue);
             PromptControl.Margin = new Thickness(5);
 
             Button okButton = new Button();
@@ -45,7 +45,7 @@ namespace OpenDreamClient.Interface.Prompts {
             PromptControl.Focus();
         }
 
-        protected virtual Control CreatePromptControl() {
+        protected virtual Control CreatePromptControl(String defaultValue) {
             return new Control();
         }
 

--- a/OpenDreamClient/Interface/Prompts/TextPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/TextPrompt.cs
@@ -8,10 +8,9 @@ namespace OpenDreamClient.Interface.Prompts {
         public TextPrompt(int promptId, String title, String message, String defaultValue) : base(promptId, title, message, defaultValue) { }
 
         protected override Control CreatePromptControl(String defaultValue) {
-            TextBox box = new() {
+            return new TextBox {
                 Text = defaultValue
             };
-            return box;
         }
 
         protected override void OkButton_Click(object sender, RoutedEventArgs e) {

--- a/OpenDreamClient/Interface/Prompts/TextPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/TextPrompt.cs
@@ -1,13 +1,17 @@
-﻿using OpenDreamShared.Dream.Procs;
+﻿using System;
+using OpenDreamShared.Dream.Procs;
 using System.Windows;
 using System.Windows.Controls;
 
 namespace OpenDreamClient.Interface.Prompts {
     class TextPrompt : PromptWindow {
-        public TextPrompt(int promptId, string title, string message) : base(promptId, title, message) { }
+        public TextPrompt(int promptId, String title, String message, String defaultValue) : base(promptId, title, message, defaultValue) { }
 
-        protected override Control CreatePromptControl() {
-            return new TextBox();
+        protected override Control CreatePromptControl(String defaultValue) {
+            TextBox box = new() {
+                Text = defaultValue
+            };
+            return box;
         }
 
         protected override void OkButton_Click(object sender, RoutedEventArgs e) {

--- a/OpenDreamServer/Dream/Procs/DreamProcInterpreterOpcodes.cs
+++ b/OpenDreamServer/Dream/Procs/DreamProcInterpreterOpcodes.cs
@@ -7,6 +7,7 @@ using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -1105,7 +1106,7 @@ namespace OpenDreamServer.Dream.Procs {
             DreamObject clientObject;
             if (recipientMob != null && recipientMob.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out clientObject)) {
                 DreamConnection connection = Program.ClientToConnection[clientObject];
-                Task<DreamValue> promptTask = connection.Prompt(types, title.Stringify(), message.Stringify());
+                Task<DreamValue> promptTask = connection.Prompt(types, title.Stringify(), message.Stringify(), defaultValue.Stringify());
 
                 promptTask.Wait();
                 interpreter.Push(promptTask.Result);
@@ -1194,6 +1195,7 @@ namespace OpenDreamServer.Dream.Procs {
             }
         }
 
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         private static bool IsEqual(DreamValue first, DreamValue second) {
             if (first.Type == DreamValue.DreamValueType.DreamObject && second.Type == DreamValue.DreamValueType.DreamObject) {
                 return first.GetValueAsDreamObject() == second.GetValueAsDreamObject();

--- a/OpenDreamServer/Net/DreamConnection.cs
+++ b/OpenDreamServer/Net/DreamConnection.cs
@@ -198,7 +198,7 @@ namespace OpenDreamServer.Net {
             statPanelLines.Add(text);
         }
 
-        public Task<DreamValue> Prompt(DMValueType types, String title, String message) {
+        public Task<DreamValue> Prompt(DMValueType types, String title, String message, String defaultValue) {
             Task<DreamValue> promptTask = new Task<DreamValue>(() => {
                 ManualResetEvent promptWaitHandle = new ManualResetEvent(false);
                 int promptId = _promptEvents.Count;
@@ -209,7 +209,7 @@ namespace OpenDreamServer.Net {
                     promptWaitHandle.Set();
                 };
 
-                SendPacket(new PacketPrompt(promptId, types, title, message));
+                SendPacket(new PacketPrompt(promptId, types, title, message, defaultValue));
                 promptWaitHandle.WaitOne();
                 return promptResponse;
             });
@@ -294,7 +294,7 @@ namespace OpenDreamServer.Net {
                         String argumentName = verb.ArgumentNames[i];
                         DMValueType argumentType = verb.ArgumentTypes[i];
                         DreamValue value = await Prompt(argumentType, title: null, // No settable title for verbs
-                                                        argumentName);
+                                                        argumentName, defaultValue: ""); // No default value for verbs
 
                         arguments.Add(argumentName, value);
                     }

--- a/OpenDreamServer/Net/DreamConnection.cs
+++ b/OpenDreamServer/Net/DreamConnection.cs
@@ -293,8 +293,8 @@ namespace OpenDreamServer.Net {
                     for (int i = 0; i < verb.ArgumentNames.Count; i++) {
                         String argumentName = verb.ArgumentNames[i];
                         DMValueType argumentType = verb.ArgumentTypes[i];
-                        DreamValue value = await Prompt(argumentType, title: null, // No settable title for verbs
-                                                        argumentName, defaultValue: ""); // No default value for verbs
+                        DreamValue value = await Prompt(argumentType, title: String.Empty, // No settable title for verbs
+                                                        argumentName, defaultValue: String.Empty); // No default value for verbs
 
                         arguments.Add(argumentName, value);
                     }

--- a/OpenDreamShared/Net/Packets/PacketPrompt.cs
+++ b/OpenDreamShared/Net/Packets/PacketPrompt.cs
@@ -9,14 +9,16 @@ namespace OpenDreamShared.Net.Packets {
         public DMValueType Types;
         public string Title;
         public string Message;
+        public String DefaultValue;
 
         public PacketPrompt() { }
 
-        public PacketPrompt(int promptId, DMValueType types, string title, string message) {
+        public PacketPrompt(int promptId, DMValueType types, String title, String message, String defaultValue) {
             PromptId = promptId;
             Types = types;
             Title = title;
             Message = message;
+            DefaultValue = defaultValue;
         }
 
         public void ReadFromStream(PacketStream stream) {
@@ -24,6 +26,7 @@ namespace OpenDreamShared.Net.Packets {
             Types = (DMValueType)stream.ReadUInt16();
             Title = stream.ReadString();
             Message = stream.ReadString();
+            DefaultValue = stream.ReadString();
         }
 
         public void WriteToStream(PacketStream stream) {
@@ -31,6 +34,7 @@ namespace OpenDreamShared.Net.Packets {
             stream.WriteUInt16((UInt16)Types);
             stream.WriteString(Title);
             stream.WriteString(Message);
+            stream.WriteString(DefaultValue);
         }
     }
 }

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -23,7 +23,7 @@
 			viewer << "[ckey] says: \"[message]\""
 	
 	verb/say_loud()
-		var/msg = input("Please put the message you want to say loudly.", "Say Loud")
+		var/msg = input("Please put the message you want to say loudly.", "Say Loud", "Hello!")
 		world << "[ckey] says loudly: \"[msg]\""
 
 	verb/move_up()


### PR DESCRIPTION
Title, adds in support for default input() values.
![2021-05-13_21-38-11](https://user-images.githubusercontent.com/4741640/118224889-dcc50600-b438-11eb-95da-bb2f12d248bf.png)

Throw a client console error if it tries to convert something that's not a number to a number. Previously, it just crashed (lol).

Converted a few of the variable settings to use object initializers.
Also threw in a suppression for #53 