### PR TITLE
Implements var/thing[len] list syntax

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -421,17 +421,26 @@ namespace OpenDreamShared.Compiler.DM {
 
                 DMASTExpression value = null;
 
-                if (Check(TokenType.DM_LeftBracket) && !Check(TokenType.DM_RightBracket)) //TODO: Multidimensional lists
+                if (Check(TokenType.DM_LeftBracket)) //TODO: Multidimensional lists
                 {
                     //Type information
                     if (path.Path.FindElement("list") != 0)
                     {
-                        path = new DMASTPath(new DreamPath("list/"  + path.Path.PathString));
+                        path = new DMASTPath(new DreamPath("list/" + path.Path.PathString));
                     }
 
-                    var size = Expression();
+                    Whitespace();
 
-                    Consume(TokenType.DM_RightBracket, "Expected ']'");
+                    var size = new DMASTConstantInteger(0);
+                    if (!Check(TokenType.DM_RightBracket))
+                    {
+                        var expr = Expression() as DMASTExpressionConstant;
+                        if (expr is DMASTConstantInteger integer)
+                        {
+                            size = integer;
+                        }
+                        Consume(TokenType.DM_RightBracket, "Expected ']'");
+                    }
 
                     value = new DMASTNewPath(new DMASTPath(DreamPath.List),
                             new[] {new DMASTCallParameter(size)});

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -447,7 +447,7 @@ namespace OpenDreamShared.Compiler.DM {
                 if (Check(TokenType.DM_Equals)) {
                     if (value is not null)
                     {
-                        Error("list doubly initialized");
+                        Error("List doubly initialized");
                     }
                     else
                     {

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -431,22 +431,8 @@ namespace OpenDreamShared.Compiler.DM {
 
                     Whitespace();
 
-                    DMASTConstantInteger size = null;
-                    if (!Check(TokenType.DM_RightBracket))
-                    {
-                        var expr = Expression() as DMASTExpressionConstant;
-                        if (expr is DMASTConstantInteger integer)
-                        {
-                            size = integer;
-                        }
-                        else
-                        {
-                            size = new DMASTConstantInteger(0);
-                        }
-
-                        Whitespace();
-                        Consume(TokenType.DM_RightBracket, "Expected ']'");
-                    }
+                    DMASTExpression size = Expression();
+                    Consume(TokenType.DM_RightBracket, "Expected ']'");
 
                     if (size is not null)
                     {

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -439,6 +439,8 @@ namespace OpenDreamShared.Compiler.DM {
                         {
                             size = integer;
                         }
+
+                        Whitespace();
                         Consume(TokenType.DM_RightBracket, "Expected ']'");
                     }
 

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -421,7 +421,7 @@ namespace OpenDreamShared.Compiler.DM {
 
                 DMASTExpression value = null;
 
-                if (Check(TokenType.DM_LeftBracket)) //TODO: Multidimensional lists
+                if (Check(TokenType.DM_LeftBracket) && !Check(TokenType.DM_RightBracket)) //TODO: Multidimensional lists
                 {
                     //Type information
                     if (path.Path.FindElement("list") != 0)
@@ -429,12 +429,7 @@ namespace OpenDreamShared.Compiler.DM {
                         path = new DMASTPath(new DreamPath("list/"  + path.Path.PathString));
                     }
 
-                    var size = Expression() as DMASTExpressionConstant;
-                    if (size is not DMASTConstantInteger)
-                    {
-                        Error("list length must be an integer");
-                        return null;
-                    }
+                    var size = Expression();
 
                     Consume(TokenType.DM_RightBracket, "Expected ']'");
 

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -431,7 +431,7 @@ namespace OpenDreamShared.Compiler.DM {
 
                     Whitespace();
 
-                    var size = new DMASTConstantInteger(0);
+                    DMASTConstantInteger size = null;
                     if (!Check(TokenType.DM_RightBracket))
                     {
                         var expr = Expression() as DMASTExpressionConstant;
@@ -442,8 +442,12 @@ namespace OpenDreamShared.Compiler.DM {
                         Consume(TokenType.DM_RightBracket, "Expected ']'");
                     }
 
-                    value = new DMASTNewPath(new DMASTPath(DreamPath.List),
+                    if (size is not null)
+                    {
+                        value = new DMASTNewPath(new DMASTPath(DreamPath.List),
                             new[] {new DMASTCallParameter(size)});
+                    }
+
                 }
 
                 Whitespace();

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -424,7 +424,7 @@ namespace OpenDreamShared.Compiler.DM {
                 if (Check(TokenType.DM_LeftBracket)) //TODO: Multidimensional lists
                 {
                     //Type information
-                    if (path.Path.PathString.Substring(0, 4) != "list")
+                    if (path.Path.FindElement("list") != 0)
                     {
                         path = new DMASTPath(new DreamPath("list/"  + path.Path.PathString));
                     }

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -439,6 +439,10 @@ namespace OpenDreamShared.Compiler.DM {
                         {
                             size = integer;
                         }
+                        else
+                        {
+                            size = new DMASTConstantInteger(0);
+                        }
 
                         Whitespace();
                         Consume(TokenType.DM_RightBracket, "Expected ']'");


### PR DESCRIPTION
Test code:
```
verb/stupid_list()
    var/thing[5]
    usr << thing.len
```

Fixes #49 