### PR TITLE
Associative lists will no longer be allocated for non-associative lists

### DIFF
--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -162,10 +162,7 @@ namespace OpenDreamRuntime.Objects {
             DreamList newList = new DreamList(Runtime);
             newList._values = _values.Union(other.GetValues()).ToList();
             var otherVals = other.GetAssociativeValues();
-            if (newList._associativeValues is null)
-            {
-                newList._associativeValues = new Dictionary<DreamValue, DreamValue>(otherVals?.Count ?? 0);
-            }
+            newList._associativeValues ??= new Dictionary<DreamValue, DreamValue>(otherVals?.Count ?? 0);
 
             if (otherVals != null)
                 foreach ((DreamValue key, DreamValue value) in otherVals)

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -83,10 +83,7 @@ namespace OpenDreamRuntime.Objects {
             } else {
                 if (!ContainsValue(key)) _values.Add(key);
 
-                if (_associativeValues is null)
-                {
-                    _associativeValues = new Dictionary<DreamValue, DreamValue>(1);
-                }
+                _associativeValues ??= new Dictionary<DreamValue, DreamValue>(1);
                 _associativeValues[key] = value;
             }
         }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -51,8 +51,8 @@ namespace OpenDreamRuntime.Objects {
                 DreamValue value = _values[i - 1];
 
                 copy._values.Add(value);
-                if (_associativeValues is not null && _associativeValues.ContainsKey(value)) {
-                    copy._associativeValues.Add(value, _associativeValues[value]);
+                if (ContainsKey(value)) {
+                    copy.SetValue(value, _associativeValues[value]);
                 }
             }
 
@@ -64,7 +64,7 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public Dictionary<DreamValue, DreamValue> GetAssociativeValues() {
-            return _associativeValues;
+            return _associativeValues ??= new Dictionary<DreamValue, DreamValue>();
         }
 
         public virtual DreamValue GetValue(DreamValue key) {
@@ -107,6 +107,11 @@ namespace OpenDreamRuntime.Objects {
         //Does not include associations
         public bool ContainsValue(DreamValue value) {
             return _values.Contains(value);
+        }
+
+        public bool ContainsKey(DreamValue value)
+        {
+            return _associativeValues != null && _associativeValues.ContainsKey(value);
         }
 
         public int FindValue(DreamValue value, int start = 1, int end = 0) {
@@ -161,14 +166,9 @@ namespace OpenDreamRuntime.Objects {
         public DreamList Union(DreamList other) {
             DreamList newList = new DreamList(Runtime);
             newList._values = _values.Union(other.GetValues()).ToList();
-            var otherVals = other.GetAssociativeValues();
-            newList._associativeValues ??= new Dictionary<DreamValue, DreamValue>(otherVals?.Count ?? 0);
-
-            if (otherVals != null)
-                foreach ((DreamValue key, DreamValue value) in otherVals)
-                {
-                    newList._associativeValues[key] = value;
-                }
+            foreach ((DreamValue key, DreamValue value) in other.GetAssociativeValues()) {
+                newList.SetValue(key, value);
+            }
 
             return newList;
         }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -345,31 +345,18 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public static ProcStatus? PushArgumentList(DMProcState state) {
-            DreamProcArguments arguments = new DreamProcArguments(new List<DreamValue>(), new Dictionary<string, DreamValue>());
-            DreamValue argListValue = state.PopDreamValue();
+            DreamProcArguments arguments = new DreamProcArguments(new(), new());
+            DreamList argList = state.PopDreamValue().GetValueAsDreamList();
 
-            if (argListValue.Value != null) {
-                DreamList argList = argListValue.GetValueAsDreamList();
-                List<DreamValue> argListValues = argList.GetValues();
-                Dictionary<DreamValue, DreamValue> argListNamedValues = argList.GetAssociativeValues();
-
-                foreach (DreamValue value in argListValues) {
-                    if (argListNamedValues != null && !argListNamedValues.ContainsKey(value)) {
-                        arguments.OrderedArguments.Add(value);
+            foreach (DreamValue value in argList.GetValues()) {
+                if (argList.ContainsKey(value)) { //Named argument
+                    if (value.TryGetValueAsString(out string name)) {
+                        arguments.NamedArguments.Add(name, argList.GetValue(value));
+                    } else {
+                        throw new Exception("List contains a non-string key, and cannot be used as an arglist");
                     }
-                }
-
-                if (argListNamedValues != null)
-                {
-                    foreach (KeyValuePair<DreamValue, DreamValue> namedValue in argListNamedValues) {
-                        string name = namedValue.Key.Value as string;
-
-                        if (name != null) {
-                            arguments.NamedArguments.Add(name, namedValue.Value);
-                        } else {
-                            throw new Exception("List contains a non-string key, and cannot be used as an arglist");
-                        }
-                    }
+                } else { //Ordered argument
+                    arguments.OrderedArguments.Add(value);
                 }
             }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -354,18 +354,21 @@ namespace OpenDreamRuntime.Procs {
                 Dictionary<DreamValue, DreamValue> argListNamedValues = argList.GetAssociativeValues();
 
                 foreach (DreamValue value in argListValues) {
-                    if (!argListNamedValues.ContainsKey(value)) {
+                    if (argListNamedValues != null && !argListNamedValues.ContainsKey(value)) {
                         arguments.OrderedArguments.Add(value);
                     }
                 }
 
-                foreach (KeyValuePair<DreamValue, DreamValue> namedValue in argListNamedValues) {
-                    string name = namedValue.Key.Value as string;
+                if (argListNamedValues != null)
+                {
+                    foreach (KeyValuePair<DreamValue, DreamValue> namedValue in argListNamedValues) {
+                        string name = namedValue.Key.Value as string;
 
-                    if (name != null) {
-                        arguments.NamedArguments.Add(name, namedValue.Value);
-                    } else {
-                        throw new Exception("List contains a non-string key, and cannot be used as an arglist");
+                        if (name != null) {
+                            arguments.NamedArguments.Add(name, namedValue.Value);
+                        } else {
+                            throw new Exception("List contains a non-string key, and cannot be used as an arglist");
+                        }
                     }
                 }
             }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -347,16 +347,19 @@ namespace OpenDreamRuntime.Procs {
         public static ProcStatus? PushArgumentList(DMProcState state) {
             DreamProcArguments arguments = new DreamProcArguments(new(), new());
             DreamList argList = state.PopDreamValue().GetValueAsDreamList();
-
-            foreach (DreamValue value in argList.GetValues()) {
-                if (argList.ContainsKey(value)) { //Named argument
-                    if (value.TryGetValueAsString(out string name)) {
-                        arguments.NamedArguments.Add(name, argList.GetValue(value));
-                    } else {
-                        throw new Exception("List contains a non-string key, and cannot be used as an arglist");
+            
+            if (argList != null)
+            {
+                foreach (DreamValue value in argList.GetValues()) {
+                    if (argList.ContainsKey(value)) { //Named argument
+                        if (value.TryGetValueAsString(out string name)) {
+                            arguments.NamedArguments.Add(name, argList.GetValue(value));
+                        } else {
+                            throw new Exception("List contains a non-string key, and cannot be used as an arglist");
+                        }
+                    } else { //Ordered argument
+                        arguments.OrderedArguments.Add(value);
                     }
-                } else { //Ordered argument
-                    arguments.OrderedArguments.Add(value);
                 }
             }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -609,11 +609,10 @@ namespace OpenDreamRuntime.Procs.Native {
             } else if (value.TryGetValueAsDreamList(out DreamList list)) {
                 if (list.IsAssociative()) {
                     Dictionary<Object, Object> jsonObject = new(list.GetLength());
-                    Dictionary<DreamValue, DreamValue> assocValues = list.GetAssociativeValues();
 
                     foreach (DreamValue listValue in list.GetValues()) {
-                        if (assocValues is not null && assocValues.ContainsKey(listValue)) {
-                            jsonObject.Add(listValue.Stringify(), CreateJsonElementFromValue(assocValues[listValue]));
+                        if (list.ContainsKey(listValue)) {
+                            jsonObject.Add(listValue.Stringify(), CreateJsonElementFromValue(list.GetValue(listValue)));
                         } else {
                             jsonObject.Add(CreateJsonElementFromValue(listValue), null); // list[x] = null
                         }
@@ -686,11 +685,10 @@ namespace OpenDreamRuntime.Procs.Native {
             StringBuilder paramBuilder = new StringBuilder();
 
             List<DreamValue> values = list.GetValues();
-            Dictionary<DreamValue, DreamValue> associativeValues = list.GetAssociativeValues();
             foreach (DreamValue entry in values) {
-                if (associativeValues is not null && associativeValues.ContainsKey(entry))
+                if (list.ContainsKey(entry))
                 {
-                    paramBuilder.Append($"{HttpUtility.UrlEncode(entry.Value.ToString())}={HttpUtility.UrlEncode(associativeValues[entry].Value.ToString())}");
+                    paramBuilder.Append($"{HttpUtility.UrlEncode(entry.Value.ToString())}={HttpUtility.UrlEncode(list.GetValue(entry).Value.ToString())}");
                     paramBuilder.Append('&');
                 } else {
                     paramBuilder.Append(HttpUtility.UrlEncode(entry.Value.ToString()));

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -612,7 +612,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     Dictionary<DreamValue, DreamValue> assocValues = list.GetAssociativeValues();
 
                     foreach (DreamValue listValue in list.GetValues()) {
-                        if (assocValues.ContainsKey(listValue)) {
+                        if (assocValues is not null && assocValues.ContainsKey(listValue)) {
                             jsonObject.Add(listValue.Stringify(), CreateJsonElementFromValue(assocValues[listValue]));
                         } else {
                             jsonObject.Add(CreateJsonElementFromValue(listValue), null); // list[x] = null
@@ -688,7 +688,7 @@ namespace OpenDreamRuntime.Procs.Native {
             List<DreamValue> values = list.GetValues();
             Dictionary<DreamValue, DreamValue> associativeValues = list.GetAssociativeValues();
             foreach (DreamValue entry in values) {
-                if (associativeValues.ContainsKey(entry))
+                if (associativeValues is not null && associativeValues.ContainsKey(entry))
                 {
                     paramBuilder.Append($"{HttpUtility.UrlEncode(entry.Value.ToString())}={HttpUtility.UrlEncode(associativeValues[entry].Value.ToString())}");
                     paramBuilder.Append('&');


### PR DESCRIPTION
Fixes a part of https://github.com/wixoaGit/OpenDream/issues/342

I didn't profile the memory usage but it is presumably better. Also might have gone overboard with the null checking but w/e.