### PR TITLE
Fixes LastElement throwing an exception

### DIFF
--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -84,7 +84,7 @@ namespace DMCompiler.DM {
             //We're searching for a proc
             if (procElement != -1) {
                 DreamPath procPath = search.FromElements(procElement + 1);
-                if (procPath.Elements.Length != 1) return null;
+                if (procPath.Elements.Length != 1 || procPath.LastElement is null) return null;
 
                 if (found.HasProc(procPath.LastElement)) {
                     return new DreamPath(found.Path.PathString + "/proc" + procPath);

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -98,6 +98,7 @@ namespace OpenDreamRuntime
                 foreach (DreamValue mobVerbPath in mobVerbPaths)
                 {
                     DreamPath path = mobVerbPath.GetValueAsPath();
+                    if (path.LastElement is null) continue;
 
                     _availableVerbs.Add(path.LastElement, MobDreamObject.GetProc(path.LastElement));
                 }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1164,9 +1164,9 @@ namespace OpenDreamRuntime.Procs {
 
                             if (procElementIndex != -1) {
                                 DreamPath procPath = fullProcPath.FromElements(procElementIndex + 1);
-                                string procName = procPath.LastElement;
+                                string? procName = procPath.LastElement;
 
-                                proc = dreamObject.GetProc(procName);
+                                if(procName != null) proc = dreamObject.GetProc(procName);
                             }
                             break;
                         }
@@ -1180,7 +1180,7 @@ namespace OpenDreamRuntime.Procs {
                 }
                 case DreamValue.DreamValueType.DreamPath: {
                     DreamPath fullProcPath = source.GetValueAsPath();
-                    if (fullProcPath.Elements.Length != 2) throw new Exception("Invalid call() proc \"" + fullProcPath + "\"");
+                    if (fullProcPath.Elements.Length != 2 || fullProcPath.LastElement is null) throw new Exception("Invalid call() proc \"" + fullProcPath + "\"");
                     string procName = fullProcPath.LastElement;
                     DreamProc proc = state.Instance.GetProc(procName);
 

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -36,7 +36,7 @@ namespace OpenDreamShared.Dream {
 
         [JsonIgnore]
         public string LastElement {
-            get => Elements.Last();
+            get => Elements.Length > 0 ? Elements.Last() : String.Empty;
         }
 
         [JsonIgnore]

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -35,8 +35,8 @@ namespace OpenDreamShared.Dream {
         }
 
         [JsonIgnore]
-        public string LastElement {
-            get => Elements.Length > 0 ? Elements.Last() : String.Empty;
+        public string? LastElement {
+            get => Elements.Length > 0 ? Elements.Last() : null;
         }
 
         [JsonIgnore]


### PR DESCRIPTION
While compiling NTstation a path string of `"/"` is causing an exception because Elements is 0.

Not sure if this is the proper fix but it does stop the exception.