### PR TITLE
Fixes a few exceptions

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -22,7 +22,7 @@ namespace OpenDreamRuntime {
         public EntityUid CreateAtomEntity(DreamObject atom) {
             EntityUid entity = _entityManager.SpawnEntity(null, new MapCoordinates(0, 0, MapId.Nullspace));
 
-            
+
             DMISpriteComponent sprite = _entityManager.AddComponent<DMISpriteComponent>(entity);
             sprite.Appearance = CreateAppearanceFromAtom(atom);
 
@@ -31,8 +31,9 @@ namespace OpenDreamRuntime {
             return entity;
         }
 
-        public EntityUid GetAtomEntity(DreamObject atom) {
-            return _atomToEntity[atom];
+        public EntityUid GetAtomEntity(DreamObject atom)
+        {
+            return _atomToEntity.ContainsKey(atom) ? _atomToEntity[atom] : CreateAtomEntity(atom);
         }
 
         public DreamObject GetAtomFromEntity(EntityUid entity) {

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -139,21 +139,25 @@ namespace OpenDreamRuntime {
                 DreamPath areaType = cellDefinition.Area != null ? _dreamManager.ObjectTree.Types[cellDefinition.Area.Type].Path : _defaultArea;
                 DreamObject area = GetArea(areaType);
 
-                DreamObject turf;
-                if (cellDefinition.Turf != null) {
-                    turf = CreateMapObject(cellDefinition.Turf);
-                } else {
-                    turf = _dreamManager.ObjectTree.CreateObject(_defaultTurf);
-                    turf.InitSpawn(new DreamProcArguments(null));
-                }
-
                 int x = block.X + blockX - 1;
                 int y = block.Y + block.Height - blockY;
 
-                SetTurf(x, y, block.Z, turf);
-                SetArea(x, y, block.Z, area);
+                DreamObject turf;
+                if (cellDefinition.Turf != null) {
+                    turf = CreateMapObject(cellDefinition.Turf);
+                    SetTurf(x, y, block.Z, turf);
+                    SetArea(x, y, block.Z, area);
+                    turf.InitSpawn(new DreamProcArguments(new() {DreamValue.Null}));
+                } else {
+                    turf = _dreamManager.ObjectTree.CreateObject(_defaultTurf);
+                    SetTurf(x, y, block.Z, turf);
+                    SetArea(x, y, block.Z, area);
+                    turf.InitSpawn(new DreamProcArguments(null));
+                }
+
                 foreach (MapObjectJson mapObject in cellDefinition.Objects) {
-                    CreateMapObject(mapObject, turf);
+                    var obj = CreateMapObject(mapObject);
+                    obj.InitSpawn(new DreamProcArguments(new() { new DreamValue(turf) }));
                 }
 
                 blockX++;
@@ -164,7 +168,7 @@ namespace OpenDreamRuntime {
             }
         }
 
-        private DreamObject CreateMapObject(MapObjectJson mapObject, DreamObject loc = null) {
+        private DreamObject CreateMapObject(MapObjectJson mapObject) {
             DreamObjectDefinition definition = _dreamManager.ObjectTree.GetObjectDefinition(mapObject.Type);
             if (mapObject.VarOverrides?.Count > 0) {
                 definition = new DreamObjectDefinition(definition);
@@ -176,9 +180,7 @@ namespace OpenDreamRuntime {
                 }
             }
 
-            var obj = new DreamObject(definition);
-            obj.InitSpawn(new DreamProcArguments(new() { new DreamValue(loc) }));
-            return obj;
+            return new DreamObject(definition);
         }
     }
 }

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -145,15 +145,14 @@ namespace OpenDreamRuntime {
                 DreamObject turf;
                 if (cellDefinition.Turf != null) {
                     turf = CreateMapObject(cellDefinition.Turf);
-                    SetTurf(x, y, block.Z, turf);
-                    SetArea(x, y, block.Z, area);
-                    turf.InitSpawn(new DreamProcArguments(new() {DreamValue.Null}));
                 } else {
                     turf = _dreamManager.ObjectTree.CreateObject(_defaultTurf);
-                    SetTurf(x, y, block.Z, turf);
-                    SetArea(x, y, block.Z, area);
-                    turf.InitSpawn(new DreamProcArguments(null));
                 }
+                
+                SetTurf(x, y, block.Z, turf);
+                SetArea(x, y, block.Z, area);
+                turf.InitSpawn(new DreamProcArguments(null));
+                    
 
                 foreach (MapObjectJson mapObject in cellDefinition.Objects) {
                     var obj = CreateMapObject(mapObject);

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -95,11 +95,22 @@ namespace OpenDreamRuntime.Objects {
             return false;
         }
 
+        /// <summary>
+        /// Handles setting a variable, and special behavior by calling OnVariableSet()
+        /// </summary>
         public void SetVariable(string name, DreamValue value) {
-            DreamValue oldValue = _variables.ContainsKey(name) ? _variables[name] : ObjectDefinition.Variables[name];
-
-            _variables[name] = value;
+            var oldValue = SetVariableValue(name, value);
             if (ObjectDefinition.MetaObject != null) ObjectDefinition.MetaObject.OnVariableSet(this, name, value, oldValue);
+        }
+
+        /// <summary>
+        /// Directly sets a variable's value, bypassing any special behavior
+        /// </summary>
+        /// <returns>The OLD variable value</returns>
+        public DreamValue SetVariableValue(string name, DreamValue value) {
+            DreamValue oldValue = _variables.ContainsKey(name) ? _variables[name] : ObjectDefinition.Variables[name];
+            _variables[name] = value;
+            return oldValue;
         }
 
         public DreamProc GetProc(string procName) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -71,7 +71,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     });
                     break;
                 case "invisibility":
-                    var vis = variableValue.TryGetValueAsFloat(out var val) ? Convert.ToInt32(Math.Floor(val)) : 0;
+                    variableValue.TryGetValueAsInteger(out int vis);
                     UpdateAppearance(dreamObject, appearance => {
                         appearance.Invisibility = vis;
                     });

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -71,9 +71,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     });
                     break;
                 case "invisibility":
+                    var vis = variableValue.TryGetValueAsFloat(out var val) ? Convert.ToInt32(Math.Floor(val)) : 0;
                     UpdateAppearance(dreamObject, appearance => {
-                        appearance.Invisibility = variableValue.GetValueAsInteger();
+                        appearance.Invisibility = vis;
                     });
+                    dreamObject.SetVariableValue("invisibility", new DreamValue(vis));
                     break;
                 case "mouse_opacity":
                     UpdateAppearance(dreamObject, appearance => {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -467,7 +467,7 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public static ProcStatus? PushSrc(DMProcState state) {
-            state.Push(new DreamValue(state.Instance));
+            state.Push(new DreamProcIdentifierSrc(state));
             return null;
         }
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -135,7 +135,7 @@ namespace OpenDreamRuntime.Procs {
         #endregion
 
         public IDreamManager DreamManager = IoCManager.Resolve<IDreamManager>();
-        public readonly DreamObject Instance;
+        public DreamObject Instance;
         public readonly DreamObject Usr;
         public readonly DreamProcArguments Arguments;
         public readonly DreamValue[] LocalVariables;
@@ -276,18 +276,7 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public IDreamProcIdentifier PeekIdentifier() {
-
-            var peek = Peek();
-            if (peek is IDreamProcIdentifier) return (IDreamProcIdentifier) peek;
-
-            // TODO: This is an awful hack to bandaid setting src
-            var val = (DreamValue)peek;
-            if (!val.TryGetValueAsDreamObject(out var obj) || !obj.IsSubtypeOf(Instance.ObjectDefinition.Type))
-            {
-                throw new Exception("Tried to peek something that is not an identifier or src");
-            }
-
-            return (IDreamProcIdentifier)_stack[_stackIndex];
+            return (IDreamProcIdentifier)Peek();
         }
 
         public IDreamProcIdentifier PopIdentifier() {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -276,7 +276,18 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public IDreamProcIdentifier PeekIdentifier() {
-            return (IDreamProcIdentifier)Peek();
+
+            var peek = Peek();
+            if (peek is IDreamProcIdentifier) return (IDreamProcIdentifier) peek;
+
+            // TODO: This is an awful hack to bandaid setting src
+            var val = (DreamValue)peek;
+            if (!val.TryGetValueAsDreamObject(out var obj) || !obj.IsSubtypeOf(Instance.ObjectDefinition.Type))
+            {
+                throw new Exception("Tried to peek something that is not an identifier or src");
+            }
+
+            return (IDreamProcIdentifier)_stack[_stackIndex];
         }
 
         public IDreamProcIdentifier PopIdentifier() {

--- a/OpenDreamRuntime/Procs/DreamProcIdentifier.cs
+++ b/OpenDreamRuntime/Procs/DreamProcIdentifier.cs
@@ -129,6 +129,29 @@ namespace OpenDreamRuntime.Procs {
         }
     }
 
+    struct DreamProcIdentifierSrc : IDreamProcIdentifier {
+        public DMProcState State;
+
+        public DreamProcIdentifierSrc(DMProcState state) {
+            State = state;
+        }
+
+        public DreamValue GetValue() {
+            return new DreamValue(State.Instance);
+        }
+
+        public void Assign(DreamValue value) {
+            if (value.TryGetValueAsDreamObject(out var obj))
+            {
+                State.Instance = obj;
+            }
+            else
+            {
+                throw new NotImplementedException("src can only be set to a DreamObject currently");
+            }
+        }
+    }
+
     struct DreamProcIdentifierNull : IDreamProcIdentifier {
         public DreamValue GetValue() {
             return DreamValue.Null;


### PR DESCRIPTION
Does a few things:
1. Makes sure a turf's loc is set before init to fix issues in New()
2. Adds the ability to modify an actual variable value. Fixes (partially) #556
3. Made Atom's OnVariableSet() a switch
4. `src` can be set to a DreamObject. Fixes #557