### PR TITLE
Whitespace removal

### DIFF
--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -105,7 +105,7 @@ namespace DMCompiler {
         }
 
         private static bool Compile(List<Token> preprocessedTokens) {
-            DMLexer dmLexer = new DMLexer(null, preprocessedTokens);
+            DMLexer dmLexer = new TokenWhitespaceFilter(null, preprocessedTokens);
             DMParser dmParser = new DMParser(dmLexer);
             DMASTFile astFile = dmParser.File();
 

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -1,15 +1,46 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Text;
+using System.Collections.Generic;
 
 namespace OpenDreamShared.Compiler {
     public struct CompilerError {
         public Token Token;
         public string Message;
+        public StackTrace StackTrace;
+
+        private static List<string> _ignoredMethods = new() { ".ctor", "Check", "Advance", "Consume", "Error", "Warning"};
 
         public CompilerError(Token token, string message) {
             Token = token;
             Message = message;
+            StackTrace = new StackTrace(true);
         }
 
+        public string FilteredStackTrace() {
+            StringBuilder sb = new();
+            int expression_count = 0;
+            foreach (var frame in StackTrace.GetFrames()) {
+                var mname = frame.GetMethod().Name;
+                if (_ignoredMethods.Contains(mname)) {
+                    continue;
+                }
+                if (mname.Contains("Expression")) {
+                    if (mname == "Expression") {
+                        expression_count = 0;
+                    }
+                    else if (expression_count > 2) {
+                        continue;
+                    }
+                    else {
+                        expression_count += 1;
+                    }
+                } 
+
+                Console.Write(frame.GetMethod().Name + ":" + frame.GetFileLineNumber() + " ");
+            }
+            return sb.ToString();
+        }
         public override string ToString() {
             string location;
 

--- a/OpenDreamShared/Compiler/DM/DMASTHelper.cs
+++ b/OpenDreamShared/Compiler/DM/DMASTHelper.cs
@@ -6,8 +6,6 @@ using System.Reflection;
 using System.Text;
 
 namespace OpenDreamShared.Compiler.DM {
-
-
     public static partial class DMAST {
         private static List<Type> printable_field_types = new() { typeof(string), typeof(Dream.DreamPath), typeof(int), typeof(float) };
         internal static StringBuilder PrintNode(DMASTNode n, int depth, int max_depth = -1) {

--- a/OpenDreamShared/Compiler/DM/DMASTHelper.cs
+++ b/OpenDreamShared/Compiler/DM/DMASTHelper.cs
@@ -1,0 +1,87 @@
+﻿
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace OpenDreamShared.Compiler.DM {
+
+
+    public static partial class DMAST {
+        private static List<Type> printable_field_types = new() { typeof(string), typeof(Dream.DreamPath), typeof(int), typeof(float) };
+        internal static StringBuilder PrintNode(DMASTNode n, int depth, int max_depth = -1) {
+            StringBuilder sb = new();
+            if (max_depth == 0) {
+                return sb;
+            }
+            var pad = new String(' ', 2 * depth);
+            if (n == null) {
+                sb.Append("null");
+                return sb;
+            }
+            sb.Append(pad + n.GetType().Name + ": ");
+            var new_max_depth = max_depth - 1;
+            foreach (var field in n.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance)) {
+                if (printable_field_types.Contains(field.FieldType)) {
+                    sb.Append(field.Name + "=" + field.GetValue(n) + " ");
+                }
+            }
+            sb.Append('\n');
+            foreach (var leaf in n.LeafNodes()) {
+                sb.Append(PrintNode(leaf, depth + 1, new_max_depth));
+            }
+            return sb;
+        }
+        public static string PrintNodes(this DMASTNode n, int depth = 0, int max_depth = -1) {
+            return PrintNode(n, depth, max_depth).ToString();
+        }
+
+        public delegate void CompareResult(DMASTNode n_l, DMASTNode n_r, string s);
+
+        public static bool Compare(DMASTNode node_l, DMASTNode node_r, CompareResult cr) {
+            if (node_l == null || node_r == null) {
+                if (node_r == node_l) { return true; }
+                cr(node_l, node_r, "null mismatch");
+                return false;
+            }
+
+            if (node_l.GetType() != node_r.GetType()) { cr(node_l, node_r, "type mismatch"); return false; }
+
+            List<object> compared = new();
+            DMASTNode[] subnodes_l = node_l.LeafNodes().ToArray();
+            DMASTNode[] subnodes_r = node_r.LeafNodes().ToArray();
+
+            if (subnodes_l.Length != subnodes_r.Length) { cr(node_l, node_r, "nodes length mismatch " + subnodes_l.Length + " " + subnodes_r.Length); return false; }
+
+            for (var i = 0; i < subnodes_l.Length; i++) {
+                Compare(subnodes_l[i], subnodes_r[i], cr);
+                compared.Add(subnodes_l);
+            }
+
+            foreach (var field in node_l.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance)) {
+                if (compared.Contains(field.GetValue(node_l))) {
+                    continue;
+                }
+                //TODO non-node type field checking goes here
+            }
+
+            return true;
+        }
+        public static IEnumerable<DMASTNode> LeafNodes(this DMASTNode node) {
+            foreach (var field in node.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic)) {
+                var value = field.GetValue(node);
+                if (value == null) { continue; }
+                if (field.FieldType.IsAssignableTo(typeof(DMASTNode))) {
+                    yield return value as DMASTNode;
+                }
+                else if (field.FieldType.IsArray && field.FieldType.GetElementType().IsAssignableTo(typeof(DMASTNode))) {
+                    var field_value = value as DMASTNode[];
+                    foreach (var subnode in field_value) {
+                        yield return subnode;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OpenDreamShared/Compiler/DM/DMLexer.cs
+++ b/OpenDreamShared/Compiler/DM/DMLexer.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Text;
 
 namespace OpenDreamShared.Compiler.DM {
-    public class DMLexer : TokenLexer {
+    public partial class DMLexer : TokenLexer {
         public static List<string> ValidEscapeSequences = new() {
             "t", "n",
             "[", "]",

--- a/OpenDreamShared/Compiler/DM/DMLexer.cs
+++ b/OpenDreamShared/Compiler/DM/DMLexer.cs
@@ -488,6 +488,10 @@ namespace OpenDreamShared.Compiler.DM {
             return current;
         }
 
+        public int CurrentIndentation() {
+            return _indentationStack.Peek();
+        }
+
         private int CheckIndentation() {
             int indentationLevel = 0;
 

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -34,8 +34,6 @@ namespace OpenDreamShared.Compiler.DM {
             List<DMASTStatement> statements = new();
             bool valid_state = true;
             do {
-                Whitespace();
-
                 _topLevelTokens.Clear();
                 Errors = new();
 
@@ -90,12 +88,9 @@ namespace OpenDreamShared.Compiler.DM {
                 List<DMASTStatement> statements = new() { statement };
 
                 while (Delimiter()) {
-                    Whitespace();
                     statement = Statement();
 
                     if (statement != null) {
-                        Whitespace();
-
                         statements.Add(statement);
                     }
                 }
@@ -114,18 +109,13 @@ namespace OpenDreamShared.Compiler.DM {
                 DreamPath oldPath = _currentPath;
                 DMASTStatement statement;
 
-                Whitespace();
-
                 _currentPath = _currentPath.Combine(path.Path);
                 //Console.WriteLine(_currentPath);
 
                 //Proc definition
                 if (Check(TokenType.DM_LeftParenthesis)) {
-                    Whitespace();
                     DMASTDefinitionParameter[] parameters = DefinitionParameters();
-                    Whitespace();
                     Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                    Whitespace();
 
                     DMASTProcBlockInner procBlock = ProcBlock();
                     if (procBlock == null) {
@@ -150,11 +140,8 @@ namespace OpenDreamShared.Compiler.DM {
                             List<DMASTObjectVarDefinition> varDefinitions = new();
 
                             while (true) {
-                                Whitespace();
-
                                 DMASTExpression value;
                                 if (Check(TokenType.DM_Equals)) {
-                                    Whitespace();
                                     value = Expression();
                                     if (value == null) Error("Expected an expression");
                                 } else {
@@ -165,7 +152,6 @@ namespace OpenDreamShared.Compiler.DM {
 
                                 varDefinitions.Add(new DMASTObjectVarDefinition(varPath, value));
                                 if (Check(TokenType.DM_Comma)) {
-                                    Whitespace();
                                     DMASTPath newVarPath = Path();
                                     if (newVarPath == null) Error("Expected a var definition");
                                     if (newVarPath.Path.Elements.Length > 1) Error("Invalid var name"); //TODO: This is valid DM
@@ -184,7 +170,6 @@ namespace OpenDreamShared.Compiler.DM {
                         } else {
                             //Var override
                             if (Check(TokenType.DM_Equals)) {
-                                Whitespace();
                                 DMASTExpression value = Expression();
                                 if (value == null) Error("Expected an expression");
 
@@ -359,7 +344,6 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTBlockInner BracedBlock() {
             if (Check(TokenType.DM_LeftCurlyBracket)) {
-                Whitespace();
                 Newline();
                 bool isIndented = Check(TokenType.DM_Indent);
                 DMASTBlockInner blockInner = BlockInner();
@@ -403,7 +387,6 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcBlockInner BracedProcBlock() {
             if (Check(TokenType.DM_LeftCurlyBracket)) {
-                Whitespace();
                 Newline();
                 bool isIndented = Check(TokenType.DM_Indent);
                 DMASTProcBlockInner procBlock = ProcBlockInner();
@@ -432,14 +415,9 @@ namespace OpenDreamShared.Compiler.DM {
 
             if (procStatement != null) {
                 List<DMASTProcStatement> procStatements = new List<DMASTProcStatement>() { procStatement };
-
                 while (procStatement is DMASTProcStatementLabel || Delimiter()) {
-                    Whitespace();
                     procStatement = ProcStatement();
-
                     if (procStatement != null) {
-                        Whitespace();
-
                         procStatements.Add(procStatement);
                     }
                 }
@@ -503,12 +481,6 @@ namespace OpenDreamShared.Compiler.DM {
                 if (procStatement == null) procStatement = DoWhile();
                 if (procStatement == null) procStatement = Switch();
 
-                if (procStatement != null)
-                {
-                    Whitespace();
-                }
-
-
                 return procStatement;
             }
         }
@@ -520,15 +492,12 @@ namespace OpenDreamShared.Compiler.DM {
             if (Check(TokenType.DM_Var)) {
                 if (wasSlash) Error("Unsupported root variable declaration");
 
-
-                Whitespace();
                 DMASTPath varPath = Path();
                 if (varPath == null) Error("Expected a variable name");
 
                 List<DMASTProcStatementVarDeclaration> varDeclarations = new();
                 while (true) {
                     DMASTExpression value = null;
-                    Whitespace();
 
                     //TODO: Multidimensional lists
                     if (Check(TokenType.DM_LeftBracket)) {
@@ -537,10 +506,8 @@ namespace OpenDreamShared.Compiler.DM {
                             varPath = new DMASTPath(DreamPath.List.Combine(varPath.Path));
                         }
 
-                        Whitespace();
                         DMASTExpression size = Expression();
                         Consume(TokenType.DM_RightBracket, "Expected ']'");
-                        Whitespace();
 
                         if (size is not null) {
                             value = new DMASTNewPath(new DMASTPath(DreamPath.List),
@@ -551,7 +518,6 @@ namespace OpenDreamShared.Compiler.DM {
                     if (Check(TokenType.DM_Equals)) {
                         if (value != null) Error("List doubly initialized");
 
-                        Whitespace();
                         value = Expression();
                         if (value == null) Error("Expected an expression");
                     }
@@ -560,7 +526,6 @@ namespace OpenDreamShared.Compiler.DM {
 
                     varDeclarations.Add(new DMASTProcStatementVarDeclaration(varPath, value ?? new DMASTConstantNull()));
                     if (allowMultiple && Check(TokenType.DM_Comma)) {
-                        Whitespace();
                         varPath = Path();
                         if (varPath == null) Error("Expected a var declaration");
                     } else {
@@ -582,7 +547,6 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementReturn Return() {
             if (Check(TokenType.DM_Return)) {
-                Whitespace();
                 DMASTExpression value = Expression();
 
                 return new DMASTProcStatementReturn(value);
@@ -609,7 +573,6 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementGoto Goto() {
             if (Check(TokenType.DM_Goto)) {
-                Whitespace();
                 DMASTIdentifier label = Identifier();
 
                 return new DMASTProcStatementGoto(label);
@@ -620,9 +583,7 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementDel Del() {
             if (Check(TokenType.DM_Del)) {
-                Whitespace();
                 bool hasParenthesis = Check(TokenType.DM_LeftParenthesis);
-                Whitespace();
                 DMASTExpression value = Expression();
                 if (value == null) Error("Expected value to delete");
                 if (hasParenthesis) Consume(TokenType.DM_RightParenthesis, "Expected ')'");
@@ -635,13 +596,10 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementSet Set() {
             if (Check(TokenType.DM_Set)) {
-                Whitespace();
                 Token attributeToken = Current();
 
                 if (Check(TokenType.DM_Identifier)) {
-                    Whitespace();
                     Consume(new TokenType[] { TokenType.DM_Equals, TokenType.DM_In }, "Expected '=' or 'in'");
-                    Whitespace();
                     DMASTExpression value = Expression();
                     if (value == null) Error("Expected an expression");
 
@@ -656,9 +614,7 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementSpawn Spawn() {
             if (Check(TokenType.DM_Spawn)) {
-                Whitespace();
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
-                Whitespace();
 
                 DMASTExpression delay;
                 if (Check(TokenType.DM_RightParenthesis)) {
@@ -671,7 +627,6 @@ namespace OpenDreamShared.Compiler.DM {
                     Consume(TokenType.DM_RightParenthesis, "Expected ')'");
                 }
 
-                Whitespace();
                 Newline();
 
                 DMASTProcBlockInner body = ProcBlock();
@@ -690,15 +645,11 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementIf If() {
             if (Check(TokenType.DM_If)) {
-                Whitespace();
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
-                Whitespace();
                 DMASTExpression condition = Expression();
                 if (condition == null) Error("Expected a condition");
                 Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                Whitespace();
                 Check(TokenType.DM_Colon);
-                Whitespace();
 
                 DMASTProcStatement procStatement = ProcStatement();
                 DMASTProcBlockInner body;
@@ -715,9 +666,7 @@ namespace OpenDreamShared.Compiler.DM {
                 bool newLineAfterIf = Newline();
                 if (newLineAfterIf) Whitespace();
                 if (Check(TokenType.DM_Else)) {
-                    Whitespace();
                     Check(TokenType.DM_Colon);
-                    Whitespace();
                     procStatement = ProcStatement();
 
                     if (procStatement != null) {
@@ -739,9 +688,7 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatement For() {
             if (Check(TokenType.DM_For)) {
-                Whitespace();
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
-                Whitespace();
                 DMASTProcStatement initializer = null;
                 DMASTIdentifier variable;
 
@@ -753,9 +700,7 @@ namespace OpenDreamShared.Compiler.DM {
                     variable = Identifier();
                     if (variable == null) Error("Expected an identifier");
 
-                    Whitespace();
                     if (Check(TokenType.DM_Equals)) {
-                        Whitespace();
                         DMASTExpression value = Expression();
                         if (value == null) Error("Expected an expression");
 
@@ -763,32 +708,24 @@ namespace OpenDreamShared.Compiler.DM {
                     }
                 }
 
-                Whitespace();
                 AsTypes(); //TODO: Correctly handle
-                Whitespace();
 
                 if (Check(TokenType.DM_In)) {
-                    Whitespace();
                     DMASTExpression enumerateValue = Expression();
                     DMASTExpression toValue = null;
                     DMASTExpression step = new DMASTConstantInteger(1);
 
                     if (Check(TokenType.DM_To)) {
-                        Whitespace();
-
                         toValue = Expression();
                         if (toValue == null) Error("Expected an end to the range");
 
                         if (Check(TokenType.DM_Step)) {
-                            Whitespace();
-
                             step = Expression();
                             if (step == null) Error("Expected a step value");
                         }
                     }
 
                     Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                    Whitespace();
                     Newline();
 
                     DMASTProcBlockInner body = ProcBlock();
@@ -805,13 +742,10 @@ namespace OpenDreamShared.Compiler.DM {
                         return new DMASTProcStatementForRange(initializer, variable, enumerateValue, toValue, step, body);
                     }
                 } else if (Check(new TokenType[] { TokenType.DM_Comma, TokenType.DM_Semicolon })) {
-                    Whitespace();
                     DMASTExpression comparator = Expression();
                     Consume(new TokenType[] { TokenType.DM_Comma, TokenType.DM_Semicolon }, "Expected ','");
-                    Whitespace();
                     DMASTExpression incrementor = Expression();
                     Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                    Whitespace();
                     Newline();
 
                     DMASTProcBlockInner body = ProcBlock();
@@ -825,22 +759,17 @@ namespace OpenDreamShared.Compiler.DM {
                     return new DMASTProcStatementForStandard(initializer, comparator, incrementor, body);
                 } else if (variableDeclaration != null) {
                     DMASTExpression rangeBegin = variableDeclaration.Value;
-                    Whitespace();
                     Consume(TokenType.DM_To, "Expected 'to'");
-                    Whitespace();
                     DMASTExpression rangeEnd = Expression();
                     if (rangeEnd == null) Error("Expected an expression");
                     DMASTExpression step = new DMASTConstantInteger(1);
 
                     if (Check(TokenType.DM_Step)) {
-                        Whitespace();
-
                         step = Expression();
                         if (step == null) Error("Expected a step value");
                     }
 
                     Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                    Whitespace();
                     Newline();
 
                     DMASTProcBlockInner body = ProcBlock();
@@ -862,13 +791,10 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementWhile While() {
             if (Check(TokenType.DM_While)) {
-                Whitespace();
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
-                Whitespace();
                 DMASTExpression conditional = Expression();
                 if (conditional == null) Error("Expected conditional");
                 Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                Whitespace();
                 DMASTProcBlockInner body = ProcBlock();
 
                 if (body == null) {
@@ -886,7 +812,6 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementDoWhile DoWhile() {
             if (Check(TokenType.DM_Do)) {
-                Whitespace();
                 DMASTProcBlockInner body = ProcBlock();
 
                 if (body == null) {
@@ -897,15 +822,11 @@ namespace OpenDreamShared.Compiler.DM {
                 }
 
                 Newline();
-                Whitespace();
                 Consume(TokenType.DM_While, "Expected 'while'");
-                Whitespace();
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
-                Whitespace();
                 DMASTExpression conditional = Expression();
                 if (conditional == null) Error("Expected conditional");
                 Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                Whitespace();
 
                 return new DMASTProcStatementDoWhile(conditional, body);
             }
@@ -915,12 +836,9 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTProcStatementSwitch Switch() {
             if (Check(TokenType.DM_Switch)) {
-                Whitespace();
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
-                Whitespace();
                 DMASTExpression value = Expression();
                 Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                Whitespace();
                 DMASTProcStatementSwitch.SwitchCase[] switchCases = SwitchCases();
 
                 if (switchCases == null) Error("Expected switch cases");
@@ -978,15 +896,12 @@ namespace OpenDreamShared.Compiler.DM {
             if (Check(TokenType.DM_If)) {
                 List<DMASTExpression> expressions = new();
 
-                Whitespace();
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
                 do {
-                    Whitespace();
                     DMASTExpression expression = Expression();
                     if (expression == null) Error("Expected an expression");
 
                     if (Check(TokenType.DM_To)) {
-                        Whitespace();
                         DMASTExpression rangeEnd = Expression();
                         if (rangeEnd == null) Error("Expected an upper limit");
 
@@ -996,7 +911,6 @@ namespace OpenDreamShared.Compiler.DM {
                     }
                 } while (Check(TokenType.DM_Comma));
                 Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                Whitespace();
                 DMASTProcBlockInner body = ProcBlock();
 
                 if (body == null) {
@@ -1011,7 +925,6 @@ namespace OpenDreamShared.Compiler.DM {
 
                 return new DMASTProcStatementSwitch.SwitchCaseValues(expressions.ToArray(), body);
             } else if (Check(TokenType.DM_Else)) {
-                Whitespace();
                 DMASTProcBlockInner body = ProcBlock();
 
                 if (body == null) {
@@ -1032,10 +945,8 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTCallParameter[] ProcCall(bool includeEmptyParameters = true) {
             if (Check(TokenType.DM_LeftParenthesis)) {
-                Whitespace();
                 DMASTCallParameter[] callParameters = CallParameters(includeEmptyParameters);
                 if (callParameters == null) callParameters = new DMASTCallParameter[0];
-                Whitespace();
                 Consume(TokenType.DM_RightParenthesis, "Expected ')'");
 
                 return callParameters;
@@ -1052,7 +963,6 @@ namespace OpenDreamShared.Compiler.DM {
                 parameters.Add(parameter);
 
                 if (Check(TokenType.DM_Comma)) {
-                    Whitespace();
                     parameter = CallParameter();
 
                     if (parameter == null) {
@@ -1099,8 +1009,6 @@ namespace OpenDreamShared.Compiler.DM {
                 if (parameter != null) parameters.Add(parameter);
 
                 while (Check(TokenType.DM_Comma)) {
-                    Whitespace();
-
                     parameter = DefinitionParameter();
                     if (parameter != null) {
                         parameters.Add(parameter);
@@ -1117,12 +1025,9 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTPath path = Path();
 
             if (path != null) {
-                Whitespace();
                 if (Check(TokenType.DM_LeftBracket)) {
-                    Whitespace();
                     DMASTExpression expression = Expression();
                     if (expression != null && expression is not DMASTExpressionConstant) Error("Expected a constant expression");
-                    Whitespace();
                     Consume(TokenType.DM_RightBracket, "Expected ']'");
                 }
 
@@ -1131,15 +1036,12 @@ namespace OpenDreamShared.Compiler.DM {
                 DMASTExpression possibleValues = null;
 
                 if (Check(TokenType.DM_Equals)) {
-                    Whitespace();
                     value = Expression();
                 }
 
                 type = AsTypes();
-                Whitespace();
 
                 if (Check(TokenType.DM_In)) {
-                    Whitespace();
                     possibleValues = Expression();
                 }
 
@@ -1173,7 +1075,6 @@ namespace OpenDreamShared.Compiler.DM {
                 };
 
                 if (Check(assignTypes)) {
-                    Whitespace();
                     DMASTExpression value = ExpressionAssign();
 
                     if (value != null) {
@@ -1203,11 +1104,9 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression a = ExpressionOr();
 
             if (a != null && Check(TokenType.DM_Question)) {
-                Whitespace();
                 DMASTExpression b = ExpressionTernary();
                 if (b == null) Error("Expected an expression");
                 Consume(TokenType.DM_Colon, "Expected ':'");
-                Whitespace();
                 DMASTExpression c = ExpressionTernary();
                 if (c == null) Error("Expected an expression");
 
@@ -1221,7 +1120,6 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression a = ExpressionAnd();
 
             if (a != null && Check(TokenType.DM_BarBar)) {
-                Whitespace();
                 DMASTExpression b = ExpressionOr();
                 if (b == null) Error("Expected a second value");
 
@@ -1235,7 +1133,6 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression a = ExpressionBinaryOr();
 
             if (a != null && Check(TokenType.DM_AndAnd)) {
-                Whitespace();
                 DMASTExpression b = ExpressionAnd();
                 if (b == null) Error("Expected a second value");
 
@@ -1249,7 +1146,6 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression a = ExpressionBinaryXor();
 
             if (a != null && Check(TokenType.DM_Bar)) {
-                Whitespace();
                 DMASTExpression b = ExpressionBinaryOr();
                 if (b == null) Error("Expected an expression");
 
@@ -1263,7 +1159,6 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression a = ExpressionBinaryAnd();
 
             if (a != null && Check(TokenType.DM_Xor)) {
-                Whitespace();
                 DMASTExpression b = ExpressionBinaryXor();
                 if (b == null) Error("Expected an expression");
 
@@ -1277,7 +1172,6 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression a = ExpressionComparison();
 
             if (a != null && Check(TokenType.DM_And)) {
-                Whitespace();
                 DMASTExpression b = ExpressionBinaryAnd();
 
                 if (b == null) Error("Expected an expression");
@@ -1293,7 +1187,6 @@ namespace OpenDreamShared.Compiler.DM {
             if (expression != null) {
                 Token token = Current();
                 if (Check(new TokenType[] { TokenType.DM_EqualsEquals, TokenType.DM_ExclamationEquals })) {
-                    Whitespace();
                     DMASTExpression b = ExpressionComparison();
 
                     if (b == null) Error("Expected an expression to compare to");
@@ -1312,13 +1205,11 @@ namespace OpenDreamShared.Compiler.DM {
 
             if (a != null) {
                 if (Check(TokenType.DM_LeftShift)) {
-                    Whitespace();
                     DMASTExpression b = ExpressionBitShift();
                     if (b == null) Error("Expected an expression");
 
                     return new DMASTLeftShift(a, b);
                 } else if (Check(TokenType.DM_RightShift)) {
-                    Whitespace();
                     DMASTExpression b = ExpressionBitShift();
                     if (b == null) Error("Expected an expression");
 
@@ -1342,7 +1233,6 @@ namespace OpenDreamShared.Compiler.DM {
                 };
 
                 if (Check(types)) {
-                    Whitespace();
                     DMASTExpression b = ExpressionComparisonLtGt();
                     if (b == null) Error("Expected an expression");
 
@@ -1369,7 +1259,6 @@ namespace OpenDreamShared.Compiler.DM {
                 };
 
                 while (Check(types)) {
-                    Whitespace();
                     DMASTExpression b = ExpressionMultiplicationDivisionModulus();
                     if (b == null) Error("Expected an expression");
 
@@ -1397,7 +1286,6 @@ namespace OpenDreamShared.Compiler.DM {
                 };
 
                 while (Check(types)) {
-                    Whitespace();
                     DMASTExpression b = ExpressionPower();
                     if (b == null) Error("Expected an expression");
 
@@ -1418,7 +1306,6 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression a = ExpressionIn();
 
             if (a != null && Check(TokenType.DM_StarStar)) {
-                Whitespace();
                 DMASTExpression b = ExpressionPower();
                 if (b == null) Error("Expected an expression");
 
@@ -1432,7 +1319,6 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression value = ExpressionUnary();
 
             if (value != null && Check(TokenType.DM_In)) {
-                Whitespace();
                 DMASTExpression list = ExpressionIn();
 
                 return new DMASTExpressionIn(value, list);
@@ -1443,25 +1329,21 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTExpression ExpressionUnary() {
             if (Check(TokenType.DM_Exclamation)) {
-                Whitespace();
                 DMASTExpression expression = ExpressionUnary();
                 if (expression == null) Error("Expected an expression");
 
                 return new DMASTNot(expression);
             } else if (Check(TokenType.DM_Tilde)) {
-                Whitespace();
                 DMASTExpression expression = ExpressionUnary();
                 if (expression == null) Error("Expected an expression");
 
                 return new DMASTBinaryNot(expression);
             } else if (Check(TokenType.DM_PlusPlus)) {
-                Whitespace();
                 DMASTExpression expression = ExpressionSign();
                 if (expression == null) Error("Expected an expression");
 
                 return new DMASTPreIncrement(expression);
             } else if (Check(TokenType.DM_MinusMinus)) {
-                Whitespace();
                 DMASTExpression expression = ExpressionSign();
                 if (expression == null) Error("Expected an expression");
 
@@ -1471,10 +1353,8 @@ namespace OpenDreamShared.Compiler.DM {
 
                 if (expression != null) {
                     if (Check(TokenType.DM_PlusPlus)) {
-                        Whitespace();
                         expression = new DMASTPostIncrement(expression);
                     } else if (Check(TokenType.DM_MinusMinus)) {
-                        Whitespace();
                         expression = new DMASTPostDecrement(expression);
                     }
                 }
@@ -1487,7 +1367,6 @@ namespace OpenDreamShared.Compiler.DM {
             Token token = Current();
 
             if (Check(new TokenType[] { TokenType.DM_Plus, TokenType.DM_Minus })) {
-                Whitespace();
                 DMASTExpression expression = ExpressionListIndex();
 
                 if (expression == null) Error("Expected an expression");
@@ -1515,10 +1394,8 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTExpression expression = ExpressionNew();
 
             while (Check(TokenType.DM_LeftBracket)) {
-                Whitespace();
                 DMASTExpression index = Expression();
                 Consume(TokenType.DM_RightBracket, "Expected ']'");
-                Whitespace();
 
                 expression = new DMASTListIndex(expression, index);
             }
@@ -1528,18 +1405,14 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTExpression ExpressionNew() {
             if (Check(TokenType.DM_New)) {
-                Whitespace();
                 DMASTDereference dereference = Dereference();
                 DMASTIdentifier identifier = (dereference == null) ? Identifier() : null;
                 DMASTPath path = (dereference == null && identifier == null ) ? Path(true) : null;
-                Whitespace();
                 DMASTCallParameter[] parameters = null;
 
                 if (Check(TokenType.DM_LeftParenthesis)) {
-                    Whitespace();
                     parameters = CallParameters(true);
                     Consume(TokenType.DM_RightParenthesis, "Expected ')'");
-                    Whitespace();
                 }
 
                 if (dereference != null) {
@@ -1558,10 +1431,8 @@ namespace OpenDreamShared.Compiler.DM {
 
         public DMASTExpression ExpressionPrimary() {
             if (Check(TokenType.DM_LeftParenthesis)) {
-                Whitespace();
                 DMASTExpression inner = Expression();
                 Consume(TokenType.DM_RightParenthesis, "Expected ')");
-                Whitespace();
 
                 return inner;
             } else {
@@ -1587,19 +1458,14 @@ namespace OpenDreamShared.Compiler.DM {
                     DMASTIdentifier identifier = (dereference == null) ? Identifier() : null;
 
                     if (dereference != null || identifier != null) {
-                        Whitespace();
                         DMASTCallParameter[] callParameters = ProcCall();
 
                         if (callParameters != null) {
-                            Whitespace();
-
                             if (identifier?.Identifier == "input") {
                                 DMValueType types = AsTypes(defaultType: DMValueType.Text);
-                                Whitespace();
                                 DMASTExpression list = null;
 
                                 if (Check(TokenType.DM_In)) {
-                                    Whitespace();
                                     list = Expression();
                                 }
 
@@ -1656,8 +1522,6 @@ namespace OpenDreamShared.Compiler.DM {
                                 } else {
                                     DMASTExpression container = null;
                                     if (Check(TokenType.DM_In)) {
-                                        Whitespace();
-
                                         container = Expression();
                                         if (container == null) Error("Expected a container for locate()");
                                     }
@@ -1693,7 +1557,6 @@ namespace OpenDreamShared.Compiler.DM {
                     DMASTCallable callable = Callable();
 
                     if (callable != null) {
-                        Whitespace();
                         DMASTCallParameter[] callParameters = ProcCall();
 
                         if (callParameters != null) {
@@ -1705,10 +1568,8 @@ namespace OpenDreamShared.Compiler.DM {
                 }
 
                 if (primary == null && Check(TokenType.DM_Call)) {
-                    Whitespace();
                     DMASTCallParameter[] callParameters = ProcCall();
                     if (callParameters == null || callParameters.Length < 1 || callParameters.Length > 2) Error("Call must have 2 parameters");
-                    Whitespace();
                     DMASTCallParameter[] procParameters = ProcCall();
                     if (procParameters == null) Error("Expected proc parameters");
 
@@ -1716,20 +1577,17 @@ namespace OpenDreamShared.Compiler.DM {
                 }
 
                 if (primary == null && Check(TokenType.DM_List)) {
-                    Whitespace();
                     DMASTCallParameter[] values = ProcCall(false);
 
                     primary = new DMASTList(values);
                 }
 
                 if (primary == null && Check(TokenType.DM_NewList)) {
-                    Whitespace();
                     DMASTCallParameter[] values = ProcCall(false);
 
                     primary = new DMASTNewList(values);
                 }
 
-                if (primary != null) Whitespace();
                 return primary;
             }
         }
@@ -1780,7 +1638,7 @@ namespace OpenDreamShared.Compiler.DM {
                                         preprocTokens.Add(preprocToken);
                                     } while (preprocToken.Type != TokenType.EndOfFile);
 
-                                    DMLexer expressionLexer = new DMLexer(constantToken.SourceFile, preprocTokens);
+                                    DMLexer expressionLexer = new TokenWhitespaceFilter(constantToken.SourceFile, preprocTokens);
                                     DMParser expressionParser = new DMParser(expressionLexer);
 
                                     expressionParser.Whitespace(true);
@@ -1871,10 +1729,8 @@ namespace OpenDreamShared.Compiler.DM {
             DMValueType type = DMValueType.Anything;
 
             if (Check(TokenType.DM_As)) {
-                Whitespace();
                 bool parenthetical = Check(TokenType.DM_LeftParenthesis);
                 bool closed = false;
-                Whitespace();
 
                 do {
                     Token typeToken = Current();
@@ -1903,7 +1759,6 @@ namespace OpenDreamShared.Compiler.DM {
                 } while (Check(TokenType.DM_Bar));
 
                 if (parenthetical && !closed) {
-                    Whitespace();
                     Consume(TokenType.DM_RightParenthesis, "Expected closing parenthesis");
                 }
             }

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -15,6 +15,7 @@ namespace OpenDreamShared.Compiler.DM {
         private int innerLevel = 0;
         private int topLevelErrors = 0;
         private int topLevelDefines = 0;
+
         public DMParser(DMLexer lexer) : base(lexer) { }
 
         public DMASTFile File() {
@@ -22,7 +23,10 @@ namespace OpenDreamShared.Compiler.DM {
             DMASTBlockInner blockInner = BlockInner();
             Newline();
             Consume(TokenType.EndOfFile, "Expected EOF");
-            Console.WriteLine("Errors: " + topLevelErrors + " / " + topLevelDefines + " ? " + blockInner.Statements.Length);
+            Console.WriteLine(new String('=', 80));
+            Console.WriteLine("Toplevel statements: " + blockInner.Statements.Length);
+            Console.WriteLine("Errors: " + topLevelErrors + " out of " + topLevelDefines + " toplevel attempts.");
+            Console.WriteLine(new String('=', 80));
 
             return new DMASTFile(blockInner);
         }
@@ -43,28 +47,7 @@ namespace OpenDreamShared.Compiler.DM {
                     RestorePosition();
                     Advance();
                     LocateNextToplevel();
-                    Console.WriteLine("----------------------");
-                    List<string> sources = new();
-                    List<int> lines = new();
-                    foreach (var error in Errors) {
-                        Console.WriteLine(error.ToString());
-                        sources.Add(error.Token.SourceFile);
-                        lines.Add(error.Token.Line);
-                    }
-                    Console.Write(">>> ");
-                    foreach (var token in _topLevelTokens) {
-                        var idx = sources.IndexOf(token.SourceFile);
-                        if (idx > -1) {
-                            if (Math.Abs(lines[idx] - token.Line) < 3) {
-                                Console.Write(token.Text);
-                                if (token.Type == TokenType.Newline) { Console.Write(">>> "); }
-                            }
-                        }
-                    }
-                    Console.WriteLine();
-                    _topLevelTokens.Clear();
-                    topLevelErrors += 1;
-                    Errors = new();
+                    HandleBlockInnerErrors(Errors);
                 }
                 else if (localInnerLevel == 0) {
                     _topLevelTokens.Clear();

--- a/OpenDreamShared/Compiler/DM/DMParserHelper.cs
+++ b/OpenDreamShared/Compiler/DM/DMParserHelper.cs
@@ -85,9 +85,6 @@ namespace OpenDreamShared.Compiler.DM {
                 Console.WriteLine(new String('-', 40));
                 Console.WriteLine(viewedTokens.ToLongString(errortokens));
             }
-            _topLevelTokens.Clear();
-            topLevelErrors += 1;
-            Errors = new();
         }
     }
 }

--- a/OpenDreamShared/Compiler/DM/DMParserHelper.cs
+++ b/OpenDreamShared/Compiler/DM/DMParserHelper.cs
@@ -6,7 +6,15 @@ namespace OpenDreamShared.Compiler.DM {
     public partial class DMParser : Parser<Token> {
 
         private bool _saveForToplevel = true;
+
+        // reused tokens can find their way in here, need to filter out for exactness
         private Queue<Token> _topLevelTokens = new();
+
+
+        private bool IsDebugSource(string filename) {
+//          return filename.Contains("donk");
+            return true;
+        }
 
         protected override Token Advance() {
             Token t = base.Advance();
@@ -28,6 +36,58 @@ namespace OpenDreamShared.Compiler.DM {
                 }
                 Advance();
             }
+        }
+
+        protected void HandleBlockInnerErrors(List<CompilerError> errors) {
+            List<string> sources = new();
+            List<int> lines = new();
+            List<Token> errortokens = new();
+            foreach (var error in Errors) {
+                if (!IsDebugSource(error.Token.SourceFile)) {
+                    continue;
+                }
+                errortokens.Add(error.Token);
+            }
+            if (errortokens.Count > 0) {
+                Console.WriteLine(new String('=', 80));
+            }
+            foreach (var error in Errors) {
+                if (!IsDebugSource(error.Token.SourceFile)) {
+                    continue;
+                }
+                Console.WriteLine(error.ToString());
+                Console.WriteLine(error.FilteredStackTrace());
+                Console.WriteLine(new String('-', 40));
+                sources.Add(error.Token.SourceFile);
+                lines.Add(error.Token.Line);
+            }
+            List<Token> viewedTokens = new();
+            List<Token> textTokens = new();
+            foreach (var token in _topLevelTokens) {
+                if (!IsDebugSource(token.SourceFile)) {
+                    continue;
+                }
+                if (textTokens.Contains(token)) {
+                    continue;
+                }
+                var idx = sources.IndexOf(token.SourceFile);
+                if (idx > -1) {
+                    if (Math.Abs(lines[idx] - token.Line) < 3) {
+                        viewedTokens.Add(token);
+                    }
+                    if (Math.Abs(lines[idx] - token.Line) < 5) {
+                        Console.Write(token.Text);
+                        textTokens.Add(token);
+                    }
+                }
+            }
+            if (errortokens.Count > 0) {
+                Console.WriteLine(new String('-', 40));
+                Console.WriteLine(viewedTokens.ToLongString(errortokens));
+            }
+            _topLevelTokens.Clear();
+            topLevelErrors += 1;
+            Errors = new();
         }
     }
 }

--- a/OpenDreamShared/Compiler/DM/DMParserHelper.cs
+++ b/OpenDreamShared/Compiler/DM/DMParserHelper.cs
@@ -1,0 +1,33 @@
+﻿
+using System;
+using System.Collections.Generic;
+namespace OpenDreamShared.Compiler.DM {
+
+    public partial class DMParser : Parser<Token> {
+
+        private bool _saveForToplevel = true;
+        private Queue<Token> _topLevelTokens = new();
+
+        protected override Token Advance() {
+            Token t = base.Advance();
+
+            if (_saveForToplevel) { _topLevelTokens.Enqueue(t); }
+
+            return t;
+        }
+
+        protected bool PeekDelimiter() {
+            return Current().Type == TokenType.Newline || Current().Type == TokenType.DM_Semicolon;
+        }
+
+        protected void LocateNextToplevel() {
+            DMLexer lexer = _lexer as DMLexer;
+            while (!PeekDelimiter() || lexer.CurrentIndentation() != 0) {
+                if (lexer.AtEndOfSource) {
+                    break;
+                }
+                Advance();
+            }
+        }
+    }
+}

--- a/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/OpenDreamShared/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -83,14 +83,30 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
 
                         textBuilder.Append('@');
                         textBuilder.Append(delimiter);
-                        do {
-                            c = Advance();
 
-                            textBuilder.Append(c);
-                        } while (c != delimiter && c != '\n');
-                        Advance();
+                            /*
+                            do {
+                                c = Advance();
 
-                        string text = textBuilder.ToString();
+                                textBuilder.Append(c);
+                            } while (c != delimiter && c != '\n');
+                            Advance();
+                            */
+
+                            var everybody_gets_one = false;
+                            do {
+                                c = Advance();
+
+                                if (c == '\n' && !everybody_gets_one) {
+                                    everybody_gets_one = true;
+                                    c = '\0';
+                                    continue;
+                                }
+                                textBuilder.Append(c);
+                            } while (c != delimiter && !AtEndOfSource);
+                            Advance();
+
+                            string text = textBuilder.ToString();
                         token = CreateToken(TokenType.DM_Preproc_ConstantString, text, text.Substring(2, text.Length - 3));
                         break;
                     }
@@ -196,10 +212,10 @@ namespace OpenDreamShared.Compiler.DMPreprocessor {
                     base.Advance();
 
                     current = Advance();
-                    while (current == ' ' || current == '\t' || current == '\n')
-                    {
-                        current = Advance();
-                    }
+//                    while (current == ' ' || current == '\t' || current == '\n')
+//                    {
+//                        current = Advance();
+//                    }
                 }
             }
 

--- a/OpenDreamShared/Compiler/Lexer.cs
+++ b/OpenDreamShared/Compiler/Lexer.cs
@@ -23,7 +23,7 @@ namespace OpenDreamShared.Compiler {
             _sourceEnumerator = Source.GetEnumerator();
         }
 
-        public Token GetNextToken() {
+        public virtual Token GetNextToken() {
             if (_pendingTokenQueue.Count > 0)
                 return _pendingTokenQueue.Dequeue();
 

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -34,6 +34,10 @@ namespace OpenDreamShared.Compiler {
                 }
             }
 
+            if (_lookahead.Count > 0) {
+                _lookahead.Peek().Push(_currentToken);
+            }
+
             return Current();
         }
 

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 
 namespace OpenDreamShared.Compiler {
-    public class Parser<SourceType> {
+    public partial class Parser<SourceType> {
         public List<CompilerError> Errors = new();
         public List<CompilerWarning> Warnings = new();
 
-        private Lexer<SourceType> _lexer;
+        protected Lexer<SourceType> _lexer;
         private Token _currentToken;
         private Stack<Token> _tokenStack = new();
 

--- a/OpenDreamShared/Compiler/ParserHelper.cs
+++ b/OpenDreamShared/Compiler/ParserHelper.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace OpenDreamShared.Compiler {
+    public partial class Parser<SourceType> {
+
+        private Stack<Stack<Token>> _lookahead = new();
+
+        protected void SavePosition() {
+            _lookahead.Push(new Stack<Token>());
+            _lookahead.Peek().Push(_currentToken);
+        }
+        protected void RestorePosition() {
+            var stack = _lookahead.Pop();
+            while (stack.Count > 1) {
+                _tokenStack.Push(stack.Pop());
+            }
+            _currentToken = stack.Pop();
+        }
+        protected void AcceptPosition() {
+            foreach (var token in _lookahead.Pop()) {
+                if (_lookahead.Count > 0) {
+                    _lookahead.Peek().Push(token);
+                }
+            }
+        }
+        protected void Fatal(string error) {
+            foreach (var err in Errors) {
+                System.Console.WriteLine(err);
+            }
+            throw new System.Exception(error);
+        }
+
+    }
+}

--- a/OpenDreamShared/Compiler/Token.cs
+++ b/OpenDreamShared/Compiler/Token.cs
@@ -164,7 +164,7 @@
         DMF_Window
     }
 
-    public class Token {
+    public partial class Token {
         public TokenType Type;
         public string Text;
         public string SourceFile;

--- a/OpenDreamShared/Compiler/Token.cs
+++ b/OpenDreamShared/Compiler/Token.cs
@@ -170,6 +170,8 @@
         public string SourceFile;
         public int Line, Column;
         public object Value;
+        public bool LeadingWhitespace;
+        public bool TrailingWhitespace;
 
         public Token(TokenType type, string text, string sourceFile, int line, int column, object value) {
             Type = type;

--- a/OpenDreamShared/Compiler/TokenHelper.cs
+++ b/OpenDreamShared/Compiler/TokenHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 using static OpenDreamShared.Compiler.TokenType;
+using OpenDreamShared.Compiler.DM;
 
 namespace OpenDreamShared.Compiler {
 
@@ -35,7 +36,40 @@ namespace OpenDreamShared.Compiler {
             return sb.ToString();
         }
     }
+    public class TokenWhitespaceFilter : DMLexer {
+
+        private Token _lastToken;
+        private Token _currentToken;
+        private Token _nextToken;
+
+        public TokenWhitespaceFilter(string sourceName, List<Token> sourceTokens) : base(sourceName, sourceTokens) {
+            _nextToken = base.GetNextToken();
+        }
+
+        public override Token GetNextToken() {
+            do {
+                _lastToken = _currentToken;
+                _currentToken = _nextToken;
+                _nextToken = base.GetNextToken();
+            } while (_currentToken.Type == TokenType.DM_Whitespace);
+
+            if (_lastToken != null && _lastToken.Type == TokenType.DM_Whitespace) {
+                _currentToken.LeadingWhitespace = true;
+            }
+            if (_nextToken != null && _nextToken.Type == TokenType.DM_Whitespace) {
+                _currentToken.TrailingWhitespace = true;
+            }
+
+            if (_currentToken != null) {
+                //System.Console.WriteLine(_currentToken.LeadingWhitespace + " " + _currentToken.ToShortString() + " " +_currentToken.TrailingWhitespace);
+            }
+
+            return _currentToken;
+        }
+    }
+
     public partial class Token {
+
         public string ToShortString() {
             string inner = Text.Replace("\n", "\\n").Replace("\t", "\\t").Replace("\r", "\\r");
 

--- a/OpenDreamShared/Compiler/TokenHelper.cs
+++ b/OpenDreamShared/Compiler/TokenHelper.cs
@@ -1,0 +1,17 @@
+﻿namespace OpenDreamShared.Compiler {
+    public partial class Token {
+        public string ShortString() {
+            string prefix = "";
+            string inner = Text.Replace("\n", "\\n").Replace("\t", "\\t").Replace("\r", "\\r");
+            switch (Type) {
+                case TokenType.DM_Whitespace:
+                case TokenType.DM_Preproc_Whitespace:
+                case TokenType.DM_Preproc_Identifier:
+                case TokenType.DM_Identifier: break;
+                default: prefix = Type.ToString(); break;
+            }
+            return prefix + "(" + inner + ")";
+        }
+    }
+
+}

--- a/OpenDreamShared/Compiler/TokenHelper.cs
+++ b/OpenDreamShared/Compiler/TokenHelper.cs
@@ -1,17 +1,109 @@
-﻿namespace OpenDreamShared.Compiler {
-    public partial class Token {
-        public string ShortString() {
-            string prefix = "";
-            string inner = Text.Replace("\n", "\\n").Replace("\t", "\\t").Replace("\r", "\\r");
-            switch (Type) {
-                case TokenType.DM_Whitespace:
-                case TokenType.DM_Preproc_Whitespace:
-                case TokenType.DM_Preproc_Identifier:
-                case TokenType.DM_Identifier: break;
-                default: prefix = Type.ToString(); break;
+﻿using System.Collections.Generic;
+using System.Text;
+using static OpenDreamShared.Compiler.TokenType;
+
+namespace OpenDreamShared.Compiler {
+
+    public static partial class TokenStatic {
+        static public string ToLongString(this IEnumerable<Token> tokens, List<Token> highlight) {
+            int i = 0;
+            bool eol = false;
+            StringBuilder sb = new();
+            foreach (var token in tokens) {
+                if (i != 0 && i % 4 == 0) { eol = true; }
+                if (eol) {
+                    sb.Append('\n');
+                }
+                string tokentext = "";
+                if (highlight.Contains(token)) {
+                    if (!eol) {
+                        tokentext = "\n";
+                    }
+                    tokentext += "%%% " + token.ToShortString() + " %%%";
+                    i = 3; 
+                }
+                else {
+                    tokentext = token.ToShortString();
+                }
+                sb.Append(string.Format("{0,-30}", tokentext));
+                if (tokentext.Length > 30) {
+                    i = 3; 
+                }
+                if (eol) { eol = false; }
+                i += 1;
             }
-            return prefix + "(" + inner + ")";
+            return sb.ToString();
         }
+    }
+    public partial class Token {
+        public string ToShortString() {
+            string inner = Text.Replace("\n", "\\n").Replace("\t", "\\t").Replace("\r", "\\r");
+
+            if (!OperatorTokenTypes.Contains(Type)) {
+                string prefix = Type.ToString();
+                switch (Type) {
+                    case DM_Identifier:
+                    case DM_String:
+                    case DM_Whitespace: prefix = ""; break;
+                }
+                return prefix + "(" + inner + ")";
+            }
+            else {
+                return "'" + Text + "'";
+            }
+        }
+        public static HashSet<TokenType> OperatorTokenTypes = new() {
+            DM_And,
+            DM_AndAnd,
+            DM_AndEquals,
+            DM_Bar,
+            DM_BarBar,
+            DM_BarEquals,
+            DM_Colon,
+            DM_Comma,
+            DM_Equals,
+            DM_EqualsEquals,
+            DM_Exclamation,
+            DM_ExclamationEquals,
+            DM_GreaterThan,
+            DM_GreaterThanEquals,
+            DM_In,
+            DM_RightShift,
+            DM_RightShiftEquals,
+            DM_LeftBracket,
+            DM_LeftCurlyBracket,
+            DM_LeftParenthesis,
+            DM_LeftShift,
+            DM_LeftShiftEquals,
+            DM_LessThan,
+            DM_LessThanEquals,
+            DM_Minus,
+            DM_MinusEquals,
+            DM_MinusMinus,
+            DM_Modulus,
+            DM_ModulusEquals,
+            DM_Period,
+            DM_Plus,
+            DM_PlusEquals,
+            DM_PlusPlus,
+            DM_Question,
+            DM_QuestionColon,
+            DM_QuestionPeriod,
+            DM_RightBracket,
+            DM_RightCurlyBracket,
+            DM_RightParenthesis,
+            DM_Semicolon,
+            DM_Slash,
+            DM_SlashEquals,
+            DM_Star,
+            DM_StarEquals,
+            DM_StarStar,
+            DM_Tilde,
+            DM_TildeEquals,
+            DM_To,
+            DM_Xor,
+            DM_XorEquals
+        };
     }
 
 }


### PR DESCRIPTION
---- bee unfiltered
Toplevel statements: 50216
Errors: 625 out of 50841 toplevel attempts.
---- bee filtered with Whitespace()
Toplevel statements: 49950
Errors: 715 out of 50665 toplevel attempts.
---- bee filtered without Whitespace()
Toplevel statements: 49950
Errors: 715 out of 50665 toplevel attempts.
---- tg filtered with Whitespace()
Toplevel statements: 8903
Errors: 48 out of 8951 toplevel attempts.
---- tg filtered without Whitespace()
Toplevel statements: 8903
Errors: 48 out of 8951 toplevel attempts.

new error fixes can be localized to where whitespace matters, like paths/dereferences