### PR TITLE
Implements modified types as an unimplemented warning

### DIFF
--- a/OpenDreamShared/Compiler/DM/DMParser.cs
+++ b/OpenDreamShared/Compiler/DM/DMParser.cs
@@ -216,6 +216,16 @@ namespace OpenDreamShared.Compiler.DM {
                     }
                 }
 
+                //TODO actual modified type support
+                if (Check(TokenType.DM_LeftCurlyBracket))
+                {
+                    if(_unimplementedWarnings) Warning("Modified types are currently not supported and modified values will be ignored.");
+
+                    while (Current().Type != TokenType.DM_RightCurlyBracket && !Check(TokenType.EndOfFile)) Advance();
+                    Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
+                    Newline(); //The lexer tosses in a newline after }
+                }
+
                 return new DMASTPath(new DreamPath(pathType, pathElements.ToArray()));
             } else if (hasPathTypeToken) {
                 if (expression) ReuseToken(firstToken);
@@ -2148,7 +2158,7 @@ namespace OpenDreamShared.Compiler.DM {
                 Whitespace();
                 bool parenthetical = Check(TokenType.DM_LeftParenthesis);
                 bool closed = false;
-                
+
                 do {
                     Whitespace();
                     Token typeToken = Current();


### PR DESCRIPTION
Eats modified types and throws an unimplemented warning.

Closes #34 and I'll make a new issue for implementing actual functionality when this is merged.