### PR TITLE
Fix newlines in project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 [*.{cs, xaml, csproj, dm, dme, dmm, dmf}]
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This removes the .editorconfig LF forcing, and properly configures git to do CRLF conversion always.
This fixes all the crap of opening a file causing it to be edited despite only EOLs changing.