### PR TITLE
Implement world.system_type

### DIFF
--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -38,3 +38,7 @@
 #define FORWARD_STEPS 1
 #define SLIDE_STEPS 2
 #define SYNC_STEPS 3
+
+//world.system_type
+#define UNIX 0
+#define MS_WINDOWS 1

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -24,6 +24,8 @@
 	var/address
 	var/status
 	var/list/params = null
+	
+	var/system_type
 
 	proc/New()
 	proc/Del()

--- a/OpenDreamServer/Dream/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamServer/Dream/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -19,15 +19,6 @@ namespace OpenDreamServer.Dream.Objects.MetaObjects {
                 dreamObject.SetVariable("tick_lag", new DreamValue(10.0f / fps.GetValueAsInteger()));
             }
             
-            //system_type value should match the defines in Defines.dm
-            if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX or PlatformID.Other) {
-                dreamObject.SetVariable("system_type", new DreamValue(0));
-            }
-            else {
-                dreamObject.SetVariable("system_type", new DreamValue(1));
-            }
-            
-
             //New() is not called here
         }
 
@@ -69,6 +60,14 @@ namespace OpenDreamServer.Dream.Objects.MetaObjects {
                 return new DreamValue(Program.DreamMap.Levels.Count);
             } else if (variableName == "address") {
                 return DreamValue.Null;
+            } else if (variableName == "system_type") {
+                //system_type value should match the defines in Defines.dm
+                if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX or PlatformID.Other) {
+                    return new DreamValue(0);
+                }
+                //Windows
+                return new DreamValue(1);
+                
             } else {
                 return base.OnVariableGet(dreamObject, variableName, variableValue);
             }

--- a/OpenDreamServer/Dream/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamServer/Dream/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -20,7 +20,7 @@ namespace OpenDreamServer.Dream.Objects.MetaObjects {
             }
             
             //system_type value should match the defines in Defines.dm
-            if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX) {
+            if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX or PlatformID.Other) {
                 dreamObject.SetVariable("system_type", new DreamValue(0));
             }
             else {

--- a/OpenDreamServer/Dream/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamServer/Dream/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -18,6 +18,15 @@ namespace OpenDreamServer.Dream.Objects.MetaObjects {
             if (fps.Value != null) {
                 dreamObject.SetVariable("tick_lag", new DreamValue(10.0f / fps.GetValueAsInteger()));
             }
+            
+            //system_type value should match the defines in Defines.dm
+            if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX) {
+                dreamObject.SetVariable("system_type", new DreamValue(0));
+            }
+            else {
+                dreamObject.SetVariable("system_type", new DreamValue(1));
+            }
+            
 
             //New() is not called here
         }


### PR DESCRIPTION
http://www.byond.com/docs/ref/#/world/var/system_type

It checks for unix/macos rather than windows because the enum contains like 4 different entries for windows.