### PR TITLE
Fixes preceding an upward search with a slash

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -193,7 +193,8 @@ namespace OpenDreamShared.Compiler.DM {
             bool hasPathTypeToken = true;
 
             if (Check(TokenType.DM_Slash)) {
-                pathType = DreamPath.PathType.Absolute;
+                // Check if they did "/.whatever/" instead of ".whatever/"
+                pathType = Check(TokenType.DM_Period) ? DreamPath.PathType.UpwardSearch : DreamPath.PathType.Absolute;
             } else if (Check(TokenType.DM_Colon)) {
                 pathType = DreamPath.PathType.DownwardSearch;
             } else if (Check(TokenType.DM_Period)) {
@@ -2144,7 +2145,7 @@ namespace OpenDreamShared.Compiler.DM {
                 Whitespace();
                 bool parenthetical = Check(TokenType.DM_LeftParenthesis);
                 bool closed = false;
-                
+
                 do {
                     Whitespace();
                     Token typeToken = Current();


### PR DESCRIPTION
Paradise has a few places where they do something like `INVOKE_ASYNC(GLOBAL_PROC, /.proc/flick_overlay, I, speech_bubble_hearers, 30)` and that preceding `/` in `/.proc` causes problems.

~~I don't _think_ there's an open issue for this.~~ Fixes #392 