### PR TITLE
Adds italic, b, and bold as valid escape sequences

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMLexer.cs
+++ b/OpenDreamShared/Compiler/DM/DMLexer.cs
@@ -27,6 +27,7 @@ namespace OpenDreamShared.Compiler.DM {
             "ref",
             "improper", "proper",
             "red", "blue", "green", "black",
+            "b", "bold",
             "..."
             //TODO: ASCII/Unicode values
         };
@@ -95,7 +96,7 @@ namespace OpenDreamShared.Compiler.DM {
                                 _pendingTokenQueue.Enqueue(preprocToken);
                                 token = CreateToken(TokenType.Error, null, "Invalid indentation");
                             }
-                            
+
                             do {
                                 _indentationStack.Pop();
                                 _pendingTokenQueue.Enqueue(CreateToken(TokenType.DM_Dedent, '\r'));

--- a/OpenDreamShared/Compiler/DM/DMLexer.cs
+++ b/OpenDreamShared/Compiler/DM/DMLexer.cs
@@ -27,7 +27,7 @@ namespace OpenDreamShared.Compiler.DM {
             "ref",
             "improper", "proper",
             "red", "blue", "green", "black",
-            "b", "bold",
+            "b", "bold", "italic",
             "..."
             //TODO: ASCII/Unicode values
         };


### PR DESCRIPTION
Move NTstation from 220 to 186 errors with one easy trick.