### PR TITLE
Adds more info to yielding New() exceptions

### DIFF
--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -29,7 +29,7 @@ namespace OpenDreamRuntime.Objects {
             thread.PushProcState(procState);
 
             if (thread.Resume() == DreamValue.Null) {
-                throw new InvalidOperationException("DreamObject.InitSpawn called a yielding proc!");
+                throw new InvalidOperationException($"DreamObject.InitSpawn ({this.ObjectDefinition.Type}) called a yielding proc!");
             }
         }
 

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -29,7 +29,7 @@ namespace OpenDreamRuntime.Objects {
             thread.PushProcState(procState);
 
             if (thread.Resume() == DreamValue.Null) {
-                throw new InvalidOperationException($"DreamObject.InitSpawn ({this.ObjectDefinition.Type}) called a yielding proc!");
+                thread.HandleException(new InvalidOperationException("DreamObject.InitSpawn called a yielding proc!"));
             }
         }
 


### PR DESCRIPTION
Includes the typepath: 
`Unhandled exception. System.InvalidOperationException: DreamObject.InitSpawn (/obj/structure/closet/secure_closet/injection) called a yielding proc!`