### PR TITLE
Made OpenDreamServer output UTF-8 to the console

### DIFF
--- a/OpenDreamServer/Program.cs
+++ b/OpenDreamServer/Program.cs
@@ -2,10 +2,12 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Text;
 
 namespace OpenDreamServer {
     class Program {
         static void Main(string[] args) {
+            Console.OutputEncoding = Encoding.UTF8;
             if (args.Length < 1 || Path.GetExtension(args[0]) != ".json") {
                 Console.WriteLine("You must compile your game using DMCompiler, and supply its output as an argument");
 


### PR DESCRIPTION
This makes it possible to display emojis in terminals that support them.
![image](https://user-images.githubusercontent.com/6307265/130906326-8b54c3f7-3b6c-4ea0-81a9-3c1ebc37db88.png)
