### PR TITLE
Fixes an exception in ternary null handling

### DIFF
--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -360,8 +360,8 @@ namespace DMCompiler.DM.Visitors {
 
         public void VisitTernary(DMASTTernary ternary) {
             var a = DMExpression.Create(_dmObject, _proc, ternary.A, _inferredPath);
-            var b = DMExpression.Create(_dmObject, _proc, ternary.B, _inferredPath);
-            var c = DMExpression.Create(_dmObject, _proc, ternary.C, _inferredPath);
+            var b = DMExpression.Create(_dmObject, _proc, ternary.B ?? new DMASTConstantNull(ternary.Location), _inferredPath);
+            var c = DMExpression.Create(_dmObject, _proc, ternary.C ?? new DMASTConstantNull(ternary.Location), _inferredPath);
             Result = new Expressions.Ternary(a, b, c);
         }
 

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -360,7 +360,7 @@ namespace DMCompiler.DM.Visitors {
 
         public void VisitTernary(DMASTTernary ternary) {
             var a = DMExpression.Create(_dmObject, _proc, ternary.A, _inferredPath);
-            var b = DMExpression.Create(_dmObject, _proc, ternary.B ?? new DMASTConstantNull(ternary.Location), _inferredPath);
+            var b = DMExpression.Create(_dmObject, _proc, ternary.B, _inferredPath);
             var c = DMExpression.Create(_dmObject, _proc, ternary.C ?? new DMASTConstantNull(ternary.Location), _inferredPath);
             Result = new Expressions.Ternary(a, b, c);
         }


### PR DESCRIPTION
Problematic code: 
`dat+="<B><A href='?src=\ref[src];show_channel=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR></B>"`

It's the `()` for `ternary.C`