### PR TITLE
change direct to lax deref for certain expressions

### DIFF
--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -23,6 +23,9 @@ namespace DMCompiler.DM.Expressions {
                 return true;
             }
             else if (astNode.Expression is DMASTDereference deref) {
+                if (deref.Type == DMASTDereference.DereferenceType.Search) {
+                    return true;
+                }
                 if (expr is Dereference _deref) {
                     return DirectConvertable(_deref._expr, deref);
                 }

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -16,24 +16,16 @@ namespace DMCompiler.DM.Expressions {
         DreamPath? _path;
 
         public static bool DirectConvertable(DMExpression expr, DMASTDereference astNode) {
-            if (expr.Path == null && astNode.Expression is DMASTProcCall) {
-                return true;
-            }
-            else if (astNode.Expression is DMASTListIndex) {
-                return true;
-            }
-            else if (astNode.Expression is DMASTDereference deref) {
-                if (deref.Type == DMASTDereference.DereferenceType.Search) {
+            switch (astNode.Expression) {
+                case DMASTDereference deref when deref.Type == DMASTDereference.DereferenceType.Search:
+                case DMASTProcCall when expr.Path == null:
+                case DMASTDereferenceProc:
+                case DMASTListIndex:
                     return true;
-                }
-                if (expr is Dereference _deref) {
+                case DMASTDereference deref when expr is Dereference _deref:
                     return DirectConvertable(_deref._expr, deref);
-                }
+                default: return false;
             }
-            else if (astNode.Expression is DMASTDereferenceProc) {
-                return true;
-            }
-            return false;
         }
 
         public Dereference(DMExpression expr, DMASTDereference astNode)


### PR DESCRIPTION
test case:
```

#include "map.dmm"
#include "interface.dmf"

/obj
    inner
        var/ele2 = 4

    var/ele = 2
    var/innerobj

    var/obj/inner/innerobj_ty

    proc/inner_proc()
        return new /obj
    proc/elefn()
        return 3


/proc/new_obj()
    return new /obj

/world/New()
    ASSERT(new_obj().ele == 2)
    ASSERT(new_obj()?.ele == 2)
    ASSERT(new_obj().inner_proc().ele == 2)
    ASSERT(new_obj()?.inner_proc()?.ele == 2)

    var/obj/o2 = new /obj
    ASSERT(o2.inner_proc().elefn() == 3)
    ASSERT(o2?.inner_proc()?.elefn() == 3)

    o2.innerobj_ty = new /obj/inner
    ASSERT(o2:innerobj_ty.ele2 == 4)

    var/list/l = newlist(/obj)
    ASSERT(l[1].ele == 2)
    ASSERT(l[1].elefn() == 3)

    l[1].innerobj = new /obj/inner
    ASSERT(l[1].innerobj.ele2 == 4)

    var/o
    // This is still not allowed
    //world.log << "[o.ele]"
    //world.log << "[o.elefn()]"

    shutdown()
```