### PR TITLE
Implements unimplemented warnings for vars

### DIFF
--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -25,6 +25,8 @@ namespace DMCompiler.DM {
             Conditional,
         }
 
+        public DMValueType ValType = DMValueType.Anything;
+
         public static DMExpression Create(DMObject dmObject, DMProc proc, DMASTExpression expression, DreamPath? inferredPath = null) {
             var instance = new DMVisitorExpression(dmObject, proc, inferredPath);
             expression.Visit(instance);

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -2,6 +2,8 @@
 using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
+using OpenDreamShared.Compiler;
+using OpenDreamShared.Dream.Procs;
 
 namespace DMCompiler.DM {
     class DMObject {
@@ -45,6 +47,10 @@ namespace DMCompiler.DM {
 
         public DMVariable GetVariable(string name) {
             if (Variables.TryGetValue(name, out DMVariable variable)) {
+                if (variable.Value.ValType == DMValueType.Unimplemented)
+                {
+                    Program.Warning(new CompilerWarning(null, $"{Path}.{name} is not implemented and will have unexpected behavior"));
+                }
                 return variable;
             }
             return Parent?.GetVariable(name);

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -95,11 +95,6 @@ namespace DMCompiler.DM.Visitors {
                 } else {
                     DMVariable variable = new DMVariable(null, varOverride.VarName, false);
 
-                    if (variable.Value is not null && variable.Value.ValType == DMValueType.Unimplemented)
-                    {
-                        Program.Warning(new CompilerWarning(null, $"{variable.Type}.{variable.Name} is not implemented and will have unexpected behavior"));
-                    }
-
                     SetVariableValue(variable, varOverride.Value, null);
                     _currentObject.VariableOverrides[variable.Name] = variable;
                 }

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -16,6 +16,8 @@
 	var/fps = null
 	var/tick_usage
 
+	var/unimp_test = "wumbo" as opendream_unimplemented
+
 	var/maxx = 0
 	var/maxy = 0
 	var/maxz = 0

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -16,8 +16,6 @@
 	var/fps = null
 	var/tick_usage
 
-	var/unimp_test = "wumbo" as opendream_unimplemented
-
 	var/maxx = 0
 	var/maxy = 0
 	var/maxz = 0

--- a/OpenDreamShared/Compiler/DM/DMAST.cs
+++ b/OpenDreamShared/Compiler/DM/DMAST.cs
@@ -240,9 +240,9 @@ namespace OpenDreamShared.Compiler.DM {
         public string Name;
         public DMASTExpression Value;
         public bool IsGlobal = false;
-        public DMValueType ValType = DMValueType.Anything;
+        public DMValueType ValType;
 
-        public DMASTObjectVarDefinition(DreamPath path, DMASTExpression value) {
+        public DMASTObjectVarDefinition(DreamPath path, DMASTExpression value, DMValueType valType = DMValueType.Anything) {
             int globalElementIndex = path.FindElement("global");
             if (globalElementIndex != -1) path = path.RemoveElement(globalElementIndex);
 
@@ -256,6 +256,7 @@ namespace OpenDreamShared.Compiler.DM {
             IsGlobal = globalElementIndex != -1 || ObjectPath.Equals(DreamPath.Root);
             Name = varPath.LastElement;
             Value = value;
+            ValType = valType;
         }
 
         public void Visit(DMASTVisitor visitor) {

--- a/OpenDreamShared/Compiler/DM/DMAST.cs
+++ b/OpenDreamShared/Compiler/DM/DMAST.cs
@@ -240,6 +240,7 @@ namespace OpenDreamShared.Compiler.DM {
         public string Name;
         public DMASTExpression Value;
         public bool IsGlobal = false;
+        public DMValueType ValType = DMValueType.Anything;
 
         public DMASTObjectVarDefinition(DreamPath path, DMASTExpression value) {
             int globalElementIndex = path.FindElement("global");

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -132,9 +132,8 @@ namespace OpenDreamShared.Compiler.DM {
 
                             if (value == null) value = new DMASTConstantNull();
 
-                            var val = AsTypes();
-                            var varDef = new DMASTObjectVarDefinition(varPath, value);
-                            varDef.ValType = val;
+                            var valType = AsTypes();
+                            var varDef = new DMASTObjectVarDefinition(varPath, value, valType);
 
                             varDefinitions.Add(varDef);
                             if (Check(TokenType.DM_Comma)) {

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -132,9 +132,11 @@ namespace OpenDreamShared.Compiler.DM {
 
                             if (value == null) value = new DMASTConstantNull();
 
-                            AsTypes();
+                            var val = AsTypes();
+                            var varDef = new DMASTObjectVarDefinition(varPath, value);
+                            varDef.ValType = val;
 
-                            varDefinitions.Add(new DMASTObjectVarDefinition(varPath, value));
+                            varDefinitions.Add(varDef);
                             if (Check(TokenType.DM_Comma)) {
                                 Whitespace();
                                 DMASTPath newVarPath = Path();
@@ -2120,6 +2122,7 @@ namespace OpenDreamShared.Compiler.DM {
                         case "command_text": type |= DMValueType.CommandText; break;
                         case "sound": type |= DMValueType.Sound; break;
                         case "icon": type |= DMValueType.Icon; break;
+                        case "opendream_unimplemented": type |= DMValueType.Unimplemented; break;
                         default: Error("Invalid value type '" + typeToken.Text + "'"); break;
                     }
                 } while (Check(TokenType.DM_Bar));

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -120,6 +120,7 @@ namespace OpenDreamShared.Dream.Procs {
         File = 0x200,
         CommandText = 0x400,
         Sound = 0x800,
-        Icon = 0x1000
+        Icon = 0x1000,
+        Unimplemented = 0x2000
     }
 }


### PR DESCRIPTION
Closes #368 

Trying to access or override a var flagged as unimplemented will throw a compiler warning.

Ex: `var/test as opendream_unimplemented`