### PR TITLE
Implements default `atom/var/text` behavior

### DIFF
--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -96,19 +96,18 @@ namespace DMCompiler.DM.Visitors {
                     _currentObject.Parent = DMObjectTree.GetDMObject(parentType.Value.Path);
                 } else if (varOverride.VarName == "name" && _currentObject.IsSubtypeOf(DreamPath.Atom) && !_currentObject.VariableOverrides.ContainsKey("text"))
                 {
+                    SetVarOverride();
+
                     var text = new DMVariable(null, "text", false);
                     var name = varOverride.Value as DMASTConstantString;
 
                     if (name is null || name.Value.Length < 1)
                     {
-                        SetVarOverride();
                         return;
                     }
 
                     SetVariableValue(text, new DMASTConstantString(varOverride.Location, name.Value[0].ToString()));
                     _currentObject.VariableOverrides[text.Name] = text;
-
-                    SetVarOverride();
                 }
                 else {
                     SetVarOverride();

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -2,6 +2,7 @@
 	parent_type = /datum
 
 	var/name = "atom"
+	var/text = "a" // First letter of name. Name overrides set it during compilation.
 	var/desc = null
 	var/suffix = null as opendream_unimplemented
 	var/list/verbs = list()
@@ -75,5 +76,5 @@
 
 	proc/Exit(atom/movable/O, atom/newloc)
 		return TRUE
-	
+
 	proc/Stat()


### PR DESCRIPTION
Fixes #523 

Implements the default behavior for `atom/var/text`, which is setting it to the first letter of name.

According to the docs, `text` is actually quite a complex feature. But this gets the default value working.