### PR TITLE
Parse some funky bracketed var decl syntax

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -609,7 +609,10 @@ namespace DMCompiler.Compiler.DM {
                 }
 
                 if (isIndented) Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
-
+                if (isIndented) {
+                    Newline();
+                    Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
+                }
                 return varDeclarations.ToArray();
             }
             else if (hasNewline) {

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -592,7 +592,26 @@ namespace DMCompiler.Compiler.DM {
                 }
 
                 return varDeclarations.ToArray();
-            } else if (hasNewline) {
+            } else if (Check(TokenType.DM_LeftCurlyBracket)) {
+                Whitespace();
+                Newline();
+                bool isIndented = Check(TokenType.DM_Indent);
+
+                List<DMASTProcStatementVarDeclaration> varDeclarations = new();
+                while (!Check(isIndented ? TokenType.DM_Dedent : TokenType.DM_RightCurlyBracket)) {
+                    DMASTProcStatementVarDeclaration[] varDecl = ProcVarEnd(true, path: varPath);
+                    Check(TokenType.DM_Semicolon);
+                    if (varDecl == null) Error("Expected a var declaration");
+
+                    varDeclarations.AddRange(varDecl);
+                    Newline();
+                }
+
+                if (isIndented) Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
+
+                return varDeclarations.ToArray();
+            }
+            else if (hasNewline) {
                 ReuseToken(newlineToken);
             }
 
@@ -2031,7 +2050,7 @@ namespace DMCompiler.Compiler.DM {
         protected bool Whitespace(bool includeIndentation = false) {
             if (includeIndentation) {
                 bool hadWhitespace = false;
-                
+
                 while (Check(WhitespaceTypes)) hadWhitespace = true;
                 return hadWhitespace;
             } else {

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -601,12 +601,11 @@ namespace DMCompiler.Compiler.DM {
                 TokenType type = isIndented ? TokenType.DM_Dedent : TokenType.DM_RightCurlyBracket;
                 while (!Check(type)) {
                     DMASTProcStatementVarDeclaration[] varDecl = ProcVarEnd(true, path: varPath);
-                    Check(TokenType.DM_Semicolon);
+                    Delimiter();
+                    Whitespace();
                     if (varDecl == null) Error("Expected a var declaration");
 
                     varDeclarations.AddRange(varDecl);
-                    Whitespace();
-                    Newline();
                 }
 
                 if (isIndented) Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -598,7 +598,8 @@ namespace DMCompiler.Compiler.DM {
                 bool isIndented = Check(TokenType.DM_Indent);
 
                 List<DMASTProcStatementVarDeclaration> varDeclarations = new();
-                while (!Check(isIndented ? TokenType.DM_Dedent : TokenType.DM_RightCurlyBracket)) {
+                TokenType type = isIndented ? TokenType.DM_Dedent : TokenType.DM_RightCurlyBracket;
+                while (!Check(type)) {
                     DMASTProcStatementVarDeclaration[] varDecl = ProcVarEnd(true, path: varPath);
                     Check(TokenType.DM_Semicolon);
                     if (varDecl == null) Error("Expected a var declaration");

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -604,6 +604,7 @@ namespace DMCompiler.Compiler.DM {
                     if (varDecl == null) Error("Expected a var declaration");
 
                     varDeclarations.AddRange(varDecl);
+                    Whitespace();
                     Newline();
                 }
 


### PR DESCRIPTION
Makes this: `var/{flatX1=1;flatX2=flat.Width();flatY1=1;flatY2=flat.Height()}` compile.

Seems to work for this exact example, but I'm not sure if I have the right combo of `Whitespace()` and `Newline()` shenanigans for other potential cases.

Fixes #320 