### PR TITLE
Fixes braced indented inner proc blocks

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -406,6 +406,7 @@ namespace DMCompiler.Compiler.DM {
                 if (Current().Type == TokenType.DM_Indent) {
                     block = IndentedProcBlock();
                     Newline();
+                    Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
                 } else {
                     List<DMASTProcStatement> statements = new();
 


### PR DESCRIPTION
The closing `}` wasn't getting consumed in a fairly specific case.

Relevant DM:
```
proc/AStar(start,end,adjacent,dist,maxnodes,maxnodedepth = 30,mintargetdist,minnodedist,id=null, var/turf/exclude=null)
	var/PriorityQueue/open = new /PriorityQueue(/proc/PathWeightCompare) //the open list, ordered using the PathWeightCompare proc, from lower f to higher
	var/list/closed = new() //the closed list
	var/list/path = null //the returned path, if any
	var/PathNode/cur //current processed turf

	//sanitation
	start = get_turf(start)
	if(!start)
		return 0

	//initialization
	open.Enqueue(new /PathNode(start,null,0,call(start,dist)(end),0))

	//then run the main loop
	while(!open.IsEmpty() && !path)
	{
			//get the lower f node on the open list
		cur = open.Dequeue() //get the lower f turf in the open list
		closed.Add(cur.source) //and tell we've processed it

		//if we only want to get near the target, check if we're close enough
		var/closeenough
		if(mintargetdist)
			closeenough = call(cur.source,dist)(end) <= mintargetdist

		//if too many steps, abandon that path
		if(maxnodedepth && (cur.nt > maxnodedepth))
			continue

		//found the target turf (or close enough), let's create the path to it
		if(cur.source == end || closeenough)
			path = new()
			path.Add(cur.source)
			while(cur.prevNode)
				cur = cur.prevNode
				path.Add(cur.source)
			break

		//IMPLEMENTATION TO FINISH
		//do we really need this minnodedist ???
		/*if(minnodedist && maxnodedepth)
			if(call(cur.source,minnodedist)(end) + cur.nt >= maxnodedepth)
				continue
		*/

		//get adjacents turfs using the adjacent proc, checking for access with id
		var/list/L = call(cur.source,adjacent)(id,closed)

		for(var/turf/T in L)
			if(T == exclude)
				continue

			var/newg = cur.g + call(cur.source,dist)(T)
			if(!T.PNode) //is not already in open list, so add it
				open.Enqueue(new /PathNode(T,cur,newg,call(T,dist)(end),cur.nt+1))
			else //is already in open list, check if it's a better way from the current turf
				if(newg < T.PNode.g)
					T.PNode.prevNode = cur
					T.PNode.g = newg
					T.PNode.calc_f()
					open.ReSort(T.PNode)//reorder the changed element in the list

	}
```