### PR TITLE
parse variable declaration modifiers + add static vars

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -262,36 +262,23 @@ namespace DMCompiler.Compiler.DM {
     }
 
     public class DMASTObjectVarDefinition : DMASTStatement {
-        public DreamPath ObjectPath;
-        public DreamPath? Type;
-        public string Name;
+        public DreamPath ObjectPath { get => _varDecl.ObjectPath; }
+        public DreamPath? Type { get => _varDecl.TypePath; }
+        public string Name { get => _varDecl.VarName; }
         public DMASTExpression Value;
-        public bool IsTmp = false;
-        public bool IsConst = false;
-        public bool IsGlobal = false;
+
+        public ObjVarDeclInfo _varDecl;
+
+        public bool IsGlobal { get => _varDecl.IsGlobal; }
+        public bool IsConst { get => _varDecl.IsConst; }
+        public bool IsToplevel { get => _varDecl.IsToplevel; }
+        public bool IsTmp { get => _varDecl.IsTmp; }
+
         public DMValueType ValType;
 
-        public DMASTObjectVarDefinition(Location location, DreamPath path, DMASTExpression value, DMValueType valType = DMValueType.Anything) : base(location) {
-            int tmpElementIndex = path.FindElement("tmp");
-            int constElementIndex = path.FindElement("const");
-            int globalElementIndex = path.FindElement("global");
-            if (globalElementIndex == -1) globalElementIndex = path.FindElement("static");
-
-            if (tmpElementIndex != -1) path = path.RemoveElement(tmpElementIndex);
-            if (constElementIndex != -1) path = path.RemoveElement(constElementIndex);
-            if (globalElementIndex != -1) path = path.RemoveElement(globalElementIndex);
-
-            int varElementIndex = path.FindElement("var");
-            if (varElementIndex == -1) throw new Exception($"Var definition's path ({path}) did not contain a var element");
-
-            DreamPath varPath = path.FromElements(varElementIndex + 1, -1);
-
-            ObjectPath = path.FromElements(0, varElementIndex);
-            Type = (varPath.Elements.Length > 1) ? varPath.FromElements(0, -2) : null;
-            IsTmp = tmpElementIndex != -1;
-            IsConst = constElementIndex != -1;
-            IsGlobal = globalElementIndex != -1 || ObjectPath.Equals(DreamPath.Root);
-            Name = varPath.LastElement;
+        public DMASTObjectVarDefinition(Location location, DreamPath path, DMASTExpression value, DMValueType valType = DMValueType.Anything) : base(location)
+        {
+            _varDecl = new ObjVarDeclInfo(path);
             Value = value;
             ValType = valType;
         }
@@ -342,36 +329,17 @@ namespace DMCompiler.Compiler.DM {
     }
 
     public class DMASTProcStatementVarDeclaration : DMASTProcStatement {
-        public DreamPath? Type;
-        public string Name;
+        public DreamPath? Type { get => _varDecl.TypePath; }
+        public string Name { get => _varDecl.VarName; }
         public DMASTExpression Value;
-        //TODO proper support for these
-        public bool IsTmp = false;
-        public bool IsConst = false;
-        public bool IsGlobal = false;
+        private ProcVarDeclInfo _varDecl;
 
-        public DMASTProcStatementVarDeclaration(Location location, DMASTPath path, DMASTExpression value) : base(location) {
-            int tmpElementIndex = path.Path.FindElement("tmp");
-            int constElementIndex = path.Path.FindElement("const");
-            int globalElementIndex = path.Path.FindElement("global");
-            if (globalElementIndex == -1) globalElementIndex = path.Path.FindElement("static");
+        public bool IsGlobal { get => _varDecl.IsGlobal; }
+        public bool IsConst { get => _varDecl.IsConst; }
 
-            int startIdx = 1;
-            if (tmpElementIndex != -1) startIdx++;
-            if (constElementIndex != -1) startIdx++;
-            if (globalElementIndex != -1) startIdx++;
-
-            int varElementIndex = path.Path.FindElement("var");
-            DreamPath typePath = path.Path.FromElements(varElementIndex + startIdx, -2);
-
-            Type = (typePath.Elements.Length > 0) ? typePath : null;
-            IsTmp = tmpElementIndex != -1;
-            IsConst = constElementIndex != -1;
-            IsGlobal = globalElementIndex != -1;
-            if (!DMCompiler.Settings.SuppressUnimplementedWarnings && (IsTmp || IsConst || IsGlobal)) {
-                DMCompiler.Warning(new CompilerWarning(location, $"Var modifiers (static, const, tmp, global) are currently unimplemented and ignored"));
-            }
-            Name = path.Path.LastElement;
+        public DMASTProcStatementVarDeclaration(Location location, DMASTPath path, DMASTExpression value) : base(location)
+        {
+            _varDecl = new ProcVarDeclInfo(path.Path);
             Value = value;
         }
 

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -267,7 +267,7 @@ namespace DMCompiler.Compiler.DM {
         public string Name { get => _varDecl.VarName; }
         public DMASTExpression Value;
 
-        public ObjVarDeclInfo _varDecl;
+        private ObjVarDeclInfo _varDecl;
 
         public bool IsGlobal { get => _varDecl.IsGlobal; }
         public bool IsConst { get => _varDecl.IsConst; }

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -269,9 +269,10 @@ namespace DMCompiler.Compiler.DM {
 
         private ObjVarDeclInfo _varDecl;
 
-        public bool IsGlobal { get => _varDecl.IsGlobal; }
-        public bool IsConst { get => _varDecl.IsConst; }
+        public bool IsStatic { get => _varDecl.IsStatic; }
         public bool IsToplevel { get => _varDecl.IsToplevel; }
+        public bool IsGlobal { get => _varDecl.IsStatic || _varDecl.IsToplevel; }
+        public bool IsConst { get => _varDecl.IsConst; }
         public bool IsTmp { get => _varDecl.IsTmp; }
 
         public DMValueType ValType;
@@ -334,7 +335,7 @@ namespace DMCompiler.Compiler.DM {
         public DMASTExpression Value;
         private ProcVarDeclInfo _varDecl;
 
-        public bool IsGlobal { get => _varDecl.IsGlobal; }
+        public bool IsGlobal { get => _varDecl.IsStatic; }
         public bool IsConst { get => _varDecl.IsConst; }
 
         public DMASTProcStatementVarDeclaration(Location location, DMASTPath path, DMASTExpression value) : base(location)

--- a/DMCompiler/Compiler/DM/DMPath.cs
+++ b/DMCompiler/Compiler/DM/DMPath.cs
@@ -1,0 +1,112 @@
+﻿
+using System.Collections.Generic;
+using OpenDreamShared.Dream;
+
+namespace DMCompiler.Compiler.DM
+{
+
+    public class VarDeclInfo
+    {
+        public DreamPath? TypePath;
+        public string VarName;
+        public bool IsGlobal;
+        public bool IsConst;
+    }
+
+    public class ProcVarDeclInfo : VarDeclInfo
+    {
+        public ProcVarDeclInfo(DreamPath path)
+        {
+            string[] elements = path.Elements;
+            var readIdx = 0;
+            List<string> currentPath = new();
+            if (elements[readIdx] == "var")
+            {
+                readIdx++;
+            }
+            while (readIdx < elements.Length - 1)
+            {
+                var elem = elements[readIdx];
+                if (elem == "static" || elem == "global")
+                {
+                    IsGlobal = true;
+                }
+                else if (elem == "const")
+                {
+                    IsConst = true;
+                }
+                else
+                {
+                    currentPath.Add(elem);
+                }
+                readIdx += 1;
+            }
+            if (currentPath.Count > 0)
+            {
+                TypePath = new DreamPath(DreamPath.PathType.Absolute, currentPath.ToArray());
+            }
+            else
+            {
+                TypePath = null;
+            }
+            VarName = elements[elements.Length - 1];
+        }
+    }
+
+    public class ObjVarDeclInfo : VarDeclInfo
+    {
+        public DreamPath ObjectPath;
+        public bool IsTmp;
+        public bool IsToplevel;
+
+        public ObjVarDeclInfo(DreamPath path)
+        {
+            string[] elements = path.Elements;
+            var readIdx = 0;
+            List<string> currentPath = new();
+            while (readIdx < elements.Length && elements[readIdx] != "var")
+            {
+                currentPath.Add(elements[readIdx]);
+                readIdx += 1;
+            }
+            ObjectPath = new DreamPath(path.Type, currentPath.ToArray());
+            if (ObjectPath.Elements.Length == 0)
+            {
+                IsToplevel = true;
+            }
+            currentPath.Clear();
+            readIdx += 1;
+            while (readIdx < elements.Length - 1)
+            {
+                var elem = elements[readIdx];
+                if (elem == "static" || elem == "global")
+                {
+                    IsGlobal = true;
+                }
+                else if (elem == "const")
+                {
+                    IsConst = true;
+                }
+                else if (elem == "tmp")
+                {
+                    IsTmp = true;
+                }
+                else
+                {
+                    currentPath.Add(elem);
+                }
+                readIdx += 1;
+            }
+            if (currentPath.Count > 0)
+            {
+                TypePath = new DreamPath(DreamPath.PathType.Absolute, currentPath.ToArray());
+            }
+            else
+            {
+                TypePath = null;
+            }
+            VarName = elements[elements.Length - 1];
+        }
+
+    }
+}

--- a/DMCompiler/Compiler/DM/DMPath.cs
+++ b/DMCompiler/Compiler/DM/DMPath.cs
@@ -10,6 +10,7 @@ namespace DMCompiler.Compiler.DM
         public DreamPath? TypePath;
         public string VarName;
         public bool IsGlobal;
+        public bool IsStatic;
         public bool IsConst;
     }
 
@@ -29,7 +30,7 @@ namespace DMCompiler.Compiler.DM
                 var elem = elements[readIdx];
                 if (elem == "static" || elem == "global")
                 {
-                    IsGlobal = true;
+                    IsStatic = true;
                 }
                 else if (elem == "const")
                 {
@@ -81,7 +82,7 @@ namespace DMCompiler.Compiler.DM
                 var elem = elements[readIdx];
                 if (elem == "static" || elem == "global")
                 {
-                    IsGlobal = true;
+                    IsStatic = true;
                 }
                 else if (elem == "const")
                 {

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -32,8 +32,8 @@ namespace DMCompiler.DM {
             Location = location;
         }
 
-        public static DMExpression Create(DMObject dmObject, DMProc proc, DMASTExpression expression, DreamPath? inferredPath = null, string scopeMode = "normal") {
-            var instance = new DMVisitorExpression(dmObject, proc, inferredPath, scopeMode);
+        public static DMExpression Create(DMObject dmObject, DMProc proc, DMASTExpression expression, DreamPath? inferredPath = null) {
+            var instance = new DMVisitorExpression(dmObject, proc, inferredPath);
             expression.Visit(instance);
             return instance.Result;
         }

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -32,8 +32,8 @@ namespace DMCompiler.DM {
             Location = location;
         }
 
-        public static DMExpression Create(DMObject dmObject, DMProc proc, DMASTExpression expression, DreamPath? inferredPath = null) {
-            var instance = new DMVisitorExpression(dmObject, proc, inferredPath);
+        public static DMExpression Create(DMObject dmObject, DMProc proc, DMASTExpression expression, DreamPath? inferredPath = null, string scopeMode = "normal") {
+            var instance = new DMVisitorExpression(dmObject, proc, inferredPath, scopeMode);
             expression.Visit(instance);
             return instance.Result;
         }

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -38,6 +38,7 @@ namespace DMCompiler.DM {
         public bool Unimplemented { get; set; } = false;
         public Location Location = Location.Unknown;
         public string Name { get => _astDefinition.Name; }
+        public Dictionary<string, int> GlobalVariables = new();
 
         private DMASTProcDefinition _astDefinition = null;
         private BinaryWriter _bytecodeWriter = null;
@@ -91,6 +92,29 @@ namespace DMCompiler.DM {
 
         public void WaitFor(bool waitFor) {
             _waitFor = waitFor;
+        }
+
+        public DMVariable CreateGlobalVariable(DreamPath? type, string name)
+        {
+            int id = DMObjectTree.CreateGlobal(out DMVariable global, type, name);
+
+            GlobalVariables[name] = id;
+            return global;
+        }
+        public int? GetGlobalVariableId(string name)
+        {
+            if (GlobalVariables.TryGetValue(name, out int id))
+            {
+                return id;
+            }
+            return null;
+        }
+
+        public DMVariable GetGlobalVariable(string name)
+        {
+            int? id = GetGlobalVariableId(name);
+
+            return (id == null) ? null : DMObjectTree.Globals[id.Value];
         }
 
         public void AddParameter(string name, DMValueType type) {

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -3,6 +3,7 @@ using DMCompiler.Compiler.DM;
 using OpenDreamShared.Dream;
 using System;
 using OpenDreamShared.Dream.Procs;
+using System.Collections.Generic;
 
 namespace DMCompiler.DM.Visitors {
     class DMObjectBuilder {
@@ -67,7 +68,8 @@ namespace DMCompiler.DM.Visitors {
 
             _currentObject = DMObjectTree.GetDMObject(varDefinition.ObjectPath);
 
-            if (varDefinition.IsGlobal) {
+            if (varDefinition.IsGlobal || varDefinition.IsToplevel)
+            {
                 variable = _currentObject.CreateGlobalVariable(varDefinition.Type, varDefinition.Name);
             } else {
                 variable = new DMVariable(varDefinition.Type, varDefinition.Name, varDefinition.IsGlobal);
@@ -123,6 +125,27 @@ namespace DMCompiler.DM.Visitors {
                 DMProc proc = new DMProc(procDefinition);
 
                 dmObject.AddProc(procName, proc);
+                if (procDefinition.Body != null)
+                {
+                    foreach (var stmt in GetStatements(procDefinition.Body))
+                    {
+                        // TODO multiple var definitions.
+                        if (stmt is DMASTProcStatementVarDeclaration varDeclaration && varDeclaration.IsGlobal)
+                        {
+                            DMVariable variable = proc.CreateGlobalVariable(varDeclaration.Type, varDeclaration.Name);
+                            variable.Value = new Expressions.Null(varDeclaration.Location);
+
+                            Expressions.GlobalField field = new Expressions.GlobalField(varDeclaration.Location, variable.Type, proc.GetGlobalVariableId(varDeclaration.Name).Value);
+                            if (varDeclaration.Value != null)
+                            {
+                                DMExpression expression = DMExpression.Create(_currentObject, DMObjectTree.GlobalInitProc, varDeclaration.Value, varDeclaration.Type, scopeMode: "static");
+                                Expressions.Assignment assign = new Expressions.Assignment(varDeclaration.Location, field, expression);
+                                DMObjectTree.AddGlobalInitProcAssign(assign);
+                            }
+                        }
+                    }
+                }
+
                 if (procDefinition.IsVerb) {
                     Expressions.Field field = new Expressions.Field(Location.Unknown, DreamPath.List, "verbs");
                     DreamPath procPath = new DreamPath(".proc/" + procName);
@@ -132,6 +155,45 @@ namespace DMCompiler.DM.Visitors {
                 }
             } catch (CompileErrorException e) {
                 DMCompiler.Error(e.Error);
+            }
+        }
+
+        // TODO Move this to an appropriate location
+        static public IEnumerable<DMASTProcStatement> GetStatements(DMASTProcBlockInner block)
+        {
+            foreach (var stmt in block.Statements)
+            {
+                yield return stmt;
+                List<DMASTProcBlockInner> recurse;
+                switch (stmt)
+                {
+                    case DMASTProcStatementSpawn ps: recurse = new() { ps.Body }; break;
+                    case DMASTProcStatementIf ps: recurse = new() { ps.Body, ps.ElseBody }; break;
+                    case DMASTProcStatementFor ps: recurse = new() { ps.Body }; break;
+                    case DMASTProcStatementForLoop ps: recurse = new() { ps.Body }; break;
+                    case DMASTProcStatementWhile ps: recurse = new() { ps.Body }; break;
+                    case DMASTProcStatementDoWhile ps: recurse = new() { ps.Body }; break;
+                    // TODO Good luck if you declare a static var inside a switch
+                    case DMASTProcStatementSwitch ps:
+                        {
+                            recurse = new();
+                            foreach (var swcase in ps.Cases)
+                            {
+                                recurse.Add(swcase.Body);
+                            }
+                            break;
+                        }
+                    case DMASTProcStatementTryCatch ps: recurse = new() { ps.TryBody, ps.CatchBody }; break;
+                    default: recurse = new(); break;
+                }
+                foreach (var subblock in recurse)
+                {
+                    if (subblock == null) { continue; }
+                    foreach (var substmt in GetStatements(subblock))
+                    {
+                        yield return substmt;
+                    }
+                }
             }
         }
 

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -174,6 +174,8 @@ namespace DMCompiler.DM.Visitors {
         }
 
         public void ProcessStatementVarDeclaration(DMASTProcStatementVarDeclaration varDeclaration) {
+            if (varDeclaration.IsGlobal) { return; }
+
             if (!_proc.TryAddLocalVariable(varDeclaration.Name, varDeclaration.Type)) {
                 DMCompiler.Error(new CompilerError(varDeclaration.Location, $"Duplicate var {varDeclaration.Name}"));
                 return;

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -94,7 +94,7 @@ namespace DMCompiler.DM.Visitors {
                     return;
                 }
 
-                int? procGlobalId = _proc.GetGlobalVariableId(name);
+                int? procGlobalId = _proc?.GetGlobalVariableId(name);
                 if (procGlobalId != null)
                 {
                     Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[procGlobalId.Value].Type, procGlobalId.Value);

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -10,14 +10,14 @@ namespace DMCompiler.DM.Visitors {
         DreamPath? _inferredPath { get; }
         internal DMExpression Result { get; private set; }
 
-        private string _scopeMode;
+        // NOTE This needs to be turned into a Stack of modes if more complicated scope changes are added in the future
+        static public string _scopeMode;
 
-        internal DMVisitorExpression(DMObject dmObject, DMProc proc, DreamPath? inferredPath, string scopeMode = "normal")
+        internal DMVisitorExpression(DMObject dmObject, DMProc proc, DreamPath? inferredPath)
         {
             _dmObject = dmObject;
             _proc = proc;
             _inferredPath = inferredPath;
-            _scopeMode = scopeMode;
         }
 
         public void VisitProcStatementExpression(DMASTProcStatementExpression statement) {
@@ -81,23 +81,6 @@ namespace DMCompiler.DM.Visitors {
         public void VisitIdentifier(DMASTIdentifier identifier) {
             var name = identifier.Identifier;
 
-            if (_scopeMode == "static")
-            {
-                int? procGlobalId = _proc.GetGlobalVariableId(name);
-                if (procGlobalId != null)
-                {
-                    Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[procGlobalId.Value].Type, procGlobalId.Value);
-                    return;
-                }
-                int? globalId = _dmObject.GetGlobalVariableId(name);
-                if (globalId != null)
-                {
-                    Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[globalId.Value].Type, globalId.Value);
-                    return;
-                }
-                throw new CompileErrorException(new CompilerError(identifier.Location, $"unknown identifier {name}"));
-            }
-
             if (name == "src") {
                 Result = new Expressions.Src(identifier.Location, _dmObject.Path);
             } else if (name == "usr") {
@@ -106,8 +89,7 @@ namespace DMCompiler.DM.Visitors {
                 Result = new Expressions.Args(identifier.Location);
             } else {
                 DMProc.DMLocalVariable localVar = _proc?.GetLocalVariable(name);
-
-                if (localVar != null) {
+                if (localVar != null && _scopeMode == "normal") {
                     Result = new Expressions.Local(identifier.Location, localVar.Type, name);
                     return;
                 }
@@ -120,7 +102,7 @@ namespace DMCompiler.DM.Visitors {
                 }
 
                 var field = _dmObject?.GetVariable(name);
-                if (field != null) {
+                if (field != null && _scopeMode == "normal") {
                     Result = new Expressions.Field(identifier.Location, field.Type, name);
                     return;
                 }
@@ -163,6 +145,7 @@ namespace DMCompiler.DM.Visitors {
                     throw new CompileErrorException(new CompilerError(procIdentifier.Location, $"Global proc {procIdentifier.Identifier} does not exist"));
                 }
                 // TODO: substitute this to global.proc()
+                Result = new Expressions.Proc(procIdentifier.Location, procIdentifier.Identifier);
             }
             else
             {


### PR DESCRIPTION
test case:
```

#include "map.dmm"
#include "interface.dmf"

var/c = 999

/proc/init_static()
    return dynamic_value()

/proc/dynamic_value()
    static_proc()
    return --c

/proc/static_proc_shadowed()
    var/static/inner_c = 700
    return inner_c

/proc/static_proc()
    // Inner static definitions must be recursively located
    while (1)
        var/static/inner_c = init_static()
        inner_c++
        return inner_c

/obj
    var/const/c = 5
    subobj1
        var/static/s = dynamic_value()
        var/global/g = dynamic_value()
    subobj2
        var/static/s = dynamic_value()
        var/global/g = dynamic_value()

/world/New()
    var/obj/subobj1/o1 = new
    var/obj/subobj1/o2 = new
    var/obj/subobj2/o3 = new

    //world.log << "[static_proc()]"
    //world.log << "[static_proc_shadowed()]"
    //world.log << "[o1.s] [o1.g] [o1.c]"
    //o1.s -= 90
    //world.log << "[o2.s] [o2.g]"
    //world.log << "[o3.s] [o3.g]"

    ASSERT(static_proc() == 1003)
    ASSERT(static_proc_shadowed() == 700)
    ASSERT(o1.s == 997 && o1.g == 996 && o1.c == 5)
    o1.s -= 90
    ASSERT(o2.s == 907 && o2.g == 996)
    ASSERT(o3.s == 995 && o3.g == 994)
    shutdown()
```