### PR TITLE
Implements `world.sleep_offline`

### DIFF
--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -1,4 +1,4 @@
-﻿/world
+/world
 	var/list/contents = list()
 
 	var/log = null
@@ -15,6 +15,7 @@
 	var/cpu = 0
 	var/fps = null
 	var/tick_usage
+	var/sleep_offline = 0
 
 	var/maxx = 0
 	var/maxy = 0

--- a/OpenDreamRuntime/DreamRuntime.cs
+++ b/OpenDreamRuntime/DreamRuntime.cs
@@ -125,6 +125,17 @@ namespace OpenDreamRuntime
             Server.Start(this);
 
             while (!Shutdown) {
+                int tickLength = (int)(100 * WorldInstance.GetVariable("tick_lag").GetValueAsFloat());
+
+                //TODO: sleep_offline = 0
+                if (Server.GetConnectedClientCount() == 0 &&
+                    WorldInstance.GetVariable("sleep_offline").TryGetValueAsInteger(out int val) && val == 1)
+                {
+                    Server.Process();
+                    Thread.Sleep(tickLength);
+                    continue;
+                }
+
                 TickStartTime = new DateTimeOffset(DateTime.Now).ToUnixTimeMilliseconds();
 
                 _taskScheduler.Process();
@@ -138,10 +149,10 @@ namespace OpenDreamRuntime
                 TickCount++;
 
                 int elapsedTime = (int)(new DateTimeOffset(DateTime.Now).ToUnixTimeMilliseconds() - TickStartTime);
-                int tickLength = (int)(100 * WorldInstance.GetVariable("tick_lag").GetValueAsFloat());
                 int timeToSleep = tickLength - elapsedTime;
                 WorldInstance.SetVariable("cpu", new DreamValue((float)elapsedTime / tickLength * 100));
                 if (timeToSleep > 0) Thread.Sleep(timeToSleep);
+                Console.WriteLine($"Tick: {TickCount}, Connections: {Server.GetConnectedClientCount()}");
             }
         }
 

--- a/OpenDreamRuntime/DreamServer.cs
+++ b/OpenDreamRuntime/DreamServer.cs
@@ -55,5 +55,16 @@ namespace OpenDreamRuntime {
 
             return null;
         }
+
+        public int GetConnectedClientCount()
+        {
+            var clients = 0;
+
+            for (var i = 0; i < Connections.Count; i++) {
+                if (Connections[i].ClientDreamObject != null) clients++;
+            }
+
+            return clients;
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/wixoaGit/OpenDream/issues/194

Doesn't properly implement `sleep_offline = 0` because I have no idea how to handle that (see the docs: http://www.byond.com/docs/ref/#/world/var/sleep_offline)

Draft because I don't see where we actually accurately track the number of connected clients. I had to manually clear the `Connections` list while testing.