### PR TITLE
fix(client): specify default culture for float.Parse

### DIFF
--- a/OpenDreamShared/Dream/ScreenLocation.cs
+++ b/OpenDreamShared/Dream/ScreenLocation.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 
 namespace OpenDreamShared.Dream {
     public class ScreenLocation {
@@ -101,7 +102,7 @@ namespace OpenDreamShared.Dream {
                     string[] numberSplit = currentNumber.Split(":");
                     if (numberSplit.Length > 2) throw new Exception("Invalid number in screen_loc");
 
-                    operations.Add((currentOperation, float.Parse(numberSplit[0]), (numberSplit.Length == 2) ? int.Parse(numberSplit[1]) : 0));
+                    operations.Add((currentOperation, float.Parse(numberSplit[0], CultureInfo.InvariantCulture), (numberSplit.Length == 2) ? int.Parse(numberSplit[1]) : 0));
                     currentOperation = c.ToString();
                     currentNumber = String.Empty;
                 }

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Globalization;
 
 namespace OpenDreamShared.Resources {
     public static class DMIParser {
@@ -190,7 +191,7 @@ namespace OpenDreamShared.Resources {
 
                     switch (key) {
                         case "version":
-                            description.Version = float.Parse(value);
+                            description.Version = float.Parse(value, CultureInfo.InvariantCulture);
                             break;
                         case "width":
                             description.Width = int.Parse(value);
@@ -249,7 +250,7 @@ namespace OpenDreamShared.Resources {
 
                             currentStateFrameDelays = new float[frameDelays.Length];
                             for (int i = 0; i < frameDelays.Length; i++) {
-                                currentStateFrameDelays[i] = float.Parse(frameDelays[i]);
+                                currentStateFrameDelays[i] = float.Parse(frameDelays[i], CultureInfo.InvariantCulture);
                             }
 
                             break;


### PR DESCRIPTION
float.Parse uses default OS locale to parse float if it doesn't specify. In the Russian version of Windows, it expects the float separator to be "," instead of ".", which breaks the parsing of .dmi.

So I specified default culture for all float.Parse.