### PR TITLE
Makes `spawn()` and `sleep()` actually yield

### DIFF
--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -1352,7 +1352,11 @@ namespace OpenDreamRuntime.Procs {
                 // Does the value of the delay mean anything?
             } else {
                 new Task(async () => {
-                    await Task.Delay(delayMilliseconds);
+                    if (delayMilliseconds != 0) {
+                        await Task.Delay(delayMilliseconds);
+                    } else {
+                        await Task.Yield();
+                    }
                     newContext.Resume();
                 }).Start(TaskScheduler.FromCurrentSynchronizationContext());
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1271,7 +1271,7 @@ namespace OpenDreamRuntime.Procs.Native {
             float delay = state.Arguments.GetArgument(0, "Delay").GetValueAsFloat();
             int delayMilliseconds = (int)(delay * 100);
 
-            // TODO: This is may not be the proper behaviour, see https://www.byond.com/docs/ref/#/proc/sleep
+            // TODO: This may not be the proper behaviour, see https://www.byond.com/docs/ref/#/proc/sleep
             // sleep(0) should sleep for the minimum amount of time possible, whereas
             // sleep called with a negative value should do a backlog check, meaning it only sleeps
             // when other events are backlogged

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1271,12 +1271,14 @@ namespace OpenDreamRuntime.Procs.Native {
             float delay = state.Arguments.GetArgument(0, "Delay").GetValueAsFloat();
             int delayMilliseconds = (int)(delay * 100);
 
-            // TODO: This is obviously not the proper behaviour, see https://www.byond.com/docs/ref/#/proc/sleep
+            // TODO: This is may not be the proper behaviour, see https://www.byond.com/docs/ref/#/proc/sleep
             // sleep(0) should sleep for the minimum amount of time possible, whereas
             // sleep called with a negative value should do a backlog check, meaning it only sleeps
             // when other events are backlogged
             if (delayMilliseconds > 0) {
                 await Task.Delay(delayMilliseconds);
+            } else {
+                await Task.Yield();
             }
             return DreamValue.Null;
         }

--- a/OpenDreamServer/server_config.toml
+++ b/OpenDreamServer/server_config.toml
@@ -34,3 +34,10 @@ loginlocal = true
 [opendream]
 # The path to DMCompiler's output
 json_path = ""
+
+# These are actually client cvars that, currently, have to be passed as program args.
+# Documented here in hopes that we'll have a client_config.toml without using the launcher one day
+# [net]
+# connection_timeout = 300.0
+# handshake_interval = 60.0
+# handshake_attempts = 5


### PR DESCRIPTION
This partially addresses https://github.com/wixoaGit/OpenDream/issues/447 but not to the point where I'd call it fixed.

It also fixes #560 

At the moment you need to either get lucky with your connect attempt lining up with sufficient yielding, or pass the *client* each of the cvars in `server_config.toml` like you pass the json to the server. I'm going to ask around in SS14 Discord about the possibility of adding a `client_config.toml` for use when not using the launcher.