### PR TITLE
Adds placeholders for almost everything NTstation needs

### DIFF
--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -85,3 +85,9 @@
 #define BLEND_SUBTRACT 3
 #define BLEND_MULTIPLY 4
 #define BLEND_INSET_OVERLAY 5
+
+//sound.status
+SOUND_MUTE (1<<0)      // do not play the sound
+SOUND_PAUSED (1<<1)    // pause sound
+SOUND_STREAM (1<<2)    // create as a stream
+SOUND_UPDATE (1<<3)    // update a playing sound

--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -87,7 +87,7 @@
 #define BLEND_INSET_OVERLAY 5
 
 //sound.status
-SOUND_MUTE (1<<0)      // do not play the sound
-SOUND_PAUSED (1<<1)    // pause sound
-SOUND_STREAM (1<<2)    // create as a stream
-SOUND_UPDATE (1<<3)    // update a playing sound
+#define SOUND_MUTE (1<<0)      // do not play the sound
+#define SOUND_PAUSED (1<<1)    // pause sound
+#define SOUND_STREAM (1<<2)    // create as a stream
+#define SOUND_UPDATE (1<<3)    // update a playing sound

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -35,6 +35,8 @@
 	var/gender = "neuter"
 	var/density = FALSE
 
+	var/maptext //TODO
+
 	proc/Click(location, control, params)
 
 	proc/Entered(atom/movable/Obj, atom/OldLoc)

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -14,6 +14,7 @@
 	var/pixel_y = 0
 	var/pixel_z = 0
 	var/pixel_w = 0
+	var/show_popup_menus = 1 //TODO
 
 	var/byond_version = DM_VERSION
 	var/byond_build = DM_BUILD
@@ -23,6 +24,7 @@
 	var/key
 	var/ckey
 	var/connection
+	var/computer_id = 0 //TODO
 
 	var/timezone
 
@@ -71,3 +73,7 @@
 
 	proc/Center()
 		//TODO: walk(usr, 0)
+	
+	proc/IsByondMember()
+		set opendream_unimplemented = TRUE
+		return FALSE

--- a/DMCompiler/DMStandard/Types/Image.dm
+++ b/DMCompiler/DMStandard/Types/Image.dm
@@ -12,6 +12,10 @@
 	var/color = "#FFFFFF"
 	var/alpha = 255
 
+	var/blend_mode = 0
+	var/matrix/transform
+	var/override = 1 //TODO
+
 	New(icon, loc, icon_state, layer, dir)
 		src.icon = icon
 		if (!istext(loc))

--- a/DMCompiler/DMStandard/Types/Sound.dm
+++ b/DMCompiler/DMStandard/Types/Sound.dm
@@ -10,6 +10,9 @@
 	var/y
 	var/z
 
+	var/priority = 0 //TODO
+	var/status = 0 //TODO
+
 	proc/New(file, repeat=0, wait, channel, volume)
 		if (istype(file, /sound))
 			var/sound/copy_from = file

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -27,9 +27,12 @@
 
 	var/address
 	var/port
+	var/internet_address = "127.0.0.1" //TODO
 	var/url
 	var/status
 	var/list/params = null
+
+	var/sleep_offline = 0 //TODO
 
 	var/system_type
 

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -206,11 +206,11 @@ proc/get_dir(atom/Loc1, atom/Loc2)
 
 /proc/get_step_to(Ref, Trg, Min=0)
 	set opendream_unimplemented = TRUE
-    CRASH("/get_step_to() is not implemented")
+	CRASH("/get_step_to() is not implemented")
 
 /proc/walk_away(Ref,Trg,Max=5,Lag=0,Speed=0)
 	set opendream_unimplemented = TRUE
-    CRASH("/walk_away() is not implemented")
+	CRASH("/walk_away() is not implemented")
 
 /proc/turn(Dir, Angle)
 	var/dirAngle = 0

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -200,6 +200,18 @@ proc/get_dir(atom/Loc1, atom/Loc2)
 	var/step_dir = get_dir(Ref, Trg)
 	step(Ref, step_dir, Speed)
 
+/proc/walk_towards(Ref,Trg,Lag=0,Speed=0)
+	set opendream_unimplemented = TRUE
+	CRASH("/walk_towards() is not implemented")
+
+/proc/get_step_to(Ref, Trg, Min=0)
+	set opendream_unimplemented = TRUE
+    CRASH("/get_step_to() is not implemented")
+
+/proc/walk_away(Ref,Trg,Max=5,Lag=0,Speed=0)
+	set opendream_unimplemented = TRUE
+    CRASH("/walk_away() is not implemented")
+
 /proc/turn(Dir, Angle)
 	var/dirAngle = 0
 


### PR DESCRIPTION
Should be a sufficiently valid placeholder for everything except `locs`.

Not closing any issues because they still need, y'know, actual implementations at some point.