### PR TITLE
Use 32x32 as default icon size

### DIFF
--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -19,7 +19,7 @@ namespace OpenDreamShared.Resources {
         public class ParsedDMIDescription {
             public string Source;
             public float Version;
-            public int Width, Height;
+            public int Width = 32, Height = 32;
             public string DefaultStateName;
             public Dictionary<string, ParsedDMIState> States;
 


### PR DESCRIPTION
Fixes https://github.com/wixoaGit/OpenDream/issues/129