### PR TITLE
Eat trailing semicolons after for() and while()

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -789,6 +789,7 @@ namespace OpenDreamShared.Compiler.DM {
                     }
 
                     ConsumeRightParenthesis();
+                    Check(TokenType.DM_Semicolon);
                     Whitespace();
                     Newline();
 
@@ -816,6 +817,7 @@ namespace OpenDreamShared.Compiler.DM {
                     }
                     Whitespace();
                     ConsumeRightParenthesis();
+                    Check(TokenType.DM_Semicolon);
                     Whitespace();
                     Newline();
 
@@ -843,6 +845,7 @@ namespace OpenDreamShared.Compiler.DM {
                     }
 
                     ConsumeRightParenthesis();
+                    Check(TokenType.DM_Semicolon);
                     Whitespace();
                     Newline();
 
@@ -880,6 +883,7 @@ namespace OpenDreamShared.Compiler.DM {
                 DMASTExpression conditional = Expression();
                 if (conditional == null) Error("Expected conditional");
                 ConsumeRightParenthesis();
+                Check(TokenType.DM_Semicolon);
                 Whitespace();
                 DMASTProcBlockInner body = ProcBlock();
 
@@ -919,6 +923,7 @@ namespace OpenDreamShared.Compiler.DM {
                 DMASTExpression conditional = Expression();
                 if (conditional == null) Error("Expected conditional");
                 ConsumeRightParenthesis();
+                Check(TokenType.DM_Semicolon);
                 Whitespace();
 
                 return new DMASTProcStatementDoWhile(conditional, body);

--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -923,7 +923,6 @@ namespace OpenDreamShared.Compiler.DM {
                 DMASTExpression conditional = Expression();
                 if (conditional == null) Error("Expected conditional");
                 ConsumeRightParenthesis();
-                Check(TokenType.DM_Semicolon);
                 Whitespace();
 
                 return new DMASTProcStatementDoWhile(conditional, body);


### PR DESCRIPTION
This is valid DM: `for(A, A && !ismob(A), A=A.loc);`

The semicolon seems to have no effect.