### PR TITLE
Integration tests now compile and use DMProject.

### DIFF
--- a/Content.Client/EntryPoint.cs
+++ b/Content.Client/EntryPoint.cs
@@ -13,6 +13,8 @@ namespace Content.Client {
             IComponentFactory componentFactory = IoCManager.Resolve<IComponentFactory>();
             componentFactory.DoAutoRegistrations();
 
+            ClientContentIoC.Register();
+
             // This needs to happen after all IoC registrations, but before IoC.BuildGraph();
             foreach (var callback in TestingCallbacks)
             {
@@ -20,7 +22,6 @@ namespace Content.Client {
                 cast.ClientBeforeIoC?.Invoke();
             }
 
-            ClientContentIoC.Register();
             IoCManager.BuildGraph();
             componentFactory.GenerateNetIds();
 

--- a/Content.Client/EntryPoint.cs
+++ b/Content.Client/EntryPoint.cs
@@ -31,7 +31,6 @@ namespace Content.Client {
         public override void PostInit() {
             IoCManager.Resolve<ILightManager>().Enabled = false;
 
-            IoCManager.Resolve<IBaseClient>().ConnectToServer("127.0.0.1", 25566);
             IoCManager.Resolve<IOverlayManager>().AddOverlay(new DreamMapOverlay());
             IoCManager.Resolve<IDreamInterfaceManager>().LoadDMF(new ResourcePath("/Game/interface.dmf")); //TODO: Don't hardcode interface.dmf
         }

--- a/Content.IntegrationTests/Content.IntegrationTests.csproj
+++ b/Content.IntegrationTests/Content.IntegrationTests.csproj
@@ -19,11 +19,18 @@
     <ProjectReference Include="..\Content.Server\Content.Server.csproj" />
     <ProjectReference Include="..\Content.Shared\Content.Shared.csproj" />
     <ProjectReference Include="..\Content.Tests\Content.Tests.csproj" />
+    <ProjectReference Include="..\DMCompiler\DMCompiler.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.Client\Robust.Client.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.Server\Robust.Server.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.Shared.Maths\Robust.Shared.Maths.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.Shared\Robust.Shared.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.UnitTesting\Robust.UnitTesting.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Copy DMProject to output directory. !-->
+    <None Include="$(ProjectDir)\DMProject\**" CopyToOutputDirectory="PreserveNewest" LinkBase="DMProject\" />
+    <!-- Copy DMStandard to output directory. !-->
+    <None Include="$(SolutionDir)\DMCompiler\DMStandard\**" CopyToOutputDirectory="PreserveNewest" LinkBase="DMStandard\" />
   </ItemGroup>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Analyzers.targets" />
 </Project>

--- a/Content.IntegrationTests/ContentIntegrationTest.cs
+++ b/Content.IntegrationTests/ContentIntegrationTest.cs
@@ -53,6 +53,10 @@ namespace Content.IntegrationTests {
                 LoadContentResources = true,
             };
 
+            // Set compiled json path by default.
+            if (!options.CVarOverrides.ContainsKey(OpenDreamCVars.JsonPath.Name))
+                options.CVarOverrides[OpenDreamCVars.JsonPath.Name] = SetupCompileDm.CompiledProject;
+
             options.ContentStart = true;
 
             options.ContentAssemblies = new[] {

--- a/Content.IntegrationTests/DMProject/code.dm
+++ b/Content.IntegrationTests/DMProject/code.dm
@@ -1,0 +1,163 @@
+/proc/sync_test()
+	return 1992
+
+/world/proc/async_test()
+	sleep(1)
+	return 1337
+
+/world/proc/error_test()
+	. = 1
+	src:nonexistent_proc()
+	. = 2
+
+/world/proc/image_test()
+	return image('a', "Hello")
+
+/world/proc/crash_test()
+	. = 1
+	CRASH("This should stop the current proc")
+	. = 2
+
+/world/proc/stack_overflow_test()
+	. = 1
+	while(1)
+		stack_overflow_test()
+	. = 2
+
+
+//
+// waitfor_1_a() should evaluate to 3
+//
+/world/proc/waitfor_1_a()
+	. = 1
+	. = waitfor_1_b()
+
+/world/proc/waitfor_1_b()
+	set waitfor = FALSE
+	. = 2
+	. = waitfor_1_c()
+	. = 3
+	sleep(1)
+	. = 4
+
+/world/proc/waitfor_1_c()
+	set waitfor = FALSE
+	. = 5
+	sleep(1)
+	. = 6
+
+//
+// waitfor_2_a should evaluate to 2
+//
+/world/proc/waitfor_2_a()
+	. = 1
+	. = waitfor_2_b()
+
+/world/proc/waitfor_2_b()
+	set waitfor = FALSE
+	. = 2
+	. = waitfor_2_c()
+	. = 3
+	sleep(1)
+	. = 4
+
+/world/proc/waitfor_2_c()
+	set waitfor = TRUE
+	. = 5
+	sleep(1)
+	. = 6
+
+//
+
+/world/proc/default_test(datum/arg = new())
+	return arg
+
+/world/proc/crazy_inferred_types()
+	var/list/L = list()
+	L[new()] = new()
+
+/world/proc/value_in_list(test)
+	var/L = list(1, 2, 3)
+	if (4 in L)
+		return FALSE
+	if (!(3 in L))
+		return FALSE
+	return TRUE
+
+/world/proc/call_target()
+	return 13
+
+/world/proc/call_test()
+	return call(src, "call_target")()
+
+//
+
+/datum/parent
+	proc/f(a)
+		return a
+
+/datum/parent/child
+	f(a)
+		return ..()
+
+/world/proc/super_call()
+	var/datum/parent/child/C = new()
+	. = C.f(127)
+
+/datum/recursive
+	var/datum/recursive/inner
+	var/val = 2
+
+	proc/get_inner()
+		. = inner
+
+/world/proc/conditional_access_test()
+	var/datum/recursive/R = new()
+	R?.inner?.inner = CRASH("this shouldn't be evaluated")
+	R.inner = 1
+	return R?.inner
+
+/world/proc/conditional_access_test_error()
+	var/datum/recursive/R = new()
+	return R?.inner.inner
+
+/world/proc/conditional_call_test()
+	var/datum/recursive/R = new()
+	return R?.inner?.get_inner(CRASH("this shouldn't be evaluated"))
+ 
+/world/proc/conditional_call_test_error()
+ 	var/datum/recursive/R = new()
+ 	return R?.inner.get_inner()
+
+/world/proc/conditional_mutate()
+	var/datum/recursive/R = null
+	R?.val *= CRASH("this shouldn't be evaluated")
+	R = new()
+	return R?.val *= 2
+
+/world/proc/list_index_mutate()
+	var/list/L = list(1, 2, 3)
+	return L[2] *= 15
+
+/world/proc/switch_const()
+	var/a = 137
+	switch(a)
+		if(20)
+			. = 500
+		if(136 | 1)
+			. = 1
+		if(/datum, /mob)
+			. = 300
+
+/world/proc/clamp_value()
+	var/out1 = clamp(10, 1, 5)
+	if (out1 != 5) return 0
+	var/out2 = clamp(-10, 1, 5)
+	if (out2 != 1) return 0
+	var/out3 = clamp(list(-10, 5, 40, -40), 1, 10)
+	for(var/item in out3)
+		if (item < 1 || item > 10) return 0
+	return 1
+
+/world/proc/md5_test()
+	return md5("md5_test")

--- a/Content.IntegrationTests/DMProject/environment.dme
+++ b/Content.IntegrationTests/DMProject/environment.dme
@@ -1,0 +1,3 @@
+#include "code.dm"
+#include "map.dmm"
+#include "interface.dmf"

--- a/Content.IntegrationTests/DMProject/interface.dmf
+++ b/Content.IntegrationTests/DMProject/interface.dmf
@@ -1,0 +1,72 @@
+window "mapwindow"
+	elem "mapwindow"
+		type = MAIN
+		pos = 0,0
+		size = 640x480
+		is-pane = true
+	elem "map"
+		type = MAP
+		pos = 0,0
+		size = 640x480
+		anchor1 = 0,0
+		anchor2 = 100,100
+		is-default = true
+
+window "infowindow"
+	elem "infowindow"
+		type = MAIN
+		pos = 0,0
+		size = 640x480
+		is-pane = true
+	elem "info"
+		type = CHILD
+		pos = 0,30
+		size = 640x445
+		anchor1 = 0,0
+		anchor2 = 100,100
+		left = "statwindow"
+		right = "outputwindow"
+		is-vert = false
+
+window "outputwindow"
+	elem "outputwindow"
+		type = MAIN
+		pos = 0,0
+		size = 640x480
+		is-pane = true
+	elem "output"
+		type = OUTPUT
+		pos = 0,0
+		size = 640x480
+		anchor1 = 0,0
+		anchor2 = 100,100
+		is-default = true
+
+window "statwindow"
+	elem "statwindow"
+		type = MAIN
+		pos = 0,0
+		size = 640x480
+		is-pane = true
+	elem "stat"
+		type = INFO
+		pos = 0,0
+		size = 640x480
+		anchor1 = 0,0
+		anchor2 = 100,100
+		is-default = true
+
+window "mainwindow"
+	elem "mainwindow"
+		type = MAIN
+		size = 640x440
+		is-default = true
+	elem "split"
+		type = CHILD
+		pos = 3,0
+		size = 634x417
+		anchor1 = 0,0
+		anchor2 = 100,100
+		left = "mapwindow"
+		right = "infowindow"
+		is-vert = true

--- a/Content.IntegrationTests/DMProject/map.dmm
+++ b/Content.IntegrationTests/DMProject/map.dmm
@@ -1,0 +1,41 @@
+"a" = (/area,/turf)
+"b" = (/area,/turf/blue)
+
+(1, 1, 1) = {"
+bbbbbbbbbb
+baaaaaaaab
+baaaaaaaab
+baaaaaaaab
+baaaaaaaab
+baaaaaaaab
+baaaaaaaab
+baaaaaaaab
+baaaaaaaab
+bbbbbbbbbb
+"}
+
+(1, 1, 2) = {"
+baaaaaaaab
+abaaaaaaba
+aabaaaabaa
+aaabaabaaa
+aaaabbaaaa
+aaaabbaaaa
+aaabaabaaa
+aabaaaabaa
+abaaaaaaba
+baaaaaaaab
+"}
+
+(1, 1, 3) = {"
+aaaabbaaaa
+aaabaabaaa
+aabaaaabaa
+abaaaaaaba
+baaaaaaaab
+baaaaaaaab
+abaaaaaaba
+aabaaaabaa
+aaabaabaaa
+aaaabbaaaa
+"}

--- a/Content.IntegrationTests/GameStartsTest.cs
+++ b/Content.IntegrationTests/GameStartsTest.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Robust.Server.Player;
+using Robust.Shared.IoC;
+using Robust.Shared.Network;
+
+namespace Content.IntegrationTests {
+    [TestFixture]
+    public class GameStartsTest : ContentIntegrationTest {
+        /// <summary>
+        ///     A simple test that starts a server and client and makes sure they connected successfully.
+        /// </summary>
+        /// <remarks>RobustToolbox has its own integration test for this. This is an example test, delete it sometime.</remarks>
+        [Test]
+        public async Task ServerClientConnectionTest() {
+            var (client, server) = await StartConnectedServerClientPair();
+
+            await client.WaitAssertion(() => {
+                Assert.That(IoCManager.Resolve<IClientNetManager>().IsConnected);
+            });
+
+            await server.WaitAssertion(() => {
+                Assert.That(IoCManager.Resolve<IPlayerManager>().PlayerCount, Is.EqualTo(1));
+            });
+        }
+    }
+}

--- a/Content.IntegrationTests/SetupCompileDM.cs
+++ b/Content.IntegrationTests/SetupCompileDM.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+// This it outside of any namespace so it affects the whole assembly.
+[SetUpFixture]
+// ReSharper disable once CheckNamespace
+public class SetupCompileDm {
+    public const string TestProject = "DMProject";
+    public const string Environment = "environment.dme";
+
+    public static readonly string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+    public static readonly string DmEnvironment = Path.Join(BaseDirectory, TestProject, Environment);
+    public static readonly string CompiledProject = Path.ChangeExtension(DmEnvironment, "json");
+
+    [OneTimeSetUp]
+    public void Compile() {
+        // TODO: Make this more sane.
+        DMCompiler.Program.Main(new []{ DmEnvironment });
+
+        if (!File.Exists(CompiledProject)) {
+            Console.WriteLine("Failed to compile DM test project!");
+            System.Environment.Exit(1);
+        }
+    }
+
+    [OneTimeTearDown]
+    public void Cleanup() {
+        if (!File.Exists(CompiledProject))
+            return;
+
+        File.Delete(CompiledProject);
+    }
+}

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -12,11 +12,11 @@ using Content.Shared.Compiler.DMPreprocessor;
 using Content.Shared.Json;
 
 namespace DMCompiler {
-    class Program {
+    public static class Program {
         //This is ugly
         public static List<CompilerError> VisitorErrors = new();
 
-        static void Main(string[] args) {
+        public static void Main(string[] args) {
             if (!VerifyArguments(args)) return;
 
             DMPreprocessor preprocessor = Preprocess(args);
@@ -107,7 +107,7 @@ namespace DMCompiler {
 
         private static List<DreamMapJson> ConvertMaps(List<string> mapPaths) {
             List<DreamMapJson> maps = new();
-            
+
             foreach (string mapPath in mapPaths) {
                 DMPreprocessor preprocessor = new DMPreprocessor(false);
                 preprocessor.IncludeFile(String.Empty, mapPath);


### PR DESCRIPTION
The DMProject will be compiled once before any tests are ran, and used by default in all tests. When all tests have been run, the compiled file is deleted as part of cleanup. Specific tests can override the CVar to point to a different json file, but they will probably need to compile it themselves. Also, this PR doesn't include a workflow to run tests in CI yet.

As a side effect, clients don't connect to a server on EntryPoint by default anymore, just so integration tests using clients can work. However, you can pass `--connect --connect-address 127.0.0.1:25566` (replace address if needed) as program arguments to the client to auto-connect to the server. Your IDE has an option for this, 100 %.

This adds a simple example test where a server and client pair are started and connected to each other, then checks if it succeeded. This test can probably be removed once more tests are added.