### PR TITLE
Shaves 2,000 ms off of maploading

### DIFF
--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -150,11 +150,14 @@ namespace OpenDreamRuntime.Objects {
             else return false;
         }
 
-        private void CopyVariablesFrom(DreamObjectDefinition definition) {
+        private void CopyVariablesFrom(DreamObjectDefinition definition)
+        {
+            Variables = new Dictionary<string, DreamValue>(definition.Variables.Count);
             foreach (KeyValuePair<string, DreamValue> variable in definition.Variables) {
                 Variables.Add(variable.Key, variable.Value);
             }
 
+            GlobalVariables = new Dictionary<string, DreamGlobalVariable>(definition.GlobalVariables.Count);
             foreach (KeyValuePair<string, DreamGlobalVariable> globalVariable in definition.GlobalVariables) {
                 GlobalVariables.Add(globalVariable.Key, globalVariable.Value);
             }

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -152,10 +152,7 @@ namespace OpenDreamRuntime.Objects {
 
         private void CopyVariablesFrom(DreamObjectDefinition definition)
         {
-            Variables = new Dictionary<string, DreamValue>(definition.Variables.Count);
-            foreach (KeyValuePair<string, DreamValue> variable in definition.Variables) {
-                Variables.Add(variable.Key, variable.Value);
-            }
+            Variables = new Dictionary<string, DreamValue>(definition.Variables);
 
             GlobalVariables = new Dictionary<string, DreamGlobalVariable>(definition.GlobalVariables.Count);
             foreach (KeyValuePair<string, DreamGlobalVariable> globalVariable in definition.GlobalVariables) {

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -154,10 +154,7 @@ namespace OpenDreamRuntime.Objects {
         {
             Variables = new Dictionary<string, DreamValue>(definition.Variables);
 
-            GlobalVariables = new Dictionary<string, DreamGlobalVariable>(definition.GlobalVariables.Count);
-            foreach (KeyValuePair<string, DreamGlobalVariable> globalVariable in definition.GlobalVariables) {
-                GlobalVariables.Add(globalVariable.Key, globalVariable.Value);
-            }
+            GlobalVariables = new Dictionary<string, DreamGlobalVariable>(definition.GlobalVariables);
         }
     }
 }


### PR DESCRIPTION
Removes a bunch of allocations by pre-allocating the dictionary sizes for Variables and GlobalVariables. This works off of the assumption that these dictionaries are empty until `CopyVariablesFrom()` is called, and that this method is only called once. If this isn't the case then I can probably tweak it for less impressive improvements.

Basic Rider profiling (not the most accurate, mind you) shows this method going from ~3,000ms to ~1,000ms.