### PR TITLE
Fix TryParseColor() not supporting hex colors without #

### DIFF
--- a/OpenDreamShared/Dream/ColorHelpers.cs
+++ b/OpenDreamShared/Dream/ColorHelpers.cs
@@ -29,21 +29,24 @@ namespace OpenDreamShared.Dream
             { "cyan", new Color(0, 255, 255) }
         };
 
-        public static bool TryParseColor(string color, out Color colorOut, string defaultAlpha = "ff") {
-            if (color.StartsWith("#")) {
-                if (color.Length == 4 || color.Length == 5) { //4-bit color; repeat each digit
-                    string alphaComponent = (color.Length == 5) ? new string(color[4], 2) : defaultAlpha;
+        public static bool TryParseColor(string color, out Color colorOut, string defaultAlpha = "ff")
+        {
+            if (Colors.TryGetValue(color.ToLower(), out colorOut)) return true;
 
-                    color = new string(color[1], 2) + new string(color[2], 2) + new string(color[3], 2) + alphaComponent;
-                } else if (color.Length == 7) { //Missing alpha
-                    color += "ff";
-                }
+            if (!color.StartsWith("#")) color = "#" + color;
 
-                colorOut = Color.FromHex(color, Color.White);
-                return true;
+            if (color.Length == 4 || color.Length == 5) { //4-bit color; repeat each digit
+                string alphaComponent = (color.Length == 5) ? new string(color[4], 2) : defaultAlpha;
+
+                color = new string(color[1], 2) + new string(color[2], 2) + new string(color[3], 2) + alphaComponent;
+            } else if (color.Length == 7) { //Missing alpha
+                color += "ff";
+            } else {
+                return false;
             }
 
-            return Colors.TryGetValue(color.ToLower(), out colorOut);
+            colorOut = Color.FromHex(color, Color.White);
+            return true;
         }
     }
 }


### PR DESCRIPTION
There's actually a single case of `FF0000` in NTstation and it was causing an exception.

The diffs look messy but the only real changes are checking the `Colors` list first and then prefixing the color string with `#` if it isn't already. I could remove it from the start but then I'd have to go change all of the values and test it more thoroughly.