### PR TITLE
Adds support for calling initial() on a local var

### DIFF
--- a/DMCompiler/DM/Expressions/LValue.cs
+++ b/DMCompiler/DM/Expressions/LValue.cs
@@ -85,6 +85,12 @@ namespace DMCompiler.DM.Expressions {
             constant = null;
             return false;
         }
+
+        public override void EmitPushInitial(DMObject dmObject, DMProc proc) {
+            // This happens silently in BYOND
+            DMCompiler.Warning(new CompilerWarning(Location, "calling initial() on a local variable returns the current value"));
+            EmitPushValue(dmObject, proc);
+        }
     }
 
     // Identifier of field


### PR DESCRIPTION
Code:
```
/proc/wumbo(c = "c")
	var/b = 2
	world.log << initial(b)
	b = 3
	world.log << initial(b)
	world.log << initial(c)
	c = 5
	world.log << initial(c)
```

Compiler:
```
Compiling environment.dme
Warning at code.dm:10:25: calling initial() on a local variable returns the current value
Warning at code.dm:12:25: calling initial() on a local variable returns the current value
Warning at code.dm:13:25: calling initial() on a local variable returns the current value
Warning at code.dm:15:25: calling initial() on a local variable returns the current value
Compilation succeeded with 4 warnings
Saved to C:/Users/main/Documents/GitHub/OpenDream/OpenDream/TestGame/environment.json
Total time: 00:00
```

BYOND output:
![image](https://user-images.githubusercontent.com/5714543/153036276-49862941-0362-4dae-9e44-b174aae5a16b.png)

OD output:
```
[INFO] world.log: 2
[INFO] world.log: 3
[INFO] world.log: c
[INFO] world.log: 5
```