### PR TITLE
Update RobustToolbox submodule to the latest version.

### DIFF
--- a/Content.Shared/ContentNetIDs.cs
+++ b/Content.Shared/ContentNetIDs.cs
@@ -1,5 +1,0 @@
-﻿namespace Content.Shared {
-    public static class ContentNetIDs {
-        public const uint DMI_SPRITE = 1000;
-    }
-}

--- a/Content.Shared/SharedDMISpriteComponent.cs
+++ b/Content.Shared/SharedDMISpriteComponent.cs
@@ -2,18 +2,19 @@
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using System;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared {
+    [NetworkedComponent]
     public class SharedDMISpriteComponent : Component {
         public override string Name => "DMISprite";
-        public override uint? NetID => ContentNetIDs.DMI_SPRITE;
 
         [Serializable, NetSerializable]
         protected class DMISpriteComponentState : ComponentState {
             public readonly ResourcePath Icon;
             public readonly string IconState;
 
-            public DMISpriteComponentState(ResourcePath icon, string iconState) : base(ContentNetIDs.DMI_SPRITE) {
+            public DMISpriteComponentState(ResourcePath icon, string iconState) {
                 Icon = icon;
                 IconState = iconState;
             }


### PR DESCRIPTION
The most notable change is the removal of component NetIDs in favor of the `NetworkedComponent` attribute, which takes care of everything automatically when you put it in the shared component class. 