### PR TITLE
[Robust] Add localhost congroup controller

### DIFF
--- a/Content.Server/DMISpriteComponent.cs
+++ b/Content.Server/DMISpriteComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 using Robust.Shared.Players;
 using Robust.Shared.Utility;
+using Robust.Shared.ViewVariables;
 
 namespace Content.Server {
     [RegisterComponent]
@@ -18,6 +19,7 @@ namespace Content.Server {
         private Color _color = Color.White;
         private float _layer = 0.0f;
 
+        [ViewVariables]
         public ResourcePath Icon {
             get => _icon;
             set {
@@ -26,6 +28,7 @@ namespace Content.Server {
             }
         }
 
+        [ViewVariables(VVAccess.ReadWrite)]
         public string IconState {
             get => _iconState;
             set {
@@ -34,6 +37,7 @@ namespace Content.Server {
             }
         }
 
+        [ViewVariables]
         public AtomDirection Direction {
             get => _direction;
             set {
@@ -42,6 +46,7 @@ namespace Content.Server {
             }
         }
 
+        [ViewVariables(VVAccess.ReadWrite)]
         public Vector2i PixelOffset {
             get => _pixelOffset;
             set {
@@ -50,6 +55,7 @@ namespace Content.Server {
             }
         }
 
+        [ViewVariables(VVAccess.ReadWrite)]
         public Color Color {
             get => _color;
             set {
@@ -58,6 +64,7 @@ namespace Content.Server {
             }
         }
 
+        [ViewVariables(VVAccess.ReadWrite)]
         public float Layer {
             get => _layer;
             set {

--- a/Content.Server/LocalHostConGroup.cs
+++ b/Content.Server/LocalHostConGroup.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using Robust.Server.Console;
+using Robust.Server.Player;
+using Robust.Shared.IoC;
+
+namespace Content.Server {
+    #if DEBUG
+    /// <summary>
+    ///     Debug ConGroup controller implementation that gives any client connected through localhost every permission.
+    /// </summary>
+    public class LocalHostConGroup : IConGroupControllerImplementation, IPostInjectInit {
+        public bool CanCommand(IPlayerSession session, string cmdName) {
+            return IsLocal(session);
+        }
+
+        public bool CanViewVar(IPlayerSession session) {
+            return IsLocal(session);
+        }
+
+        public bool CanAdminPlace(IPlayerSession session) {
+            return IsLocal(session);
+        }
+
+        public bool CanScript(IPlayerSession session) {
+            return IsLocal(session);
+        }
+
+        public bool CanAdminMenu(IPlayerSession session) {
+            return IsLocal(session);
+        }
+
+        public bool CanAdminReloadPrototypes(IPlayerSession session) {
+            return IsLocal(session);
+        }
+
+        private static bool IsLocal(IPlayerSession player) {
+            var ep = player.ConnectedClient.RemoteEndPoint;
+            var addr = ep.Address;
+            if (addr.IsIPv4MappedToIPv6) {
+                addr = addr.MapToIPv4();
+            }
+
+            return Equals(addr, IPAddress.Loopback) || Equals(addr, IPAddress.IPv6Loopback);
+        }
+
+        void IPostInjectInit.PostInject() {
+            IoCManager.Resolve<IConGroupController>().Implementation = this;
+        }
+    }
+    #endif
+}

--- a/Content.Server/ServerContentIoC.cs
+++ b/Content.Server/ServerContentIoC.cs
@@ -7,6 +7,10 @@ namespace Content.Server {
             IoCManager.Register<IDreamManager, DreamManager>();
             IoCManager.Register<IAtomManager, AtomManager>();
             IoCManager.Register<IDreamMapManager, DreamMapManager>();
+
+            #if DEBUG
+            IoCManager.Register<LocalHostConGroup>();
+            #endif
         }
     }
 }


### PR DESCRIPTION
This allows clients connected through localhost to have all admin permissions when the server is compiled in DEBUG, therefore allowing you to access server-side ViewVariables and SCSI (once #321 is merged) when testing the server & client locally.
Ideally, in the future a more advanced system can be implemented that allows hosts to give some accounts certain permissions.
Also adds VV attributes to a few DMISpriteComponent properties.