### PR TITLE
Implements DreamList unions (aka `L1 | L2`)

### DIFF
--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -140,6 +140,15 @@ namespace OpenDreamRuntime.Objects {
         public int GetLength() {
             return _values.Count;
         }
+
+        public DreamList Union(DreamList other) {
+            DreamList copy = CreateCopy();
+            copy._values.AddRange(other.GetValues());
+            foreach ((DreamValue key, DreamValue value) in other.GetAssociativeValues()) {
+                copy._associativeValues[key] = value;
+            }
+            return copy;
+        }
     }
 
     // /datum.vars list

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -1,5 +1,6 @@
 ﻿using OpenDreamRuntime.Procs;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenDreamRuntime.Objects {
     delegate void DreamListValueAssignedEventHandler(DreamList list, DreamValue key, DreamValue value);
@@ -142,12 +143,12 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public DreamList Union(DreamList other) {
-            DreamList copy = CreateCopy();
-            copy._values.AddRange(other.GetValues());
+            DreamList newList = new DreamList(Runtime);
+            newList._values = _values.Union(other.GetValues()).ToList();
             foreach ((DreamValue key, DreamValue value) in other.GetAssociativeValues()) {
-                copy._associativeValues[key] = value;
+                newList._associativeValues[key] = value;
             }
-            return copy;
+            return newList;
         }
     }
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
@@ -93,6 +93,19 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             return a;
         }
 
+        public override DreamValue OperatorOr(DreamValue a, DreamValue b) {
+            DreamList list = a.GetValueAsDreamList();
+
+            if (b.TryGetValueAsDreamList(out DreamList bList)) {    // List | List
+                list = list.Union(bList);
+            } else {                                                // List | x
+                list = list.CreateCopy();
+                list.AddValue(b);
+            }
+
+            return new DreamValue(list);
+        }
+
         public override DreamValue OperatorCombine(DreamValue a, DreamValue b) {
             DreamList list = a.GetValueAsDreamList();
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRoot.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRoot.cs
@@ -42,6 +42,9 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public virtual DreamValue OperatorRemove(DreamValue a, DreamValue b) {
             throw new InvalidOperationException("Cannot remove " + b + " from " + a);
         }
+        public virtual DreamValue OperatorOr(DreamValue a, DreamValue b) {
+            throw new InvalidOperationException("Cannot or " + a + " and " + b);
+        }
 
         public virtual DreamValue OperatorCombine(DreamValue a, DreamValue b) {
             throw new InvalidOperationException("Cannot combine " + a + " and " + b);

--- a/OpenDreamRuntime/Objects/MetaObjects/IDreamMetaObject.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/IDreamMetaObject.cs
@@ -12,6 +12,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamValue OperatorSubtract(DreamValue a, DreamValue b);
         public DreamValue OperatorAppend(DreamValue a, DreamValue b);
         public DreamValue OperatorRemove(DreamValue a, DreamValue b);
+        public DreamValue OperatorOr(DreamValue a, DreamValue b);
         public DreamValue OperatorCombine(DreamValue a, DreamValue b);
         public DreamValue OperatorMask(DreamValue a, DreamValue b);
     }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -578,7 +578,9 @@ namespace OpenDreamRuntime.Procs {
                     state.Push(new DreamValue(firstInt | secondInt));
                 } else if (firstValue.TryGetValueAsDreamList(out DreamList firstList)) {    // List | 2
                     firstList.AddValue(secondValue);
+                    state.Push(new DreamValue(firstList));
                 } else {
+                    // TODO: Icon | 2
                     throw new NotImplementedException("| is only implemented for lists and numbers");
                 }
             }
@@ -590,9 +592,11 @@ namespace OpenDreamRuntime.Procs {
                 } else if (firstValue.Type == DreamValue.DreamValueType.Float) {            // 1 | List
                     throw new Exception("Type mismatch: " + firstValue + "(number) | " + secondList + "(/list)");
                 } else {
+                    // TODO: Icon | List
                     throw new NotImplementedException("| is only implemented for lists and numbers");
                 }
             }
+            // TODO: x | Icon
             return null;
         }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -568,35 +568,31 @@ namespace OpenDreamRuntime.Procs {
             return null;
         }
 
