### PR TITLE
add test for async proc call & fix for potential resumptions of stale proc states

### DIFF
--- a/OpenDreamRuntime.Tests/DMProject/code.dm
+++ b/OpenDreamRuntime.Tests/DMProject/code.dm
@@ -1,6 +1,10 @@
 /proc/sync_test()
 	return 1992
 
+/world/proc/async_test()
+	sleep(1)
+	return 1337
+
 /world/proc/error_test()
 	. = 1
 	src:nonexistent_proc()

--- a/OpenDreamRuntime.Tests/UnitTest1.cs
+++ b/OpenDreamRuntime.Tests/UnitTest1.cs
@@ -146,7 +146,7 @@ namespace OpenDreamRuntime.Tests
             Assert.Zero(runtime.ExceptionCount);
         }
 
-        [Test, Timeout(1000)]
+        [Test, Timeout(10000)]
         public void AsyncCall() {
             var runtime = CreateRuntime();
             var result = DreamValue.Null;

--- a/OpenDreamRuntime.Tests/UnitTest1.cs
+++ b/OpenDreamRuntime.Tests/UnitTest1.cs
@@ -145,5 +145,24 @@ namespace OpenDreamRuntime.Tests
             Assert.AreEqual(imageDefinition, obj.ObjectDefinition);
             Assert.Zero(runtime.ExceptionCount);
         }
+
+        [Test, Timeout(1000)]
+        public void AsyncCall() {
+            var runtime = CreateRuntime();
+            var result = DreamValue.Null;
+
+            DreamThread.Run(runtime, async(state) => {
+                var world = runtime.WorldInstance;
+                var proc = world.GetProc("async_test");
+                result = await state.Call(proc, world, null, new DreamProcArguments(null));
+                state.Runtime.Shutdown = true;
+                return DreamValue.Null;
+            });
+
+            runtime.Run();
+
+            Assert.AreEqual(result, new DreamValue(1337));
+            Assert.Zero(runtime.ExceptionCount);
+        }
     }
 }

--- a/OpenDreamRuntime/DreamRuntime.cs
+++ b/OpenDreamRuntime/DreamRuntime.cs
@@ -47,6 +47,8 @@ namespace OpenDreamRuntime
 
         private readonly InterfaceDescriptor _clientInterface;
 
+        public bool Shutdown;
+
         // Global state that may not really (really really) belong here
         public Dictionary<ServerIconAppearance, int> AppearanceToID = new();
         public Dictionary<DreamObject, int> ReferenceIDs = new();
@@ -128,7 +130,7 @@ namespace OpenDreamRuntime
         public void Run() {
             Server.Start(this);
 
-            while (true) {
+            while (!Shutdown) {
                 TickStartTime = new DateTimeOffset(DateTime.Now).ToUnixTimeMilliseconds();
                 
                 _taskScheduler.Process();


### PR DESCRIPTION
The problem I noticed was that if a proc completes synchronously, we'd return `ProcStatus.Returned` on the first call to InternalResume but the task's continuation would still be scheduled (and would later call Thread.Resume again.)

Seeing as we've already got the result, we don't need to schedule the task at all and can just discard it. 