### PR TITLE
Implementation of z-level removal (`world.maxz--`)

### DIFF
--- a/OpenDreamRuntime/DreamMap.cs
+++ b/OpenDreamRuntime/DreamMap.cs
@@ -19,7 +19,7 @@ namespace OpenDreamRuntime {
 
         public class MapCell {
             public DreamObject Area;
-            public UInt32 Turf;
+            public DreamObject Turf;
         }
 
         public class MapLevel {
@@ -101,6 +101,14 @@ namespace OpenDreamRuntime {
                 }
             }
         }
+        
+        public void RemoveLevel() {
+            MapLevel toRemove = Levels[^1];
+            foreach (MapCell cell in toRemove.Cells) {
+                cell.Turf.Delete();
+            }
+            Levels.Remove(toRemove);
+        }
 
         public void SetTurf(int x, int y, int z, DreamObject turf, bool replace = true) {
             if (!turf.IsSubtypeOf(DreamPath.Turf)) {
@@ -120,7 +128,7 @@ namespace OpenDreamRuntime {
             }
             
 
-            Levels[z - 1].Cells[x - 1, y - 1].Turf = Runtime.AtomIDs[turf];
+            Levels[z - 1].Cells[x - 1, y - 1].Turf = turf;
             Runtime.StateManager.AddTurfDelta(x - 1, y - 1, z - 1, turf);
         }
 
@@ -137,7 +145,7 @@ namespace OpenDreamRuntime {
 
         public DreamObject GetTurfAt(int x, int y, int z) {
             if (x >= 1 && x <= Runtime.Map.Width && y >= 1 && y <= Runtime.Map.Height && z >= 1 && z <= Runtime.Map.Levels.Count) {
-                return Runtime.AtomIDToAtom[Levels[z - 1].Cells[x - 1, y - 1].Turf];
+                return Levels[z - 1].Cells[x - 1, y - 1].Turf;
             } else {
                 return null;
             }

--- a/OpenDreamRuntime/DreamRuntime.cs
+++ b/OpenDreamRuntime/DreamRuntime.cs
@@ -123,6 +123,7 @@ namespace OpenDreamRuntime
 
             Map = new DreamMap(this);
             Map.LoadMap(CompiledJson.Maps[0]);
+            WorldInstance.SetVariable("maxz", new DreamValue(Map.Levels.Count));
 
             WorldInstance.SpawnProc("New");
         }

--- a/OpenDreamRuntime/DreamRuntime.cs
+++ b/OpenDreamRuntime/DreamRuntime.cs
@@ -123,8 +123,7 @@ namespace OpenDreamRuntime
 
             Map = new DreamMap(this);
             Map.LoadMap(CompiledJson.Maps[0]);
-            WorldInstance.SetVariable("maxz", new DreamValue(Map.Levels.Count));
-
+            
             WorldInstance.SpawnProc("New");
         }
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -32,7 +32,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             } else if (variableName == "maxz") {
                 int newMaxZ = variableValue.GetValueAsInteger();
 
-                if (newMaxZ < oldVariableValue.GetValueAsInteger()) {
+                if (newMaxZ < Runtime.Map.Levels.Count) {
                     while (Runtime.Map.Levels.Count > newMaxZ) {
                         Runtime.Map.RemoveLevel();
                     }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -32,9 +32,15 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             } else if (variableName == "maxz") {
                 int newMaxZ = variableValue.GetValueAsInteger();
 
-                if (newMaxZ < oldVariableValue.GetValueAsInteger()) throw new NotImplementedException("Cannot set maxz lower than previous value");
-
-                while (Runtime.Map.Levels.Count < newMaxZ) Runtime.Map.AddLevel();
+                if (newMaxZ < oldVariableValue.GetValueAsInteger()) {
+                    while (Runtime.Map.Levels.Count > newMaxZ) {
+                        Runtime.Map.RemoveLevel();
+                    }
+                } else {
+                    while (Runtime.Map.Levels.Count < newMaxZ) {
+                        Runtime.Map.AddLevel();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Unsure on exact GC behavior regarding the deletion of the levels, please advise.

The actual z-removal works though. You're no longer able to traverse to the level in the test project.

If you are on a Z-level when it gets removed, your client just stays stuck and can't move. This is similar to BYOND's behavior, where it just crashes your client.