### PR TITLE
Upgrade dependencies

### DIFF
--- a/OpenDreamClient/Interface/Elements/ElementBrowser.cs
+++ b/OpenDreamClient/Interface/Elements/ElementBrowser.cs
@@ -28,7 +28,7 @@ namespace OpenDreamClient.Interface.Elements {
 
             this.Children.Add(WebView);
             this.Children.Add(_loadingLabel);
-            WebView.CoreWebView2Ready += OnWebView2Ready;
+            WebView.CoreWebView2InitializationCompleted += OnWebView2InitializationCompleted;
             WebView.NavigationStarting += OnWebViewNavigationStarting;
             WebView.EnsureCoreWebView2Async();
         }
@@ -51,7 +51,7 @@ namespace OpenDreamClient.Interface.Elements {
             WebView.CoreWebView2.ExecuteScriptAsync(jsFunction + "(\"" + value + "\")");
         }
 
-        private void OnWebView2Ready(object sender, EventArgs e) {
+        private void OnWebView2InitializationCompleted(object sender, EventArgs e) {
             _webViewReady = true;
 
             this.Children.Remove(_loadingLabel);

--- a/OpenDreamClient/OpenDreamClient.csproj
+++ b/OpenDreamClient/OpenDreamClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.664.37" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.818.41" />
     <PackageReference Include="NAudio" Version="1.10.0" />
     <PackageReference Include="NAudio.Vorbis" Version="1.2.0" />
     <PackageReference Include="SharpGL" Version="3.1.1" />

--- a/OpenDreamClient/OpenDreamClient.csproj
+++ b/OpenDreamClient/OpenDreamClient.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.818.41" />
-    <PackageReference Include="NAudio" Version="1.10.0" />
-    <PackageReference Include="NAudio.Vorbis" Version="1.2.0" />
+    <PackageReference Include="NAudio" Version="2.0.0" />
+    <PackageReference Include="NAudio.Vorbis" Version="1.3.1" />
     <PackageReference Include="SharpGL" Version="3.1.1" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>

--- a/OpenDreamClient/OpenDreamClient.csproj
+++ b/OpenDreamClient/OpenDreamClient.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NAudio" Version="1.10.0" />
     <PackageReference Include="NAudio.Vorbis" Version="1.2.0" />
     <PackageReference Include="SharpGL" Version="3.1.1" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
title

https://docs.microsoft.com/en-us/microsoft-edge/webview2/release-notes#10721-prerelease changed `CoreWebView2Ready` to `CoreWebView2InitializationCompleted`.