### PR TITLE
Converts foreach -> for List loops for `ProcNativeList`/`DreamList`

### DIFF
--- a/OpenDreamServer/Dream/Objects/DreamList.cs
+++ b/OpenDreamServer/Dream/Objects/DreamList.cs
@@ -21,9 +21,9 @@ namespace OpenDreamServer.Dream.Objects {
 
         private static DreamObjectDefinition _listDefinition = null;
 
-        private List<DreamValue> _values = new();
-        private Dictionary<DreamValue, DreamValue> _associativeValues = new();
-        private object _listLock = new object();
+        private readonly List<DreamValue> _values = new();
+        private readonly Dictionary<DreamValue, DreamValue> _associativeValues = new();
+        private readonly object _listLock = new object();
 
         public DreamList() : base(ListDefinition, new DreamProcArguments(null)) { }
 
@@ -122,7 +122,8 @@ namespace OpenDreamServer.Dream.Objects {
         //Does not include associations
         public bool ContainsValue(DreamValue value) {
             lock (_listLock) {
-                foreach (DreamValue listValue in _values) {
+                for (int idx = 0; idx < _values.Count; idx++) {
+                    DreamValue listValue = _values[idx];
                     if (value == listValue) return true;
                 }
             }
@@ -186,7 +187,7 @@ namespace OpenDreamServer.Dream.Objects {
 
     // /datum.vars list
     class DreamListVars : DreamList {
-        private DreamObject _dreamObject;
+        private readonly DreamObject _dreamObject;
 
         public DreamListVars(DreamObject dreamObject) : base() {
             _dreamObject = dreamObject;
@@ -201,7 +202,7 @@ namespace OpenDreamServer.Dream.Objects {
         }
 
         public override void SetValue(DreamValue key, DreamValue value) {
-            string varName = key.GetValueAsString();
+            String varName = key.GetValueAsString();
 
             if (_dreamObject.HasVariable(varName)) {
                 _dreamObject.SetVariable(varName, value);

--- a/OpenDreamServer/Dream/Procs/Native/DreamProcNativeList.cs
+++ b/OpenDreamServer/Dream/Procs/Native/DreamProcNativeList.cs
@@ -19,7 +19,6 @@ namespace OpenDreamServer.Dream.Procs.Native {
                     list.AddValue(argument);
                 }
             }
-
             return DreamValue.Null;
         }
 
@@ -73,7 +72,9 @@ namespace OpenDreamServer.Dream.Procs.Native {
                 DreamValue item = arguments.OrderedArguments[i];
 
                 if (item.TryGetValueAsDreamList(out DreamList valueList)) {
-                    foreach (DreamValue value in valueList.GetValues()) {
+                    List<DreamValue> values = valueList.GetValues();
+                    for (int idx = 0; idx < values.Count; idx++) {
+                        DreamValue value = values[idx];
                         list.Insert(index++, value);
                     }
                 } else {


### PR DESCRIPTION
These were iterating on `List`s. The other one in `DreamProcNativeList` are iterating on arguments, so I don't care about them.

![](https://cdn.discordapp.com/attachments/484170915253321734/843727655081345024/unknown.png)

Profiling for `ContainsValue` (called via `Set`):
```
DreamList.ContainsValue(DreamValue) - Own+System / Total time
foreach: 9,585ms / 22,320ms  (3,338ms was spent by System)
for: 3,544ms / 16,198ms      (No System time spent!)
```

test code:
```cs
var/list/L = list()
for(var/i in 1 to 12500)
    L["[i]"] = 1
```

Reading:
https://codingsight.com/foreach-or-for-that-is-the-question
https://stackoverflow.com/questions/365615/in-net-which-loop-runs-faster-for-or-foreach