### PR TITLE
Implementation of `client.timezone` and corresponding `ClientData`

### DIFF
--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -17,6 +17,8 @@
 	var/inactivity = 0
 	var/key
 	var/ckey
+	
+	var/timezone
 
 	proc/New(TopicData)
 		view = world.view

--- a/OpenDreamClient/OpenDream.cs
+++ b/OpenDreamClient/OpenDream.cs
@@ -4,6 +4,7 @@ using OpenDreamClient.Interface;
 using OpenDreamClient.Net;
 using OpenDreamClient.Resources;
 using OpenDreamShared.Dream;
+using OpenDreamShared.Net;
 using OpenDreamShared.Net.Packets;
 using System;
 using System.Collections.Generic;
@@ -17,6 +18,7 @@ namespace OpenDreamClient {
         public DreamResourceManager ResourceManager = null;
         public DreamInterface Interface = null;
         public ClientConnection Connection = new ClientConnection();
+        public ClientData ClientData = new ClientData();
 
         public Map Map;
         public ATOM Eye;
@@ -46,7 +48,7 @@ namespace OpenDreamClient {
             if (Connection.Connected) throw new InvalidOperationException("Already connected to a server!");
             Connection.Connect(ip, port);
 
-            PacketRequestConnect pRequestConnect = new PacketRequestConnect(username);
+            PacketRequestConnect pRequestConnect = new PacketRequestConnect(username, ClientData);
             Connection.SendPacket(pRequestConnect);
 
             Interface = new DreamInterface();
@@ -73,6 +75,7 @@ namespace OpenDreamClient {
             SoundEngine = null;
             ResourceManager = null;
             StateManager = null;
+            ClientData = null;
 
             Map = null;
             ATOMs = null;

--- a/OpenDreamClient/OpenDream.cs
+++ b/OpenDreamClient/OpenDream.cs
@@ -18,7 +18,7 @@ namespace OpenDreamClient {
         public DreamResourceManager ResourceManager = null;
         public DreamInterface Interface = null;
         public ClientConnection Connection = new ClientConnection();
-        public ClientData ClientData = new ClientData();
+        public ClientData ClientData = new ClientData(setDefaults: true);
 
         public Map Map;
         public ATOM Eye;

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -14,6 +14,7 @@ using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Resources;
+using OpenDreamShared.Net;
 
 namespace OpenDreamRuntime {
     public abstract class DreamConnection {
@@ -32,6 +33,7 @@ namespace OpenDreamRuntime {
         }
 
         public DreamObject ClientDreamObject;
+        public ClientData ClientData;
 
         private DreamObject _mobDreamObject;
         private Dictionary<int, Action<DreamValue>> _promptEvents = new();

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -63,6 +63,9 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 return new DreamValue(connection.Address.ToString());
             } else if (variableName == "inactivity") {
                 return new DreamValue(0);
+            } else if (variableName == "timezone") {
+                DreamConnection connection = Runtime.Server.GetConnectionFromClient(dreamObject);
+                return new((float)connection.ClientData.Timezone.BaseUtcOffset.TotalHours);           
             } else {
                 return base.OnVariableGet(dreamObject, variableName, variableValue);
             }

--- a/OpenDreamServer/Server.cs
+++ b/OpenDreamServer/Server.cs
@@ -1,11 +1,13 @@
+using OpenDreamShared.Net;
 using OpenDreamShared.Net.Packets;
 using OpenDreamRuntime;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Net.Sockets;	
-    
+using System.Net.Sockets;
+
+
 
 namespace OpenDreamServer {
     class Connection : DreamConnection
@@ -14,6 +16,8 @@ namespace OpenDreamServer {
         private readonly NetworkStream _tcpStream;
         private readonly BinaryReader _tcpStreamBinaryReader;
         private readonly BinaryWriter _tcpStreamBinaryWriter;
+        
+        public ClientData ClientData;
 
         public Connection(DreamRuntime runtime, TcpClient tcpClient)
             : base(runtime)
@@ -119,6 +123,7 @@ namespace OpenDreamServer {
         private void OnPacketRequestConnect(DreamConnection connection, PacketRequestConnect pRequestConnect) {
             if (!_ckeyToConnection.ContainsKey(pRequestConnect.CKey)) {
                 connection.CKey = pRequestConnect.CKey;
+                connection.ClientData = pRequestConnect.ClientData;
 
                 DreamConnectionRequest.Invoke(connection);
             } else {

--- a/OpenDreamServer/Server.cs
+++ b/OpenDreamServer/Server.cs
@@ -16,8 +16,6 @@ namespace OpenDreamServer {
         private readonly NetworkStream _tcpStream;
         private readonly BinaryReader _tcpStreamBinaryReader;
         private readonly BinaryWriter _tcpStreamBinaryWriter;
-        
-        public ClientData ClientData;
 
         public Connection(DreamRuntime runtime, TcpClient tcpClient)
             : base(runtime)

--- a/OpenDreamShared/Net/ClientData.cs
+++ b/OpenDreamShared/Net/ClientData.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace OpenDreamShared.Net {
+    [Serializable]
+    public class ClientData: ISerializable {
+
+        public readonly TimeZoneInfo Timezone;
+
+        public ClientData() {
+            Timezone = TimeZoneInfo.Local;
+        }
+
+        public ClientData(SerializationInfo info, StreamingContext context) {
+            String tData = info.GetString(nameof(Timezone));
+            if (tData == null) 
+                throw new InvalidDataException("Invalid timezone data received from client.");
+            Timezone = TimeZoneInfo.FromSerializedString(tData);
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) {
+            info.AddValue(nameof(Timezone), Timezone.ToSerializedString());
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) {
+            if (info == null) 
+                throw new ArgumentNullException(nameof(info));  
+
+            GetObjectData(info, context);
+        }
+    }
+}

--- a/OpenDreamShared/Net/ClientData.cs
+++ b/OpenDreamShared/Net/ClientData.cs
@@ -1,33 +1,25 @@
 ﻿using System;
-using System.IO;
-using System.Runtime.Serialization;
+using OpenDreamShared.Net.Packets;
 
 namespace OpenDreamShared.Net {
-    [Serializable]
-    public class ClientData: ISerializable {
+    public class ClientData {
 
-        public readonly TimeZoneInfo Timezone;
-
-        public ClientData() {
-            Timezone = TimeZoneInfo.Local;
+        public TimeZoneInfo Timezone;
+        
+        public ClientData(bool setDefaults = false) {
+            if (setDefaults) {
+                Timezone = TimeZoneInfo.Local;
+            }
         }
 
-        public ClientData(SerializationInfo info, StreamingContext context) {
-            String tData = info.GetString(nameof(Timezone));
-            if (tData == null) 
-                throw new InvalidDataException("Invalid timezone data received from client.");
-            Timezone = TimeZoneInfo.FromSerializedString(tData);
+        public void WriteToPacket(PacketStream packetStream) {
+            packetStream.WriteString(Timezone.ToSerializedString());
         }
 
-        public void GetObjectData(SerializationInfo info, StreamingContext context) {
-            info.AddValue(nameof(Timezone), Timezone.ToSerializedString());
-        }
-
-        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) {
-            if (info == null) 
-                throw new ArgumentNullException(nameof(info));  
-
-            GetObjectData(info, context);
+        public static ClientData ReadFromPacket(PacketStream packetStream) {
+            return new ClientData() {
+                Timezone = TimeZoneInfo.FromSerializedString(packetStream.ReadString())
+            };
         }
     }
 }

--- a/OpenDreamShared/Net/Packets/IPacket.cs
+++ b/OpenDreamShared/Net/Packets/IPacket.cs
@@ -48,7 +48,7 @@ namespace OpenDreamShared.Net.Packets {
         }
 
         private static void RegisterPacket<PacketClass>(PacketID packetID) where PacketClass : IPacket, new() {
-            if (PacketIDToType.ContainsKey(packetID)) throw new Exception("Packet ID '" + packetID.ToString() + "' was already registered");
+            if (PacketIDToType.ContainsKey(packetID)) throw new Exception("Packet ID '" + packetID + "' was already registered");
 
             PacketIDToType[packetID] = typeof(PacketClass);
         }

--- a/OpenDreamShared/Net/Packets/PacketRequestConnect.cs
+++ b/OpenDreamShared/Net/Packets/PacketRequestConnect.cs
@@ -1,21 +1,27 @@
-﻿namespace OpenDreamShared.Net.Packets {
+﻿using System.Text.Json;
+
+namespace OpenDreamShared.Net.Packets {
     public class PacketRequestConnect : IPacket {
         public PacketID PacketID => PacketID.RequestConnect;
 
         public string CKey;
+        public ClientData ClientData;
 
         public PacketRequestConnect() { }
 
-        public PacketRequestConnect(string cKey) {
+        public PacketRequestConnect(string cKey, ClientData clientData) {
             CKey = cKey;
+            ClientData = clientData;
         }
 
         public void ReadFromStream(PacketStream stream) {
             CKey = stream.ReadString();
+            ClientData = JsonSerializer.Deserialize<ClientData>(stream.ReadString());
         }
 
         public void WriteToStream(PacketStream stream) {
             stream.WriteString(CKey);
+            stream.WriteString(JsonSerializer.Serialize(ClientData));
         }
     }
 }

--- a/OpenDreamShared/Net/Packets/PacketRequestConnect.cs
+++ b/OpenDreamShared/Net/Packets/PacketRequestConnect.cs
@@ -16,12 +16,12 @@ namespace OpenDreamShared.Net.Packets {
 
         public void ReadFromStream(PacketStream stream) {
             CKey = stream.ReadString();
-            ClientData = JsonSerializer.Deserialize<ClientData>(stream.ReadString());
+            ClientData = ClientData.ReadFromPacket(stream);
         }
 
         public void WriteToStream(PacketStream stream) {
             stream.WriteString(CKey);
-            stream.WriteString(JsonSerializer.Serialize(ClientData));
+            ClientData.WriteToPacket(stream);
         }
     }
 }

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -15,7 +15,6 @@
 
 	verb/tell_location()
 		usr << "You are at ([x], [y], [z])"
-		usr << usr.client.timezone
 
 	verb/say(message as text)
 		var/list/viewers = viewers()

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -15,6 +15,7 @@
 
 	verb/tell_location()
 		usr << "You are at ([x], [y], [z])"
+		usr << usr.client.timezone
 
 	verb/say(message as text)
 		var/list/viewers = viewers()


### PR DESCRIPTION
Implements `client.timezone`.

I made a new shared class to keep track of this, and info like it.

Me receiving my UTC offset:
![image](https://user-images.githubusercontent.com/4741640/118331477-95348d80-b4bd-11eb-8bb6-0c238658296d.png)