### PR TITLE
Adds `--unique-errors`

### DIFF
--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -22,6 +22,7 @@ namespace DMCompiler {
                     case "--suppress-unimplemented": settings.SuppressUnimplementedWarnings = true; break;
                     case "--dump-preprocessor": settings.DumpPreprocessor = true; break;
                     case "--no-standard": settings.NoStandard = true; break;
+                    case "--unique-errors": settings.UniqueErrors = true; break;
                     default: {
                         string extension = Path.GetExtension(arg);
 


### PR DESCRIPTION
Adds an arg of dubious use, `--unique-errors`.

It's an inaccurate way of getting a rough idea of what individual things are broken.

I'm not sure if it's even worth merging or not, but it does make it slightly easier to look through the error list for things to work on.