### PR TITLE
Make bad ..() calls a warning instead of an error

### DIFF
--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -81,7 +81,7 @@ namespace DMCompiler.DM.Expressions {
         public override (DMReference Reference, bool Conditional) EmitReference(DMObject dmObject, DMProc proc) {
             if (!proc.IsOverride)
             {
-                throw new CompileErrorException(Location, "Cannot call parents via ..() in a proc definition");
+                DMCompiler.Warning(new CompilerWarning(Location, "Cannot call parents via ..() in a proc definition"));
             }
             return (DMReference.SuperProc, false);
         }

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -81,7 +81,7 @@ namespace DMCompiler.DM.Expressions {
         public override (DMReference Reference, bool Conditional) EmitReference(DMObject dmObject, DMProc proc) {
             if (!proc.IsOverride)
             {
-                DMCompiler.Warning(new CompilerWarning(Location, "Cannot call parents via ..() in a proc definition"));
+                DMCompiler.Warning(new CompilerWarning(Location, "Calling parents via ..() in a proc definition does nothing"));
             }
             return (DMReference.SuperProc, false);
         }


### PR DESCRIPTION
Bad DM code has too much of this. If we ever make a clone of C# pragmas we could consider having it default as an error.