### PR TITLE
DreamList.ContainsValue speedup

### DIFF
--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -4,7 +4,7 @@ using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime {
-    public struct DreamValue {
+    public struct DreamValue : IEquatable<DreamValue> {
         [Flags]
         public enum DreamValueType {
             String = 1,

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -89,11 +89,7 @@ namespace OpenDreamRuntime.Objects {
 
         //Does not include associations
         public bool ContainsValue(DreamValue value) {
-            foreach (DreamValue listValue in _values) {
-                if (value == listValue) return true;
-            }
-
-            return false;
+            return _values.Contains(value);
         }
 
         public int FindValue(DreamValue value, int start = 1, int end = 0) {


### PR DESCRIPTION
Implements IEquatable<DreamValue> for DreamValue
Converts DreamList to use .Contains for ContainsValue

https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1?view=net-5.0#remarks
> Methods such as Contains, IndexOf, LastIndexOf, and Remove use an equality comparer for the list elements. The default equality comparer for type T is determined as follows. If type T implements the IEquatable<T> generic interface, then the equality comparer is the Equals(T) method of that interface; otherwise, the default equality comparer is Object.Equals(Object).

> Make certain the value type used for type T implements the IEquatable<T> generic interface. If not, methods such as Contains must call the Object.Equals(Object) method, which boxes the affected list element.