### PR TITLE
Two compiler optimizations

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -531,6 +531,7 @@ namespace DMCompiler.Compiler.DM {
 
                 return new DMASTProcStatementExpression(loc, expression);
             } else {
+                // These are sorted by frequency, except If() is moved to the end because it's really slow (relatively)
                 DMASTProcStatement procStatement = Return();
                 if (procStatement == null) procStatement = ProcVarDeclaration();
                 if (procStatement == null) procStatement = For();

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -531,21 +531,21 @@ namespace DMCompiler.Compiler.DM {
 
                 return new DMASTProcStatementExpression(loc, expression);
             } else {
-                DMASTProcStatement procStatement = ProcVarDeclaration();
-                if (procStatement == null) procStatement = Return();
-                if (procStatement == null) procStatement = Break();
-                if (procStatement == null) procStatement = Continue();
-                if (procStatement == null) procStatement = Goto();
-                if (procStatement == null) procStatement = Del();
-                if (procStatement == null) procStatement = Set();
-                if (procStatement == null) procStatement = Spawn();
-                if (procStatement == null) procStatement = If();
+                DMASTProcStatement procStatement = Return();
+                if (procStatement == null) procStatement = ProcVarDeclaration();
                 if (procStatement == null) procStatement = For();
+                if (procStatement == null) procStatement = Set();
+                if (procStatement == null) procStatement = Switch();
+                if (procStatement == null) procStatement = Continue();
+                if (procStatement == null) procStatement = Break();
+                if (procStatement == null) procStatement = Spawn();
                 if (procStatement == null) procStatement = While();
                 if (procStatement == null) procStatement = DoWhile();
-                if (procStatement == null) procStatement = Switch();
-                if (procStatement == null) procStatement = TryCatch();
                 if (procStatement == null) procStatement = Throw();
+                if (procStatement == null) procStatement = Del();
+                if (procStatement == null) procStatement = TryCatch();
+                if (procStatement == null) procStatement = Goto();
+                if (procStatement == null) procStatement = If();
 
                 if (procStatement != null) {
                     Whitespace();

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -52,14 +52,17 @@ namespace OpenDreamShared.Dream {
             get {
                 if (_pathString != null) return _pathString;
 
-                StringBuilder pathStringBuilder = new StringBuilder();
-                if (Type == PathType.Absolute) pathStringBuilder.Append('/');
-                else if (Type == PathType.DownwardSearch) pathStringBuilder.Append(':');
-                else if (Type == PathType.UpwardSearch) pathStringBuilder.Append('.');
+                _pathString = Type switch
+                {
+                    PathType.Absolute => "/",
+                    PathType.DownwardSearch => ":",
+                    PathType.UpwardSearch => ".",
+                    _ => string.Empty
+                };
 
-                pathStringBuilder.AppendJoin('/', Elements);
+                // Elements is usually small enough for this to be faster than StringBuilder
+                _pathString += string.Join("/", Elements);
 
-                _pathString = pathStringBuilder.ToString();
                 return _pathString;
             }
             set => SetFromString(value);


### PR DESCRIPTION
1. PathString's getter was relatively quite expensive. StringBuilder is actually a worse option when you're only concatenating a few strings. Replaced it with a regular `string.Join()` and shaved off a small amount of both time and memory usage.
2. Reorganized the dozen or so procStatement method calls to be primarily sorted by frequency, then moved `If()` last because although it's by far the most common it's also by far the most expensive of them.

Altogether this shaves about 5 seconds off my compile time, making us officially 4x faster at compiling than byond.