### PR TITLE
Implement placeholder hearers()

### DIFF
--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -216,6 +216,10 @@ proc/get_step_away(atom/movable/Ref, /atom/Trg, Max = 5)
 
 	return get_step(Ref, dir)
 
+proc/hearers(Depth = world.view, Center = usr)
+	//TODO: Actual cursed hearers implementation
+	return viewers(Depth, Center)
+
 proc/step_towards(atom/movable/Ref, /atom/Trg, Speed)
 	Ref.Move(get_step_towards(Ref, Trg), get_dir(Ref, Trg))
 


### PR DESCRIPTION
The list quickly stops being alphabetical once you reach the procs implemented in DM, but let me know if you want to move it anyways.