### PR TITLE
Fixes setting list.len to non-numbers

### DIFF
--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
@@ -15,7 +15,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
             if (variableName == "len") {
                 DreamList list = (DreamList)dreamObject;
-                int newLen = variableValue.GetValueAsInteger();
+                variableValue.TryGetValueAsInteger(out var newLen);
 
                 list.Resize(newLen);
             }


### PR DESCRIPTION
The default behavior is to set it to 0 if it's not a number.