### PR TITLE
DM Error Handling

### DIFF
--- a/DMCompiler/DM/Visitors/DMASTSimplifier.cs
+++ b/DMCompiler/DM/Visitors/DMASTSimplifier.cs
@@ -166,6 +166,18 @@ namespace DMCompiler.DM.Visitors {
                 varDeclaration.Visit(this);
             }
         }
+
+        public void VisitProcStatementTryCatch(DMASTProcStatementTryCatch tryCatch) {
+            if (tryCatch.CatchParameters is not null)
+            {
+                foreach (DMASTDefinitionParameter parameter in tryCatch.CatchParameters) {
+                    SimplifyExpression(ref parameter.Value);
+                }
+            }
+
+            tryCatch.TryBody.Visit(this);
+            tryCatch.CatchBody.Visit(this);
+        }
         #endregion Procs
 
         private void SimplifyExpression(ref DMASTExpression expression) {
@@ -230,7 +242,7 @@ namespace DMCompiler.DM.Visitors {
                 switch (negate.Expression) {
                     case DMASTConstantInteger exprInteger: expression = new DMASTConstantInteger(-exprInteger.Value); break;
                     case DMASTConstantFloat exprFloat: expression = new DMASTConstantFloat(-exprFloat.Value); break;
-                } 
+                }
 
                 return;
             }

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -13,6 +13,7 @@ namespace OpenDreamShared.Compiler {
             Token = token;
             Message = message;
             StackTrace = new StackTrace(true);
+            throw new Exception(message);
         }
 
         public override string ToString() {

--- a/OpenDreamShared/Compiler/DM/DMAST.cs
+++ b/OpenDreamShared/Compiler/DM/DMAST.cs
@@ -34,6 +34,7 @@ namespace OpenDreamShared.Compiler.DM {
         public void VisitProcStatementBrowse(DMASTProcStatementBrowse statementBrowse) { throw new NotImplementedException(); }
         public void VisitProcStatementBrowseResource(DMASTProcStatementBrowseResource statementBrowseResource) { throw new NotImplementedException(); }
         public void VisitProcStatementOutputControl(DMASTProcStatementOutputControl statementOutputControl) { throw new NotImplementedException(); }
+        public void VisitProcStatementTryCatch(DMASTProcStatementTryCatch statementTryCatch) { throw new NotImplementedException(); }
         public void VisitProcDefinition(DMASTProcDefinition procDefinition) { throw new NotImplementedException(); }
         public void VisitIdentifier(DMASTIdentifier identifier) { throw new NotImplementedException(); }
         public void VisitConstantInteger(DMASTConstantInteger constant) { throw new NotImplementedException(); }
@@ -615,6 +616,22 @@ namespace OpenDreamShared.Compiler.DM {
 
         public void Visit(DMASTVisitor visitor) {
             visitor.VisitProcStatementOutputControl(this);
+        }
+    }
+
+    public class DMASTProcStatementTryCatch : DMASTProcStatement {
+        public DMASTProcBlockInner TryBody;
+        public DMASTProcBlockInner CatchBody;
+        public DMASTDefinitionParameter[] CatchParameters;
+        public DMASTProcStatementTryCatch(DMASTProcBlockInner tryBody, DMASTProcBlockInner catchBody, DMASTDefinitionParameter[] catchParameters)
+        {
+            TryBody = tryBody;
+            CatchBody = catchBody;
+            CatchParameters = catchParameters;
+        }
+
+        public void Visit(DMASTVisitor visitor) {
+            visitor.VisitProcStatementTryCatch(this);
         }
     }
 

--- a/OpenDreamShared/Compiler/DM/DMLexer.cs
+++ b/OpenDreamShared/Compiler/DM/DMLexer.cs
@@ -55,7 +55,9 @@ namespace OpenDreamShared.Compiler.DM {
             { "spawn", TokenType.DM_Spawn },
             { "newlist", TokenType.DM_NewList },
             { "goto", TokenType.DM_Goto },
-            { "step", TokenType.DM_Step }
+            { "step", TokenType.DM_Step },
+            { "try", TokenType.DM_Try },
+            { "catch", TokenType.DM_Catch }
         };
 
         public int BracketNesting = 0;

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -513,6 +513,7 @@ namespace OpenDreamShared.Compiler.DM {
                 if (procStatement == null) procStatement = While();
                 if (procStatement == null) procStatement = DoWhile();
                 if (procStatement == null) procStatement = Switch();
+                if (procStatement == null) procStatement = TryCatch();
 
                 if (procStatement != null) {
                     Whitespace();
@@ -1081,6 +1082,45 @@ namespace OpenDreamShared.Compiler.DM {
                 }
 
                 return new DMASTProcStatementSwitch.SwitchCaseDefault(body);
+            }
+
+            return null;
+        }
+
+        public DMASTProcStatementTryCatch TryCatch() {
+            if (Check(TokenType.DM_Try)) {
+                DMASTProcBlockInner tryBody = ProcBlock();
+                if (tryBody == null) {
+                    DMASTProcStatement statement = ProcStatement();
+
+                    if (statement == null) Error("Expected body or statement");
+                    tryBody = new DMASTProcBlockInner(new DMASTProcStatement[] { statement });
+                }
+
+                Newline();
+                Consume(TokenType.DM_Catch, "Expected catch");
+
+                // catch(var/exception/E)
+                // TODO: handle correctly
+                DMASTDefinitionParameter[] parameters = null;
+                if (Check(TokenType.DM_LeftParenthesis))
+                {
+                    BracketWhitespace();
+                    parameters = DefinitionParameters();
+                    BracketWhitespace();
+                    ConsumeRightParenthesis();
+                    Whitespace();
+                }
+
+                DMASTProcBlockInner catchBody = ProcBlock();
+                if (catchBody == null) {
+                    DMASTProcStatement statement = ProcStatement();
+
+                    //if (statement == null) Error("Expected body or statement");
+                    catchBody = new DMASTProcBlockInner(new DMASTProcStatement[] { statement });
+                }
+
+                return new DMASTProcStatementTryCatch(tryBody, catchBody, parameters);
             }
 
             return null;

--- a/OpenDreamShared/Compiler/Token.cs
+++ b/OpenDreamShared/Compiler/Token.cs
@@ -123,6 +123,8 @@
         DM_Whitespace,
         DM_Xor,
         DM_XorEquals,
+        DM_Try,
+        DM_Catch,
 
         //DMF
         DMF_Attribute,

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -15,6 +15,10 @@
 
 	verb/tell_location()
 		usr << "You are at ([x], [y], [z])"
+		try
+			usr << "oooooooooh he's trying"
+		catch
+			usr << "shit"
 
 	verb/say(message as text)
 		var/list/viewers = viewers()


### PR DESCRIPTION
This is `try`/`catch` support, basically.

TODO:

- [ ] Try/catch blocks compile
- [ ] Only the try block executes by default
- [ ] Add the `/datum/exception` type
- [ ] Properly handle `catch(var/exception/varname)` rather than using placeholder copypasted proc definition code
- [ ] If an exception is thrown in the try block, properly move to the catch block
- [ ] Implement support for `world/Error()` (future PR?)
- [ ] `EXCEPTION()` macro
- [ ] Implement `throw`