### PR TITLE
Retain _currentPath proc elements in DMParser

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -143,7 +143,6 @@ namespace DMCompiler.Compiler.DM {
                 DreamPath oldPath = _currentPath;
                 Whitespace();
                 _currentPath = _currentPath.Combine(path.Path);
-                if (_currentPath.LastElement == "proc") _currentPath = _currentPath.RemoveElement(-1);
 
                 try {
                     DMASTStatement statement = null;


### PR DESCRIPTION
This was causing the AST to mark procs defined like:

```
proc 
    Fn1()
    Fn2()
```

as overrides