### PR TITLE
Adds location support to CompilerWarnings

### DIFF
--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -52,7 +52,7 @@ namespace DMCompiler.DM {
             if (Variables.TryGetValue(name, out DMVariable variable)) {
                 if ((variable.Value?.ValType & DMValueType.Unimplemented) == DMValueType.Unimplemented && !DMCompiler.Settings.SuppressUnimplementedWarnings)
                 {
-                    DMCompiler.Warning(new CompilerWarning(null, $"{Path}.{name} is not implemented and will have unexpected behavior"));
+                    DMCompiler.Warning(new CompilerWarning(Location.Unknown, $"{Path}.{name} is not implemented and will have unexpected behavior"));
                 }
                 return variable;
             }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -170,7 +170,7 @@ namespace DMCompiler.DM.Expressions {
 
             if (weighted) {
                 if (_values.Length == 1) {
-                    DMCompiler.Warning(new CompilerWarning(null, "Weighted pick() with one argument"));
+                    DMCompiler.Warning(new CompilerWarning(proc.Location, "Weighted pick() with one argument"));
                 }
 
                 foreach (PickValue pickValue in _values) {

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -138,7 +138,7 @@ namespace DMCompiler.DM.Expressions {
 
             DMObject dmObject = DMObjectTree.GetDMObject(_expr.Path.Value);
             if (!DMCompiler.Settings.SuppressUnimplementedWarnings && dmObject.IsProcUnimplemented(_field)) {
-                DMCompiler.Warning(new CompilerWarning(null, $"{dmObject.Path}.{_field}() is not implemented"));
+                DMCompiler.Warning(new CompilerWarning(Location.Unknown, $"{dmObject.Path}.{_field}() is not implemented"));
             }
         }
     }

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -24,7 +24,7 @@ namespace DMCompiler.DM.Expressions {
 
         public void UnimplementedCheck(DMObject dmObject) {
             if (!DMCompiler.Settings.SuppressUnimplementedWarnings && dmObject.IsProcUnimplemented(_identifier)) {
-                DMCompiler.Warning(new CompilerWarning(null, $"{dmObject.Path}.{_identifier}() is not implemented"));
+                DMCompiler.Warning(new CompilerWarning(Location.Unknown, $"{dmObject.Path}.{_identifier}() is not implemented"));
             }
         }
     }

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -274,7 +274,7 @@ namespace DMCompiler.DM.Visitors {
                         var obj = DMObjectTree.GetDMObject(varDeclaration.Type.Value);
                         if (statementForList.List is DMASTIdentifier list && list.Identifier == "world" && !obj.IsSubtypeOf(DreamPath.Atom))
                         {
-                            var warn = new CompilerWarning(null, "Cannot currently loop 'in world' for non-ATOM types");
+                            var warn = new CompilerWarning(statementForList.Location, "Cannot currently loop 'in world' for non-ATOM types");
                             DMCompiler.Warning(warn);
                         }
                         DMExpression.Emit(_dmObject, _proc, statementForList.Variable);

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -32,7 +32,7 @@ namespace DMCompiler {
             _compileStartTime = DateTime.Now;
 
             if (settings.SuppressUnimplementedWarnings) {
-                Warning(new CompilerWarning(null, "Unimplemented proc & var warnings are currently suppressed"));
+                Warning(new CompilerWarning(Location.Unknown, "Unimplemented proc & var warnings are currently suppressed"));
             }
 
             DMPreprocessor preprocessor = Preprocess(settings.Files);

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -2,18 +2,15 @@
 
 namespace OpenDreamShared.Compiler {
     public struct CompilerError {
-        public Token Token;
         public Location? Location;
         public string Message;
 
         public CompilerError(Token token, string message) {
-            Token = token;
             Location = token?.Location ?? Compiler.Location.Unknown;
             Message = message;
         }
 
         public CompilerError(Location location, string message) {
-            Token = null;
             Location = location;
             Message = message;
         }
@@ -24,24 +21,21 @@ namespace OpenDreamShared.Compiler {
     }
 
     public struct CompilerWarning {
-        public Token Token;
+        public Location? Location;
         public string Message;
 
         public CompilerWarning(Token token, string message) {
-            Token = token;
+            Location = token?.Location ?? Compiler.Location.Unknown;
+            Message = message;
+        }
+
+        public CompilerWarning(Location location, string message) {
+            Location = location;
             Message = message;
         }
 
         public override string ToString() {
-            string location;
-
-            if (Token != null) {
-                location = Token.Location.ToString();
-            } else {
-                location = Location.Unknown.ToString();
-            }
-
-            return $"Warning at {location}: {Message}";
+            return $"Warning at {Location.ToString()}: {Message}";
         }
     }
 

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -2,7 +2,7 @@
 
 namespace OpenDreamShared.Compiler {
     public struct CompilerError {
-        public Location? Location;
+        public Location Location;
         public string Message;
 
         public CompilerError(Token token, string message) {

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -21,7 +21,7 @@ namespace OpenDreamShared.Compiler {
     }
 
     public struct CompilerWarning {
-        public Location? Location;
+        public Location Location;
         public string Message;
 
         public CompilerWarning(Token token, string message) {


### PR DESCRIPTION
Not quite as useful until we have location information stored in expressions, but it does point out unsupported `in world` loops.