### PR TITLE
Implement IconStates through icon_states

### DIFF
--- a/DMCompiler/DMStandard/Types/Icon.dm
+++ b/DMCompiler/DMStandard/Types/Icon.dm
@@ -28,8 +28,7 @@
 		CRASH("/icon.Height() is not implemented")
 
 	proc/IconStates(mode = 0)
-		set opendream_unimplemented = TRUE
-		CRASH("/icon.IconStates() is not implemented")
+		return icon_states(src, mode)
 
 	proc/Insert(new_icon, icon_state, dir, frame, moving, delay)
 		set opendream_unimplemented = TRUE


### PR DESCRIPTION
http://www.byond.com/docs/ref/#/icon/proc/IconStates
"This returns a list of all icon state text strings that exist in the /icon object. This works in exactly the same way as icon_states(icon)."

Ticks off one of https://github.com/wixoaGit/OpenDream/issues/141