### PR TITLE
Fix some issues with appearances and client images

### DIFF
--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -1,4 +1,4 @@
-﻿using OpenDreamRuntime.Procs;
+using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
@@ -233,7 +233,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     appearance.SetColor("white");
                 }
 
-                appearance.IconState = mutableAppearance.GetVariable("icon_state").GetValueAsString();
+                appearance.IconState = mutableAppearance.GetVariable("icon_state").TryGetValueAsString(out var iconState) ? iconState : null;
                 appearance.Layer = mutableAppearance.GetVariable("layer").GetValueAsFloat();
                 appearance.PixelOffset.X = mutableAppearance.GetVariable("pixel_x").GetValueAsInteger();
                 appearance.PixelOffset.Y = mutableAppearance.GetVariable("pixel_y").GetValueAsInteger();
@@ -244,11 +244,14 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 if (icon.TryGetValueAsDreamResource(out DreamResource iconResource)) {
                     appearance.Icon = iconResource.ResourcePath;
                 } else {
-                    appearance.Icon = icon.GetValueAsString();
+                    appearance.Icon = icon.TryGetValueAsString(out var iconString) ? iconString : null;
                 }
 
                 if (iconState.TryGetValueAsString(out string iconStateString)) appearance.IconState = iconStateString;
-                appearance.SetColor(image.GetVariable("color").GetValueAsString());
+                var color = image.GetVariable("color").TryGetValueAsString(out var colorString)
+                    ? colorString
+                    : "#FFFFFF"; // Defaults to white
+                appearance.SetColor(color);
                 appearance.Direction = (AtomDirection)image.GetVariable("dir").GetValueAsInteger();
                 appearance.Layer = image.GetVariable("layer").GetValueAsFloat();
                 appearance.PixelOffset.X = image.GetVariable("pixel_x").GetValueAsInteger();

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -1,4 +1,4 @@
-﻿using OpenDreamRuntime.Procs;
+using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Shared.GameObjects;
@@ -62,6 +62,21 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     screenList.ValueAssigned += ScreenValueAssigned;
                     screenList.BeforeValueRemoved += ScreenBeforeValueRemoved;
                     _screenListToClient[screenList] = dreamObject;
+                    break;
+                }
+                case "images":
+                {
+                    //TODO properly implement this var
+                    if (oldVariableValue.TryGetValueAsDreamList(out DreamList oldList)) {
+                        oldList.Cut();
+                    }
+
+                    DreamList imageList;
+                    if (!variableValue.TryGetValueAsDreamList(out imageList)) {
+                        imageList = DreamList.Create();
+                    }
+
+                    dreamObject.SetVariableValue(variableName, new DreamValue(imageList));
                     break;
                 }
                 case "statpanel": {


### PR DESCRIPTION
1. Fixes setting `client.images` to a non-list. It'll probably need to be tweaked when the var is actually implemented.
2. Made `CreateOverlayAppearance()` better at coping with unexpected value types.