### PR TITLE
CRASH proc ceases execution of caller

### DIFF
--- a/OpenDreamRuntime.Tests/DMProject/code.dm
+++ b/OpenDreamRuntime.Tests/DMProject/code.dm
@@ -13,6 +13,11 @@
 /world/proc/image_test()
 	return image('a', "Hello")
 
+/world/proc/crash_test()
+	. = 1
+	CRASH("This should stop the current proc")
+	. = 2
+
 /world/New()
 	..()
 	world.log << "World loaded!"

--- a/OpenDreamRuntime.Tests/DMProject/code.dm
+++ b/OpenDreamRuntime.Tests/DMProject/code.dm
@@ -18,6 +18,12 @@
 	CRASH("This should stop the current proc")
 	. = 2
 
+/world/proc/stack_overflow_test()
+	. = 1
+	while(1)
+		stack_overflow_test()
+	. = 2
+
 /world/New()
 	..()
 	world.log << "World loaded!"

--- a/OpenDreamRuntime.Tests/UnitTest1.cs
+++ b/OpenDreamRuntime.Tests/UnitTest1.cs
@@ -65,7 +65,7 @@ namespace OpenDreamRuntime.Tests
             process.Start();
             process.WaitForExit();
 
-            Assert.AreEqual(process.ExitCode, 0);
+            Assert.AreEqual(0, process.ExitCode);
         }
 
         private DreamRuntime CreateRuntime() {
@@ -82,7 +82,7 @@ namespace OpenDreamRuntime.Tests
             });
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
-            Assert.AreEqual(result, new DreamValue(1337));
+            Assert.AreEqual(new DreamValue(1337), result);
             Assert.Zero(runtime.ExceptionCount);
         }
 
@@ -96,7 +96,7 @@ namespace OpenDreamRuntime.Tests
                 return new DreamValue(1337);
             });
 
-            Assert.AreEqual(sync_result, new DreamValue(420));
+            Assert.AreEqual(new DreamValue(420), sync_result);
             Assert.Zero(runtime.ExceptionCount);
         }
 
@@ -110,7 +110,7 @@ namespace OpenDreamRuntime.Tests
                 return await state.Call(proc, null, null, new DreamProcArguments(null));
             });
 
-            Assert.AreEqual(sync_result, new DreamValue(1992));
+            Assert.AreEqual(new DreamValue(1992), sync_result);
             Assert.Zero(runtime.ExceptionCount);
         }
 
@@ -124,8 +124,8 @@ namespace OpenDreamRuntime.Tests
                 return await state.Call(proc, world, null, new DreamProcArguments(null));
             });
 
-            Assert.AreEqual(sync_result, new DreamValue(1));
-            Assert.AreEqual(runtime.ExceptionCount, 1);
+            Assert.AreEqual(new DreamValue(1), sync_result);
+            Assert.AreEqual(1, runtime.ExceptionCount);
         }
 
         [Test]
@@ -161,8 +161,22 @@ namespace OpenDreamRuntime.Tests
 
             runtime.Run();
 
-            Assert.AreEqual(result, new DreamValue(1337));
+            Assert.AreEqual(new DreamValue(1337), result);
             Assert.Zero(runtime.ExceptionCount);
+        }
+
+        [Test]
+        public void CrashPropagation() {
+            var runtime = CreateRuntime();
+
+            var sync_result = DreamThread.Run(runtime, async(state) => {
+                var world = runtime.WorldInstance;
+                var proc = world.GetProc("crash_test");
+                return await state.Call(proc, world, null, new DreamProcArguments(null));
+            });
+
+            Assert.AreEqual(new DreamValue(1), sync_result);
+            Assert.AreEqual(1, runtime.ExceptionCount);
         }
     }
 }

--- a/OpenDreamRuntime.Tests/UnitTest1.cs
+++ b/OpenDreamRuntime.Tests/UnitTest1.cs
@@ -178,5 +178,19 @@ namespace OpenDreamRuntime.Tests
             Assert.AreEqual(new DreamValue(1), sync_result);
             Assert.AreEqual(1, runtime.ExceptionCount);
         }
+
+        [Test]
+        public void StackOverflow() {
+            var runtime = CreateRuntime();
+
+            var sync_result = DreamThread.Run(runtime, async(state) => {
+                var world = runtime.WorldInstance;
+                var proc = world.GetProc("stack_overflow_test");
+                return await state.Call(proc, world, null, new DreamProcArguments(null));
+            });
+
+            Assert.AreEqual(new DreamValue(1), sync_result);
+            Assert.AreEqual(1, runtime.ExceptionCount);
+        }
     }
 }

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -176,7 +176,6 @@ namespace OpenDreamRuntime {
             _current = state;
         }
 
-        // Returns true if the thread still contains any proc states
         public void PopProcState() {
             if (!_stack.TryPop(out _current)) {
                 _current = null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -172,7 +172,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_CRASH(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             string message = arguments.GetArgument(0, "msg").GetValueAsString();
 
-            throw new Exception(message);
+            throw new PropagatingRuntime(message);
         }
 
         [DreamProc("fcopy")]


### PR DESCRIPTION
I made this work by having the CRASH proc return a special kind of exception. I also swapped around the args to Assert.AreEqual in my tests because I didn't realise it mattered before.