### PR TITLE
Fix exception with negative sleeps

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1271,7 +1271,10 @@ namespace OpenDreamRuntime.Procs.Native {
             float delay = state.Arguments.GetArgument(0, "Delay").GetValueAsFloat();
             int delayMilliseconds = (int)(delay * 100);
 
-            // This is obviously not the proper behaviour
+            // TODO: This is obviously not the proper behaviour, see https://www.byond.com/docs/ref/#/proc/sleep
+            // sleep(0) should sleep for the minimum amount of time possible, whereas
+            // sleep called with a negative value should do a backlog check, meaning it only sleeps
+            // when other events are backlogged
             if (delayMilliseconds > 0) {
                 await Task.Delay(delayMilliseconds);
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1272,7 +1272,9 @@ namespace OpenDreamRuntime.Procs.Native {
             int delayMilliseconds = (int)(delay * 100);
 
             // This is obviously not the proper behaviour
-            await Task.Delay(delayMilliseconds);
+            if (delayMilliseconds > 0) {
+                await Task.Delay(delayMilliseconds);
+            }
             return DreamValue.Null;
         }
 


### PR DESCRIPTION
Code used to test:

```dm
/world/New()
	..()
	world.log << "Running"
	sleep(-1)
	world.log << "No exception"
```

Fixes #489. Does not reproduce byond behavior exactly, just stops the exception