### PR TITLE
fix(webview2): process webview2 runtime missing error

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -47,7 +47,12 @@ namespace OpenDreamClient.Interface.Controls {
             if (_webViewReady) _webView.CoreWebView2.Navigate("file://" + _fileSource);
         }
 
-        private void OnWebView2InitializationCompleted(object sender, EventArgs e) {
+        private void OnWebView2InitializationCompleted(object sender, CoreWebView2InitializationCompletedEventArgs e) {
+            if (!e.IsSuccess) {
+                Console.WriteLine(e.InitializationException);
+                return;
+            }
+
             _webViewReady = true;
 
             _dockPanel.Children.Remove(_loadingLabel);


### PR DESCRIPTION
Fix weird behavior when the WebView2 Runtime is missing by adding some error processing.