### PR TITLE
Eliminates boxing on equality for DreamValue

### DIFF
--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -276,7 +276,8 @@ namespace OpenDreamServer.Dream {
 
         public override bool Equals(object obj) {
             if (obj is DreamValue b) {
-                if (Value == null) return b.Value == null;
+                if (Value == null) 
+                        return b.Value == null;
                 return Value.Equals(b.Value);
             }
             return false;

--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -270,13 +270,16 @@ namespace OpenDreamServer.Dream {
             }
         }
 
+        public bool Equals(DreamValue other) {
+            return Value == other.Value;
+        }
+
         public override bool Equals(object obj) {
             if (obj is DreamValue b) {
                 if (Value == null) return b.Value == null;
-                else return Value.Equals(b.Value);
-            } else {
-                return false;
+                return Value.Equals(b.Value);
             }
+            return false;
         }
 
         public override int GetHashCode() {


### PR DESCRIPTION
Implements a `DreamValue`-specific equality instead of just using the `object` version

profiling results:
```
byond: 11 dseconds

C#: 107 dseconds for both (profiler on)
C#: 91 dseconds for new (profiler off)

Boxing: 0.08% - 236ms/367ms DreamValue.Equals(Object)
Non-Boxing: 0.03% 92ms / 139ms DreamValue.Equals(DremaValue)
```

<details><summary><b>DA CODE</b></summary>
<p>

```cs
var/list/L = list()
var/testy = 50

for (var/i = 1, i <= 4000000, i++)
  L += rand(1, 100)

var/start = world.timeofday
for (var/i = 1, i <= 4000000, i++)
  if (testy == L[i])
    testy = i
		
var/elapsed = world.timeofday - start
world << "[elapsed] dseconds"
```

</p>
</details>



Methodology from https://theburningmonk.com/2015/07/beware-of-implicit-boxing-of-value-types/

We might also want to look at: https://theburningmonk.com/2015/07/smallest-net-ref-type-is-12-bytes-or-why-you-should-consider-using-value-types/ - I remember seeing a few places where this could be improved.