### PR TITLE
Removes boxing for DreamPath equality

### DIFF
--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -193,7 +193,7 @@ namespace OpenDreamShared.Dream {
 
         public static bool operator ==(DreamPath lhs, DreamPath rhs) => lhs.Equals(rhs);
         
-        public static bool operator !=(DreamPath lhs, DreamPath rhs) => (lhs == rhs);
+        public static bool operator !=(DreamPath lhs, DreamPath rhs) => !(lhs == rhs);
 
         private void Normalize() {
             Stack<string> elements = new Stack<string>();

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -175,6 +175,8 @@ namespace OpenDreamShared.Dream {
             return PathString;
         }
 
+        public override bool Equals(object obj) => obj is DreamPath other && Equals(other);
+        
         public bool Equals(DreamPath other) {
             if (other.Elements.Length != Elements.Length) return false;
 
@@ -185,13 +187,13 @@ namespace OpenDreamShared.Dream {
             return true;
         }
         
-        public override bool Equals(object obj) {
-            return false; // A DreamPath can only be equal to another DreamPath (see other DreamPath.Equals)
-        }
-
         public override int GetHashCode() {
             return PathString.GetHashCode();
         }
+
+        public static bool operator ==(DreamPath lhs, DreamPath rhs) => lhs.Equals(rhs);
+        
+        public static bool operator !=(DreamPath lhs, DreamPath rhs) => (lhs == rhs);
 
         private void Normalize() {
             Stack<string> elements = new Stack<string>();

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -175,18 +175,18 @@ namespace OpenDreamShared.Dream {
             return PathString;
         }
 
-        public override bool Equals(object obj) {
-            if (obj is DreamPath otherPath) {
-                if (otherPath.Elements.Length != Elements.Length) return false;
+        public bool Equals(DreamPath other) {
+            if (other.Elements.Length != Elements.Length) return false;
 
-                for (int i = 0; i < Elements.Length; i++) {
-                    if (Elements[i] != otherPath.Elements[i]) return false;
-                }
-
-                return true;
-            } else {
-                return base.Equals(obj);
+            for (int i = 0; i < Elements.Length; i++) {
+                if (Elements[i] != other.Elements[i]) return false;
             }
+
+            return true;
+        }
+        
+        public override bool Equals(object obj) {
+            return false; // A DreamPath can only be equal to another DreamPath (see other DreamPath.Equals)
         }
 
         public override int GetHashCode() {


### PR DESCRIPTION
title

See #95 for reasoning

![](https://file.house/lRox.png)

relevant: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type