### PR TITLE
Implements most _char procs and findlastextEx()

### DIFF
--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -23,6 +23,7 @@ proc/file2text(File)
 proc/findtext(Haystack, Needle, Start = 1, End = 0)
 proc/findtextEx(Haystack, Needle, Start = 1, End = 0)
 proc/findlasttext(Haystack, Needle, Start = 1, End = 0)
+proc/findlasttextEx(Haystack, Needle, Start = 1, End = 0)
 proc/flick(Icon, Object)
 proc/flist(Path)
 proc/hascall(Object, ProcName)
@@ -269,8 +270,26 @@ proc/jointext(list/List, Glue, Start = 1, End = 0)
 
 	return List.Join(Glue, Start, End)
 
+proc/copytext_char(T,Start=1,End=0)
+	return copytext(T, Start, End)
+
+proc/length_char(E)
+	return length(E)
+
 proc/lentext(T)
 	return length(T)
+
+proc/text2ascii_char(T,pos=1)
+	return text2ascii(T,pos)
+
+proc/findtext_char(Haystack,Needle,Start=1,End=0)
+	return findtext(Haystack,Needle,Start,End)
+
+proc/findlasttext_char(Haystack,Needle,Start=0,End=1)
+	return findlasttext(Haystack,Needle,Start,End)
+
+proc/findlasttextEx_char(Haystack,Needle,Start=0,End=1)
+	return findlasttextEx(Haystack,Needle,Start,End)
 
 proc/isobj(Loc1)
 	for(var/arg in args)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -333,7 +333,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 end = text.Length + 1;
             }
 
-            int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
+            int needleIndex = text.IndexOf(needle, start - 1, end - start);
             if (needleIndex != -1) {
                 return new DreamValue(needleIndex + 1); //1-indexed
             } else {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -333,7 +333,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 end = text.Length + 1;
             }
 
-            int needleIndex = text.IndexOf(needle, start - 1, end - start);
+            int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
             if (needleIndex != -1) {
                 return new DreamValue(needleIndex + 1); //1-indexed
             } else {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -333,7 +333,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 end = text.Length + 1;
             }
 
-            int needleIndex = text.IndexOf(needle, start - 1, end - start);
+            int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
             if (needleIndex != -1) {
                 return new DreamValue(needleIndex + 1); //1-indexed
             } else {
@@ -349,6 +349,29 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_findlasttext(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             string text = arguments.GetArgument(0, "Haystack").GetValueAsString().ToLower();
             string needle = arguments.GetArgument(1, "Needle").GetValueAsString().ToLower();
+            int start = arguments.GetArgument(2, "Start").GetValueAsInteger(); //1-indexed
+            int end = arguments.GetArgument(3, "End").GetValueAsInteger(); //1-indexed
+
+            if (end == 0) {
+                end = text.Length + 1;
+            }
+
+            int needleIndex = text.LastIndexOf(needle, end - 1, end - start);
+            if (needleIndex != -1) {
+                return new DreamValue(needleIndex + 1); //1-indexed
+            } else {
+                return new DreamValue(0);
+            }
+        }
+
+        [DreamProc("findlasttextEx")]
+        [DreamProcParameter("Haystack", Type = DreamValueType.String)]
+        [DreamProcParameter("Needle", Type = DreamValueType.String)]
+        [DreamProcParameter("Start", Type = DreamValueType.Float, DefaultValue = 1)]
+        [DreamProcParameter("End", Type = DreamValueType.Float, DefaultValue = 0)]
+        public static DreamValue NativeProc_findlasttextEx(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
+            string text = arguments.GetArgument(0, "Haystack").GetValueAsString();
+            string needle = arguments.GetArgument(1, "Needle").GetValueAsString();
             int start = arguments.GetArgument(2, "Start").GetValueAsInteger(); //1-indexed
             int end = arguments.GetArgument(3, "End").GetValueAsInteger(); //1-indexed
 


### PR DESCRIPTION
Closes #353 
Closes #347
Closes #345
Closes #344
Closes #288
Closes #273
Closes #268 

Adds `_char()` procs for every already-implemented text proc, and implements `findlasttextEx()`

The unimplemented text procs are `splicetext()`, `spantext()`, and `nonspantext()`. Issues exist for all 3.