### PR TITLE
Adds DM_VERSION and DM_BUILD

### DIFF
--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -67,3 +67,7 @@
 #define MOB_PERSPECTIVE 0
 #define EYE_PERSPECTIVE 1
 #define EDGE_PERSPECTIVE 2
+
+//These are used for the world.byond_version, client.byond_version, etc. vars too
+#define DM_VERSION 513
+#define DM_BUILD 1561

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -15,6 +15,9 @@
 	var/pixel_z = 0
 	var/pixel_w = 0
 
+	var/byond_version = DM_VERSION
+	var/byond_build = DM_BUILD
+
 	var/address
 	var/inactivity = 0
 	var/key
@@ -56,7 +59,7 @@
 
 	proc/Northeast()
 		Move(get_step(mob, NORTHEAST), NORTHEAST)
-	
+
 	proc/Southeast()
 		Move(get_step(mob, SOUTHEAST), SOUTHEAST)
 

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -22,12 +22,15 @@
 	var/icon_size = 32
 	var/view = 5
 
+	var/byond_version = DM_VERSION
+	var/byond_build = DM_BUILD
+
 	var/address
 	var/port
 	var/url
 	var/status
 	var/list/params = null
-	
+
 	var/system_type
 
 	proc/New()
@@ -35,6 +38,6 @@
 
 	proc/Reboot()
 		CRASH("/world.Reboot() is not implemented")
-		
+
 	proc/Repop()
 		CRASH("/world.Repop() will not be implemented")


### PR DESCRIPTION
These should be deprecated once there's codebases actually targeting OpenDream, but until then this is needed for any modern SS13 code.