### PR TITLE
fixes stupid reference equality in #95

### DIFF
--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -270,14 +270,11 @@ namespace OpenDreamServer.Dream {
             }
         }
 
-        public bool Equals(DreamValue other) {
-            return Value == other.Value;
-        }
-
+        public bool Equals(DreamValue other) => Value.Equals(other.Value);
+        
         public override bool Equals(object obj) {
             if (obj is DreamValue b) {
-                if (Value == null) 
-                        return b.Value == null;
+                if (Value == null) return b.Value == null;
                 return Value.Equals(b.Value);
             }
             return false;

--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -269,15 +269,12 @@ namespace OpenDreamServer.Dream {
                     throw new NotImplementedException("Cannot stringify " + this);
             }
         }
-
-        public bool Equals(DreamValue other) => Value.Equals(other.Value);
         
-        public override bool Equals(object obj) {
-            if (obj is DreamValue b) {
-                if (Value == null) return b.Value == null;
-                return Value.Equals(b.Value);
-            }
-            return false;
+        public override bool Equals(object obj) => obj is DreamValue other && Equals(other);
+
+        public bool Equals(DreamValue other) {
+            if (Value == null) return other.Value == null;
+            return Value.Equals(other.Value);
         }
 
         public override int GetHashCode() {

--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -276,7 +276,8 @@ namespace OpenDreamServer.Dream {
 
         public override bool Equals(object obj) {
             if (obj is DreamValue b) {
-                if (Value == null) return b.Value == null;
+                if (Value == null) 
+                        return b.Value == null;
                 return Value.Equals(b.Value);
             }
             return false;

--- a/OpenDreamServer/Dream/DreamValue.cs
+++ b/OpenDreamServer/Dream/DreamValue.cs
@@ -270,13 +270,16 @@ namespace OpenDreamServer.Dream {
             }
         }
 
+        public bool Equals(DreamValue other) {
+            return Value == other.Value;
+        }
+
         public override bool Equals(object obj) {
             if (obj is DreamValue b) {
                 if (Value == null) return b.Value == null;
-                else return Value.Equals(b.Value);
-            } else {
-                return false;
+                return Value.Equals(b.Value);
             }
+            return false;
         }
 
         public override int GetHashCode() {


### PR DESCRIPTION
see title, fixes #95 / #97 

https://web.archive.org/web/20100317143155/http://msdn.microsoft.com/en-us/library/ms173147(VS.80).aspx / https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type

> By default, the operator `==` tests for reference equality by determining if two references indicate the same object...

> The `==` and `!=` operators can be used with classes even if the class does not overload them. However, the default behavior is to perform a reference equality check.

now is also faster: 80ds