### PR TITLE
Pre-allocate the stack in Normalize()

### DIFF
--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -198,7 +198,7 @@ namespace OpenDreamShared.Dream {
         public static bool operator !=(DreamPath lhs, DreamPath rhs) => !(lhs == rhs);
 
         private void Normalize() {
-            Stack<string> elements = new Stack<string>();
+            Stack<string> elements = new Stack<string>(Elements.Length);
 
             foreach (string element in Elements) {
                 if (element == "..") {


### PR DESCRIPTION
Memory allocations go brrrrrrr.

I didn't bother profiling it but it's so bad even my IDE pointed it out.