-        public static ProcStatus? BitOr(DMProcState state) {                                // x | y
-            DreamValue secondValue = state.PopDreamValue();
+        public static ProcStatus? BitOr(DMProcState state) {                        // x | y
+            DreamValue second = state.PopDreamValue();
+            DreamValue first = state.PopDreamValue();
 
-            if (secondValue.TryGetValueAsInteger(out int secondInt)) {                      // x | 2
-                DreamValue firstValue = state.PopDreamValue();
+            if (first.Type == DreamValue.DreamValueType.DreamObject) {              // Object | y
+                if (first.Value != null) {
+                    IDreamMetaObject metaObject = first.GetValueAsDreamObject().ObjectDefinition.MetaObject;
 
-                if (firstValue.TryGetValueAsInteger(out int firstInt)) {                    // 1 | 2
-                    state.Push(new DreamValue(firstInt | secondInt));
-                } else if (firstValue.TryGetValueAsDreamList(out DreamList firstList)) {    // List | 2
-                    firstList.AddValue(secondValue);
-                    state.Push(new DreamValue(firstList));
+                    if (metaObject != null) {
+                        state.Push(metaObject.OperatorOr(first, second));
+                    } else {
+                        throw new Exception("Invalid or operation on " + first + " and " + second);
+                    }
                 } else {
-                    // TODO: Icon | 2
-                    throw new NotImplementedException("| is only implemented for lists and numbers");
+                    state.Push(DreamValue.Null);
+                }
+            } else if (second.Value != null) {                                      // Non-Object | y
+                switch (first.Type) {
+                    case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
+                        state.Push(new DreamValue(first.GetValueAsInteger() | second.GetValueAsInteger()));
+                        break;
+                    default:
+                        throw new Exception("Invalid or operation on " + first + " and " + second);
                 }
             }
-            else if (secondValue.TryGetValueAsDreamList(out DreamList secondList)) {        // x | List
-                DreamValue firstValue = state.PopDreamValue();
-
-                if (firstValue.TryGetValueAsDreamList(out DreamList firstList)) {           // List | List
-                    state.Push(new DreamValue(firstList.Union(secondList)));
-                } else if (firstValue.Type == DreamValue.DreamValueType.Float) {            // 1 | List
-                    throw new Exception("Type mismatch: " + firstValue + "(number) | " + secondList + "(/list)");
-                } else {
-                    // TODO: Icon | List
-                    throw new NotImplementedException("| is only implemented for lists and numbers");
-                }
-            }
-            // TODO: x | Icon
             return null;
         }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -568,16 +568,30 @@ namespace OpenDreamRuntime.Procs {
             return null;
         }
 
-        public static ProcStatus? BitOr(DMProcState state) {
-            DreamValue value = state.PopDreamValue();
-            if (value.TryGetValueAsInteger(out int secondInt)) {
-                int first = state.PopDreamValue().GetValueAsInteger();
+        public static ProcStatus? BitOr(DMProcState state) {                                // x | y
+            DreamValue secondValue = state.PopDreamValue();
 
-                state.Push(new DreamValue(first | secondInt));
-            } else if (value.TryGetValueAsDreamList(out DreamList secondList)) {
-                DreamList first = state.PopDreamValue().GetValueAsDreamList();
+            if (secondValue.TryGetValueAsInteger(out int secondInt)) {                      // x | 2
+                DreamValue firstValue = state.PopDreamValue();
 
-                state.Push(new DreamValue(first.Union(secondList)));
+                if (firstValue.TryGetValueAsInteger(out int firstInt)) {                    // 1 | 2
+                    state.Push(new DreamValue(firstInt | secondInt));
+                } else if (firstValue.TryGetValueAsDreamList(out DreamList firstList)) {    // List | 2
+                    firstList.AddValue(secondValue);
+                } else {
+                    throw new NotImplementedException("| is only implemented for lists and numbers");
+                }
+            }
+            else if (secondValue.TryGetValueAsDreamList(out DreamList secondList)) {        // x | List
+                DreamValue firstValue = state.PopDreamValue();
+
+                if (firstValue.TryGetValueAsDreamList(out DreamList firstList)) {           // List | List
+                    state.Push(new DreamValue(firstList.Union(secondList)));
+                } else if (firstValue.Type == DreamValue.DreamValueType.Float) {            // 1 | List
+                    throw new Exception("Type mismatch: " + firstValue + "(number) | " + secondList + "(/list)");
+                } else {
+                    throw new NotImplementedException("| is only implemented for lists and numbers");
+                }
             }
             return null;
         }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -569,10 +569,16 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public static ProcStatus? BitOr(DMProcState state) {
-            int second = state.PopDreamValue().GetValueAsInteger();
-            int first = state.PopDreamValue().GetValueAsInteger();
+            DreamValue value = state.PopDreamValue();
+            if (value.TryGetValueAsInteger(out int secondInt)) {
+                int first = state.PopDreamValue().GetValueAsInteger();
 
-            state.Push(new DreamValue(first | second));
+                state.Push(new DreamValue(first | secondInt));
+            } else if (value.TryGetValueAsDreamList(out DreamList secondList)) {
+                DreamList first = state.PopDreamValue().GetValueAsDreamList();
+
+                state.Push(new DreamValue(first.Union(secondList)));
+            }
             return null;
         }
 

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -14,16 +14,40 @@
 		loc = locate(5, 5, 1)
 
 	verb/tell_location()
-		var/list/L = list(1, 2, 3)
-		var/list/G = list(3, 4, 5)
-		var/num = 6
-		var/numm = 8
+		usr << "You are at ([x], [y], [z])"
 
-		world << json_encode(L | G)
-		world << json_encode(G | L)
-		//world << num | L
-		world << json_encode(L | num)
-		world << (num | numm)
+	verb/say(message as text)
+		var/list/viewers = viewers()
+
+		for (var/mob/viewer in viewers)
+			viewer << "[ckey] says: \"[message]\""
+
+	verb/say_loud()
+		var/msg = input("Please put the message you want to say loudly.", "Say Loud", "Hello!")
+		world << "[ckey] says loudly: \"[msg]\""
+
+	verb/move_up()
+		step(src, UP)
+
+	verb/move_down()
+		step(src, DOWN)
+
+	verb/md5_ckey()
+		var/hash = md5(ckey)
+		usr << "The md5 hash of your ckey is: [hash]"
+
+	verb/roll_dice(dice as text)
+		var/result = roll(dice)
+		usr << "The total shown on the dice is: [result]"
+
+	verb/clamp_value()
+	    var/out1 = clamp(10, 1, 5)
+	    usr << "The output should be 5: [out1]"
+	    var/out2 = clamp(-10, 1, 5)
+	    usr << "The output should be 1: [out2]"
+	    var/out3 = clamp(list(-10, 5, 40, -40), 1, 10)
+	    for(var/item in out3)
+	    	usr << "The output should be between 1 and 10: [item]"
 
 /mob/Stat()
 	statpanel("Status", "CPU: [world.cpu]")

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -14,41 +14,17 @@
 		loc = locate(5, 5, 1)
 
 	verb/tell_location()
-		usr << "You are at ([x], [y], [z])"
+		var/list/L = list(1, 2, 3)
+		var/list/G = list(3, 4, 5)
+		var/num = 6
+		var/numm = 8
 
-	verb/say(message as text)
-		var/list/viewers = viewers()
+		world << json_encode(L | G)
+		world << json_encode(G | L)
+		//world << num | L
+		world << json_encode(L | num)
+		world << (num | numm)
 
-		for (var/mob/viewer in viewers)
-			viewer << "[ckey] says: \"[message]\""
-
-	verb/say_loud()
-		var/msg = input("Please put the message you want to say loudly.", "Say Loud", "Hello!")
-		world << "[ckey] says loudly: \"[msg]\""
-
-	verb/move_up()
-		step(src, UP)
-
-	verb/move_down()
-		step(src, DOWN)
-
-	verb/md5_ckey()
-		var/hash = md5(ckey)
-		usr << "The md5 hash of your ckey is: [hash]"
-	    
-	verb/roll_dice(dice as text)
-		var/result = roll(dice)
-		usr << "The total shown on the dice is: [result]"
-
-	verb/clamp_value()
-	    var/out1 = clamp(10, 1, 5)
-	    usr << "The output should be 5: [out1]"
-	    var/out2 = clamp(-10, 1, 5)
-	    usr << "The output should be 1: [out2]"
-	    var/out3 = clamp(list(-10, 5, 40, -40), 1, 10)
-	    for(var/item in out3)
-	    	usr << "The output should be between 1 and 10: [item]"
-	
 /mob/Stat()
 	statpanel("Status", "CPU: [world.cpu]")
 


### PR DESCRIPTION
title

partially solves #120 - won't be doing the icon bit now

```cs
var/list/L = list(1,2,3)
var/list/G = list(3,4,5)
var/x = 7
var/y = 8
world.log << json_encode(L | G)
world.log << json_encode(G | L)
world.log << json_encode(L | x)
world.log << json_encode(x | y)
world.log << json_encode(L | null)
world.log << json_encode(null | L)
```
to
```
[1,2,3,4,5]
[3,4,5,1,2]
[1,2,3,7]
15
[1,2,3,null]
null
```