### PR TITLE
Makes `range()` and `orange()` unordered

### DIFF
--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -133,7 +133,7 @@ proc/block(var/atom/Start, var/atom/End)
 
 	return atoms
 
-// TODO: Investigate "for(var/turf/T in range(Dist, Center))"-style weirdness that BYOND does
+// TODO: Investigate "for(var/turf/T in range(Dist, Center))"-style weirdness that BYOND does. It's a center-out spiral and we need to replicate that.
 proc/range(Dist, Center)
 	. = list()
 

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -150,6 +150,9 @@ proc/range(Dist, Center)
 			TrueCenter = Center
 		if(isnull(TrueCenter))
 			return
+		if(TrueCenter != usr && !istype(Center, /atom))
+			. += Center
+			return
 		TrueDist = Dist
 	else
 		if(isnull(Center))
@@ -163,6 +166,10 @@ proc/range(Dist, Center)
 		if(isnull(TrueCenter))
 			return
 		TrueDist = Center
+
+	if(!istype(TrueCenter, /atom))
+		. += TrueCenter
+		return
 
 	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)
 		for (var/y = TrueCenter.y - TrueDist; y <= TrueCenter.y + TrueDist; y++)
@@ -201,6 +208,10 @@ proc/orange(Dist, Center)
 		if(isnull(TrueCenter))
 			return
 		TrueDist = Center
+
+	if(!istype(TrueCenter, /atom))
+		. += TrueCenter
+		return
 
 	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)
 		for (var/y = TrueCenter.y - TrueDist; y <= TrueCenter.y + TrueDist; y++)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -146,10 +146,10 @@ proc/range(Dist, Center)
 			return
 		if(isnull(Center))
 			TrueCenter = usr
+			if(isnull(TrueCenter))
+				return
 		else
 			TrueCenter = Center
-		if(isnull(TrueCenter))
-			return
 		if(TrueCenter != usr && !istype(Center, /atom))
 			. += Center
 			return

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -151,10 +151,10 @@ proc/range(Dist, Center)
 			return
 		TrueDist = Dist
 	else
-		if(!isnum(Center))
-			CRASH("invalid view size")
 		if(isnull(Center))
 			return
+		if(!isnum(Center))
+			CRASH("invalid view size")
 		if(isnull(Dist))
 			TrueCenter = usr
 		else
@@ -189,10 +189,10 @@ proc/orange(Dist, Center)
 			return
 		TrueDist = Dist
 	else
-		if(!isnum(Center))
-			CRASH("invalid view size")
 		if(isnull(Center))
 			return
+		if(!isnum(Center))
+			CRASH("invalid view size")
 		if(isnull(Dist))
 			TrueCenter = usr
 		else

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -161,10 +161,10 @@ proc/range(Dist, Center)
 			CRASH("invalid view size")
 		if(isnull(Dist))
 			TrueCenter = usr
+			if(isnull(TrueCenter))
+				return
 		else
 			TrueCenter = Dist
-		if(isnull(TrueCenter))
-			return
 		TrueDist = Center
 
 	if(!istype(TrueCenter, /atom))

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -150,29 +150,33 @@ proc/range(Dist, Center)
 				return
 		else
 			TrueCenter = Center
-		if(TrueCenter != usr && !istype(Center, /atom))
-			. += Center
-			return
 		TrueDist = Dist
 	else
 		if(isnull(Center))
-			return
-		if(!isnum(Center))
-			CRASH("invalid view size")
-		if(isnull(Dist))
-			TrueCenter = usr
-			if(isnull(TrueCenter))
+			var/atom/A = Dist
+			if(istype(A))
+				//TODO change this once spiralling is implemented
+				TrueCenter = locate(1, 1, A.z)
+				TrueDist = world.maxx > world.maxy ? world.maxx : world.maxy
+			else
 				return
 		else
-			TrueCenter = Dist
-		TrueDist = Center
+			if(!isnum(Center))
+				CRASH("invalid view size")
+			if(isnull(Dist))
+				TrueCenter = usr
+				if(isnull(TrueCenter))
+					return
+			else
+				TrueCenter = Dist
+			TrueDist = Center
 
 	if(!istype(TrueCenter, /atom))
 		. += TrueCenter
 		return
 
-	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)
-		for (var/y = TrueCenter.y - TrueDist; y <= TrueCenter.y + TrueDist; y++)
+	for (var/x = max(TrueCenter.x - TrueDist, 1); x <= min(TrueCenter.x + TrueDist, world.maxx); x++)
+		for (var/y = max(TrueCenter.y - TrueDist, 1); y <= min(TrueCenter.y + TrueDist, world.maxy); y++)
 			var/turf/t = locate(x, y, TrueCenter.z)
 
 			if (t != null)
@@ -198,23 +202,30 @@ proc/orange(Dist, Center)
 		TrueDist = Dist
 	else
 		if(isnull(Center))
-			return
-		if(!isnum(Center))
-			CRASH("invalid view size")
-		if(isnull(Dist))
-			TrueCenter = usr
-			if(isnull(TrueCenter))
+			var/atom/A = Dist
+			if(istype(A))
+				//TODO change this once spiralling is implemented
+				TrueCenter = locate(1, 1, A.z)
+				TrueDist = world.maxx > world.maxy ? world.maxx : world.maxy
+			else
 				return
 		else
-			TrueCenter = Dist
-		TrueDist = Center
+			if(!isnum(Center))
+				CRASH("invalid view size")
+			if(isnull(Dist))
+				TrueCenter = usr
+				if(isnull(TrueCenter))
+					return
+			else
+				TrueCenter = Dist
+			TrueDist = Center
 
 	if(!istype(TrueCenter, /atom))
 		. += TrueCenter
 		return
 
