### PR TITLE
Fix sound volume.

### DIFF
--- a/OpenDreamClient/Audio/DreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/DreamSoundEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
 using OpenDreamShared.Network.Messages;
@@ -44,7 +45,7 @@ namespace OpenDreamClient.Audio
 
             StopChannel(channel);
 
-            var source = sound.Play(AudioParams.Default.WithVolume(volume));
+            var source = sound.Play(AudioParams.Default.WithVolume(20 * MathF.Log10(volume)));
             _channels[channel - 1] = new DreamSoundChannel(source);
         }
 

--- a/OpenDreamClient/Audio/DreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/DreamSoundEngine.cs
@@ -45,7 +45,7 @@ namespace OpenDreamClient.Audio
 
             StopChannel(channel);
 
-            var source = sound.Play(AudioParams.Default.WithVolume(20 * MathF.Log10(volume)));
+            var source = sound.Play(AudioParams.Default.WithVolume(20 * MathF.Log10(volume))); // convert from DM volume (0-100) to OpenAL volume (db)
             _channels[channel - 1] = new DreamSoundChannel(source);
         }
 


### PR DESCRIPTION
OpenAL volume is in decibels, BYOND's volume goes from 0 to 100.
I fixed this issue by doing a funny logarithm volume scale.
In C#, `MathF.Log10(0)` is negative infinity, therefore resulting in completely muted audio.

DM Snippet for easy testing (works in testgame!)
```DM
	verb/input_num()
		var/v = input("A") as num
		usr << sound("test.ogg", volume=v)
		usr << "you entered [v]"
```