### PR TITLE
Don't save nulls to global list in the compiler

### DIFF
--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -182,14 +182,22 @@ namespace DMCompiler {
             if (DMObjectTree.GlobalInitProc.Bytecode.Length > 0) compiledDream.GlobalInitProc = DMObjectTree.GlobalInitProc.GetJsonRepresentation();
 
             if (DMObjectTree.Globals.Count > 0) {
-                compiledDream.Globals = new List<object>();
+                GlobalListJson globalListJson = new GlobalListJson();
+                globalListJson.GlobalCount = DMObjectTree.Globals.Count;
 
-                foreach (DMVariable global in DMObjectTree.Globals) {
+                // Approximate capacity (4/285 in tgstation, ~3%)
+                globalListJson.Globals = new Dictionary<int, object>((int) (DMObjectTree.Globals.Count * 0.03));
+
+                for (int i = 0; i < DMObjectTree.Globals.Count; i++) {
+                    DMVariable global = DMObjectTree.Globals[i];
                     if (!global.TryAsJsonRepresentation(out var globalJson))
                         throw new Exception($"Failed to serialize global {global.Name}");
 
-                    compiledDream.Globals.Add(globalJson);
+                    if (globalJson != null) {
+                        globalListJson.Globals.Add(i, globalJson);
+                    }
                 }
+                compiledDream.Globals = globalListJson;
             }
 
             string json = JsonSerializer.Serialize(compiledDream, new JsonSerializerOptions() {

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -58,7 +58,11 @@ namespace OpenDreamRuntime {
             WorldInstance.InitSpawn(new DreamProcArguments(null));
 
             if (_compiledJson.Globals != null) {
-                foreach (object globalValue in _compiledJson.Globals) {
+                var jsonGlobals = _compiledJson.Globals;
+                Globals.EnsureCapacity(jsonGlobals.GlobalCount);
+
+                for (int i = 0; i < jsonGlobals.GlobalCount; i++) {
+                    object globalValue = jsonGlobals.Globals.GetValueOrDefault(i, null);
                     Globals.Add(ObjectTree.GetDreamValueFromJsonElement(globalValue));
                 }
             }

--- a/OpenDreamShared/Json/DreamCompiledJson.cs
+++ b/OpenDreamShared/Json/DreamCompiledJson.cs
@@ -3,7 +3,7 @@
 namespace OpenDreamShared.Json {
     public class DreamCompiledJson {
         public List<string> Strings { get; set; }
-        public List<object> Globals { get; set; }
+        public GlobalListJson Globals { get; set; }
         public ProcDefinitionJson GlobalInitProc { get; set; }
         public List<DreamMapJson> Maps { get; set; }
         public string Interface { get; set; }

--- a/OpenDreamShared/Json/DreamObjectJson.cs
+++ b/OpenDreamShared/Json/DreamObjectJson.cs
@@ -18,8 +18,13 @@ namespace OpenDreamShared.Json {
         public List<int> Children { get; set; }
     }
 
-    public class ProcDefinitionJson
+    public class GlobalListJson
     {
+        public int GlobalCount { get; set; }
+        public Dictionary<int, object> Globals { get; set; }
+    }
+
+    public class ProcDefinitionJson {
         public bool? WaitFor { get; set; }
         public int MaxStackSize { get; set; }
         public List<ProcArgumentJson> Arguments { get; set; }


### PR DESCRIPTION
Fixes issue #536

Example from tgstation:
![image](https://user-images.githubusercontent.com/318789/146644337-519566d7-8de3-403e-8626-c705a4262bf8.png)