-	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)
-		for (var/y = TrueCenter.y - TrueDist; y <= TrueCenter.y + TrueDist; y++)
+	for (var/x = max(TrueCenter.x - TrueDist, 1); x <= min(TrueCenter.x + TrueDist, world.maxx); x++)
+		for (var/y = max(TrueCenter.y - TrueDist, 1); y <= min(TrueCenter.y + TrueDist, world.maxy); y++)
 			if (x == TrueCenter.x && y == TrueCenter.y) continue
 
 			var/turf/t = locate(x, y, TrueCenter.z)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -133,6 +133,7 @@ proc/block(var/atom/Start, var/atom/End)
 
 	return atoms
 
+// TODO: Investigate "for(var/turf/T in range(Dist, Center))"-style weirdness that BYOND does
 proc/range(Dist, Center)
 	. = list()
 

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -151,6 +151,8 @@ proc/range(Dist, Center)
 			return
 		TrueDist = Dist
 	else
+		if(!isnum(Center))
+			CRASH("invalid view size")
 		if(isnull(Center))
 			return
 		if(isnull(Dist))
@@ -159,8 +161,6 @@ proc/range(Dist, Center)
 			TrueCenter = Dist
 		if(isnull(TrueCenter))
 			return
-		if(!isnum(Center))
-			CRASH("invalid view size")
 		TrueDist = Center
 
 	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)
@@ -189,6 +189,8 @@ proc/orange(Dist, Center)
 			return
 		TrueDist = Dist
 	else
+		if(!isnum(Center))
+			CRASH("invalid view size")
 		if(isnull(Center))
 			return
 		if(isnull(Dist))
@@ -197,8 +199,6 @@ proc/orange(Dist, Center)
 			TrueCenter = Dist
 		if(isnull(TrueCenter))
 			return
-		if(!isnum(Center))
-			CRASH("invalid view size")
 		TrueDist = Center
 
 	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -191,10 +191,10 @@ proc/orange(Dist, Center)
 			return
 		if(isnull(Center))
 			TrueCenter = usr
+			if(isnull(TrueCenter))
+				return
 		else
 			TrueCenter = Center
-		if(isnull(TrueCenter))
-			return
 		TrueDist = Dist
 	else
 		if(isnull(Center))

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -133,29 +133,79 @@ proc/block(var/atom/Start, var/atom/End)
 
 	return atoms
 
-proc/range(Dist, atom/Center = usr)
+proc/range(Dist, Center)
 	. = list()
 
-	if (isnull(Center)) return
+	var/TrueDist
+	var/atom/TrueCenter
 
-	for (var/x = Center.x - Dist; x <= Center.x + Dist; x++)
-		for (var/y = Center.y - Dist; y <= Center.y + Dist; y++)
-			var/turf/t = locate(x, y, Center.z)
+	if(isnum(Dist))
+		if(isnum(Center))
+			. += Center
+			return
+		if(isnull(Center))
+			TrueCenter = usr
+		else
+			TrueCenter = Center
+		if(isnull(TrueCenter))
+			return
+		TrueDist = Dist
+	else
+		if(isnull(Center))
+			return
+		if(isnull(Dist))
+			TrueCenter = usr
+		else
+			TrueCenter = Dist
+		if(isnull(TrueCenter))
+			return
+		if(!isnum(Center))
+			CRASH("invalid view size")
+		TrueDist = Center
+
+	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)
+		for (var/y = TrueCenter.y - TrueDist; y <= TrueCenter.y + TrueDist; y++)
+			var/turf/t = locate(x, y, TrueCenter.z)
 
 			if (t != null)
 				. += t
 				. += t.contents
 
-proc/orange(Dist = 5, var/atom/Center = usr)
+proc/orange(Dist, Center)
 	. = list()
 
-	if (isnull(Center)) return
+	var/TrueDist
+	var/atom/TrueCenter
 
-	for (var/x = Center.x - Dist; x <= Center.x + Dist; x++)
-		for (var/y = Center.y - Dist; y <= Center.y + Dist; y++)
-			if (x == Center.x && y == Center.y) continue
+	if(isnum(Dist))
+		if(isnum(Center))
+			. += Center
+			return
+		if(isnull(Center))
+			TrueCenter = usr
+		else
+			TrueCenter = Center
+		if(isnull(TrueCenter))
+			return
+		TrueDist = Dist
+	else
+		if(isnull(Center))
+			return
+		if(isnull(Dist))
+			TrueCenter = usr
+		else
+			TrueCenter = Dist
+		if(isnull(TrueCenter))
+			return
+		if(!isnum(Center))
+			CRASH("invalid view size")
+		TrueDist = Center
 
-			var/turf/t = locate(x, y, Center.z)
+	for (var/x = TrueCenter.x - TrueDist; x <= TrueCenter.x + TrueDist; x++)
+		for (var/y = TrueCenter.y - TrueDist; y <= TrueCenter.y + TrueDist; y++)
+			if (x == TrueCenter.x && y == TrueCenter.y) continue
+
+			var/turf/t = locate(x, y, TrueCenter.z)
 			if (t != null)
 				. += t
 				. += t.contents

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -203,10 +203,10 @@ proc/orange(Dist, Center)
 			CRASH("invalid view size")
 		if(isnull(Dist))
 			TrueCenter = usr
+			if(isnull(TrueCenter))
+				return
 		else
 			TrueCenter = Dist
-		if(isnull(TrueCenter))
-			return
 		TrueDist = Center
 
 	if(!istype(TrueCenter, /atom))


### PR DESCRIPTION
For some crazy reason the args are unordered, as stated in the docs.

I also think I improved the handling for bad args to more closely replicate BYOND.

Fixes #547 