### PR TITLE
Adds support for label blocks

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -272,7 +272,7 @@ namespace DMCompiler.DM {
                 }
                 var labelList = _labels.Keys.ToList();
                 var continueLabel = string.Empty;
-                for (var i = labelList.IndexOf(codeLabel) + 2; i < labelList.Count; i++)
+                for (var i = labelList.IndexOf(codeLabel) + 1; i < labelList.Count; i++)
                 {
                     if(labelList[i].EndsWith("_start"))
                     {

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -6,6 +6,8 @@ using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using OpenDreamShared.Compiler;
 
 namespace DMCompiler.DM {
     class DMProc {
@@ -245,7 +247,22 @@ namespace DMCompiler.DM {
         public void Continue(DMASTIdentifier label = null) {
             if (label is not null)
             {
-                Jump(label.Identifier + "_start");
+                var codeLabel = label.Identifier + "_codelabel";
+                if (!_labels.ContainsKey(codeLabel))
+                {
+                    Program.Error(new CompilerError(null, $"Unknown label {label.Identifier}"));
+                }
+                var labelList = _labels.Keys.ToList();
+                var continueLabel = string.Empty;
+                for (var i = labelList.IndexOf(codeLabel); i < labelList.Count; i++)
+                {
+                    if(labelList[i].EndsWith("_continue"))
+                    {
+                        continueLabel = labelList[i];
+                        break;
+                    }
+                }
+                Jump(continueLabel);
             }
             else
             {

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -227,16 +227,30 @@ namespace DMCompiler.DM {
             WriteLabel(jumpTo);
         }
 
-        public void Break() {
-            Jump(_loopStack.Peek() + "_end");
+        public void Break(DMASTIdentifier label = null) {
+            if (label is not null)
+            {
+                Jump(label.Identifier + "_end");
+            }
+            else
+            {
+                Jump(_loopStack.Peek() + "_end");
+            }
         }
 
         public void BreakIfFalse() {
             JumpIfFalse(_loopStack.Peek() + "_end");
         }
 
-        public void Continue() {
-            Jump(_loopStack.Peek() + "_continue");
+        public void Continue(DMASTIdentifier label = null) {
+            if (label is not null)
+            {
+                Jump(label.Identifier + "_start");
+            }
+            else
+            {
+                Jump(_loopStack.Peek() + "_continue");
+            }
         }
 
         public void ContinueIfFalse() {

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -98,7 +98,7 @@ namespace DMCompiler.DM {
                     _bytecodeWriter.Seek((int)unresolvedLabel.Position, SeekOrigin.Begin);
                     WriteInt((int)labelPosition);
                 } else {
-                    throw new Exception("Invalid label \"" + unresolvedLabel.LabelName + "\"");
+                    Program.Error(new CompilerError(null, "Invalid label \"" + unresolvedLabel.LabelName + "\""));
                 }
             }
 
@@ -245,6 +245,7 @@ namespace DMCompiler.DM {
         }
 
         public void Continue(DMASTIdentifier label = null) {
+            // TODO: Clean up this godawful label handling
             if (label is not null)
             {
                 var codeLabel = label.Identifier + "_codelabel";
@@ -254,11 +255,11 @@ namespace DMCompiler.DM {
                 }
                 var labelList = _labels.Keys.ToList();
                 var continueLabel = string.Empty;
-                for (var i = labelList.IndexOf(codeLabel); i < labelList.Count; i++)
+                for (var i = labelList.IndexOf(codeLabel) + 2; i < labelList.Count; i++)
                 {
-                    if(labelList[i].EndsWith("_continue"))
+                    if(labelList[i].EndsWith("_start"))
                     {
-                        continueLabel = labelList[i];
+                        continueLabel = labelList[i].Replace("_start", "_continue");
                         break;
                     }
                 }

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -115,7 +115,6 @@ namespace DMCompiler.DM.Visitors {
             {
                 _proc.StartScope();
                 {
-                    _proc.AddLabel(statementLabel.Name + "_start");
                     ProcessBlockInner(statementLabel.Body);
                 }
                 _proc.EndScope();

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -106,10 +106,20 @@ namespace DMCompiler.DM.Visitors {
 
         public void ProcessStatementLabel(DMASTProcStatementLabel statementLabel) {
             _proc.AddLabel(statementLabel.Name + "_codelabel");
+            if (statementLabel.Body is not null)
+            {
+                _proc.StartScope();
+                {
+                    _proc.AddLabel(statementLabel.Name + "_start");
+                    ProcessBlockInner(statementLabel.Body);
+                }
+                _proc.EndScope();
+                _proc.AddLabel(statementLabel.Name + "_end");
+            }
         }
 
         public void ProcessStatementBreak(DMASTProcStatementBreak statementBreak) {
-            _proc.Break();
+            _proc.Break(statementBreak.Label);
         }
 
         public void ProcessStatementSet(DMASTProcStatementSet statementSet) {

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -97,7 +97,7 @@ namespace DMCompiler.DM.Visitors {
         }
 
         public void ProcessStatementContinue(DMASTProcStatementContinue statementContinue) {
-            _proc.Continue();
+            _proc.Continue(statementContinue.Label);
         }
 
         public void ProcessStatementGoto(DMASTProcStatementGoto statementGoto) {

--- a/OpenDreamShared/Compiler/DM/DMAST.cs
+++ b/OpenDreamShared/Compiler/DM/DMAST.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection.Emit;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 
@@ -348,13 +349,26 @@ namespace OpenDreamShared.Compiler.DM {
         }
     }
 
-    public class DMASTProcStatementBreak : DMASTProcStatement {
+    public class DMASTProcStatementBreak : DMASTProcStatement
+    {
+        public DMASTIdentifier Label;
+
+        public DMASTProcStatementBreak(DMASTIdentifier label = null)
+        {
+            Label = label;
+        }
         public void Visit(DMASTVisitor visitor) {
             visitor.VisitProcStatementBreak(this);
         }
     }
 
     public class DMASTProcStatementContinue : DMASTProcStatement {
+        public DMASTIdentifier Label;
+
+        public DMASTProcStatementContinue(DMASTIdentifier label = null)
+        {
+            Label = label;
+        }
         public void Visit(DMASTVisitor visitor) {
             visitor.VisitProcStatementContinue(this);
         }
@@ -374,9 +388,11 @@ namespace OpenDreamShared.Compiler.DM {
 
     public class DMASTProcStatementLabel : DMASTProcStatement {
         public string Name;
+        public DMASTProcBlockInner Body;
 
-        public DMASTProcStatementLabel(string name) {
+        public DMASTProcStatementLabel(string name, DMASTProcBlockInner body) {
             Name = name;
+            Body = body;
         }
 
         public void Visit(DMASTVisitor visitor) {

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -594,12 +594,9 @@ namespace OpenDreamShared.Compiler.DM {
             if (Check(TokenType.DM_Break))
             {
                 Whitespace();
-                DMASTExpression expression = Expression();
-                if (expression is DMASTIdentifier)
-                {
-                    return new DMASTProcStatementBreak((DMASTIdentifier)expression);
-                }
-                return new DMASTProcStatementBreak();
+                DMASTExpression label = Expression();
+                
+                return new DMASTProcStatementBreak(label as DMASTIdentifier);
             } else {
                 return null;
             }

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -605,12 +605,9 @@ namespace OpenDreamShared.Compiler.DM {
         public DMASTProcStatementContinue Continue() {
             if (Check(TokenType.DM_Continue)) {
                 Whitespace();
-                DMASTExpression expression = Expression();
-                if (expression is DMASTIdentifier)
-                {
-                    return new DMASTProcStatementContinue((DMASTIdentifier)expression);
-                }
-                return new DMASTProcStatementContinue();
+                DMASTExpression label = Expression();
+                
+                return new DMASTProcStatementContinue(label as DMASTIdentifier);
             } else {
                 return null;
             }

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -1164,8 +1164,7 @@ namespace OpenDreamShared.Compiler.DM {
             if (body == null) {
                 DMASTProcStatement statement = ProcStatement();
                 
-                if (statement == null) return new DMASTProcStatementLabel(expression.Identifier, null);
-                body = new DMASTProcBlockInner(new DMASTProcStatement[] { statement });
+                if (statement != null) body = new DMASTProcBlockInner(new DMASTProcStatement[] { statement });
             }
             return new DMASTProcStatementLabel(expression.Identifier, body);
         }


### PR DESCRIPTION
Fixes #408 

Adds support for label blocks and using continue/break in them.

This survived extremely basic testing but could probably use more rigorous BYOND parity testing.