### PR TITLE
Remove Check() parser array allocations.

### DIFF
--- a/OpenDreamClient/Interface/DreamInterface.cs
+++ b/OpenDreamClient/Interface/DreamInterface.cs
@@ -258,7 +258,7 @@ namespace OpenDreamClient.Interface {
                     string value = query.GetValues(attribute)[^1];
 
                     Token attributeValue = new DMFLexer(null, value).GetNextToken();
-                    if (DMFParser.ValidAttributeValueTypes.Contains(attributeValue.Type)) {
+                    if (Array.IndexOf(DMFParser.ValidAttributeValueTypes, attributeValue.Type) >= 0) {
                         element.SetAttribute(attribute, attributeValue.Value);
                     } else {
                         throw new Exception("Invalid attribute value (" + attributeValue.Text + ")");

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -1233,7 +1233,7 @@ namespace OpenDreamShared.Compiler.DM {
 
             if (expression != null) {
                 Token token = Current();
-                TokenType[] assignTypes = new TokenType[] {
+                ReadOnlySpan<TokenType> assignTypes = new TokenType[] {
                     TokenType.DM_Equals,
                     TokenType.DM_PlusEquals,
                     TokenType.DM_MinusEquals,
@@ -1411,7 +1411,7 @@ namespace OpenDreamShared.Compiler.DM {
 
             if (a != null) {
                 Token token = Current();
-                TokenType[] types = new TokenType[] {
+                ReadOnlySpan<TokenType> types = new TokenType[] {
                     TokenType.DM_LessThan,
                     TokenType.DM_LessThanEquals,
                     TokenType.DM_GreaterThan,
@@ -1440,7 +1440,7 @@ namespace OpenDreamShared.Compiler.DM {
 
             if (a != null) {
                 Token token = Current();
-                TokenType[] types = new TokenType[] {
+                ReadOnlySpan<TokenType> types = new TokenType[] {
                     TokenType.DM_Plus,
                     TokenType.DM_Minus,
                 };
@@ -1467,7 +1467,7 @@ namespace OpenDreamShared.Compiler.DM {
 
             if (a != null) {
                 Token token = Current();
-                TokenType[] types = new TokenType[] {
+                ReadOnlySpan<TokenType> types = new[] {
                     TokenType.DM_Star,
                     TokenType.DM_Slash,
                     TokenType.DM_Modulus

--- a/OpenDreamShared/Compiler/DMF/DMFParser.cs
+++ b/OpenDreamShared/Compiler/DMF/DMFParser.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace OpenDreamShared.Compiler.DMF {
     public class DMFParser : Parser<char> {
-        public static readonly List<TokenType> ValidAttributeValueTypes = new() {
+        public static readonly TokenType[] ValidAttributeValueTypes = {
             TokenType.DMF_None,
             TokenType.DMF_String,
             TokenType.DMF_Integer,

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace OpenDreamShared.Compiler {
     public partial class Parser<SourceType> {
@@ -56,7 +57,7 @@ namespace OpenDreamShared.Compiler {
             return false;
         }
 
-        protected bool Check(IEnumerable<TokenType> types) {
+        protected bool Check(ReadOnlySpan<TokenType> types) {
             TokenType currentType = Current().Type;
             foreach (TokenType type in types) {
                 if (currentType == type) {

--- a/OpenDreamShared/Compiler/Token.cs
+++ b/OpenDreamShared/Compiler/Token.cs
@@ -1,5 +1,6 @@
 ﻿namespace OpenDreamShared.Compiler {
-    public enum TokenType {
+    // Must be : byte for ReadOnlySpan<TokenType> x = new TokenType[] { } to be intrinsic'd by the compiler.
+    public enum TokenType : byte {
         //Base lexer
         Error,
         Warning,


### PR DESCRIPTION
This pattern (`ReadOnlySpan<T> x = new T[] { ... }`) is optimized by Roslyn to create a Span from assembly image memory instead of allocating, if T : byte. I tested and it works for enums too.

This saves ~700 MB of allocations parsing /vg/.