### PR TITLE
Marks `GetValueAs[Type]()` obsolete, removes some usages

### DIFF
--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -62,7 +62,7 @@ namespace OpenDreamRuntime {
                      worldDefinition.Variables["turf"].TryGetValueAsInteger(out var turfInt) && turfInt == 0)
             {
                 //TODO: Properly handle disabling default turf
-                _defaultTurf = new DreamPath("/turf");
+                _defaultTurf = DreamPath.Turf;
             }
             else
             {

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -45,7 +45,7 @@ namespace OpenDreamRuntime {
                      worldDefinition.Variables["area"].TryGetValueAsInteger(out var areaInt) && areaInt == 0)
             {
                 //TODO: Properly handle disabling default area
-                _defaultArea = new DreamPath("/area");
+                _defaultArea = DreamPath.Area;
             }
             else
             {

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -33,8 +33,41 @@ namespace OpenDreamRuntime {
             _mapManager.CreateNewMapEntity(MapId.Nullspace);
 
             DreamObjectDefinition worldDefinition = _dreamManager.ObjectTree.GetObjectDefinition(DreamPath.World);
-            _defaultArea = worldDefinition.Variables["area"].GetValueAsPath();
-            _defaultTurf = worldDefinition.Variables["turf"].GetValueAsPath();
+
+            // Default area
+            if (worldDefinition.Variables["area"].TryGetValueAsPath(out var area))
+            {
+                if(!area.IsDescendantOf(DreamPath.Area)) throw new Exception("bad area");
+                _defaultArea = area;
+
+            }
+            else if (worldDefinition.Variables["area"] == DreamValue.Null ||
+                     worldDefinition.Variables["area"].TryGetValueAsInteger(out var areaInt) && areaInt == 0)
+            {
+                //TODO: Properly handle disabling default area
+                _defaultArea = new DreamPath("/area");
+            }
+            else
+            {
+                throw new Exception("bad area");
+            }
+
+            //Default turf
+            if (worldDefinition.Variables["turf"].TryGetValueAsPath(out var turf))
+            {
+                if(!turf.IsDescendantOf(DreamPath.Turf)) throw new Exception("bad turf");
+                _defaultTurf = turf;
+            }
+            else if (worldDefinition.Variables["turf"] == DreamValue.Null ||
+                     worldDefinition.Variables["turf"].TryGetValueAsInteger(out var turfInt) && turfInt == 0)
+            {
+                //TODO: Properly handle disabling default turf
+                _defaultTurf = new DreamPath("/turf");
+            }
+            else
+            {
+                throw new Exception("bad turf");
+            }
         }
 
         public void LoadMaps(List<DreamMapJson> maps) {
@@ -148,11 +181,11 @@ namespace OpenDreamRuntime {
                 } else {
                     turf = _dreamManager.ObjectTree.CreateObject(_defaultTurf);
                 }
-                
+
                 SetTurf(x, y, block.Z, turf);
                 SetArea(x, y, block.Z, area);
                 turf.InitSpawn(new DreamProcArguments(null));
-                    
+
 
                 foreach (MapObjectJson mapObject in cellDefinition.Objects) {
                     var obj = CreateMapObject(mapObject);

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -37,7 +37,8 @@ namespace OpenDreamRuntime {
             // Default area
             if (worldDefinition.Variables["area"].TryGetValueAsPath(out var area))
             {
-                if(!area.IsDescendantOf(DreamPath.Area)) throw new Exception("bad area");
+
+                if(!_dreamManager.ObjectTree.GetObjectDefinition(area).IsSubtypeOf(DreamPath.Area)) throw new Exception("bad area");
                 _defaultArea = area;
 
             }
@@ -55,7 +56,7 @@ namespace OpenDreamRuntime {
             //Default turf
             if (worldDefinition.Variables["turf"].TryGetValueAsPath(out var turf))
             {
-                if(!turf.IsDescendantOf(DreamPath.Turf)) throw new Exception("bad turf");
+                if(!_dreamManager.ObjectTree.GetObjectDefinition(turf).IsSubtypeOf(DreamPath.Turf)) throw new Exception("bad turf");
                 _defaultTurf = turf;
             }
             else if (worldDefinition.Variables["turf"] == DreamValue.Null ||

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -95,7 +95,8 @@ namespace OpenDreamRuntime {
             return "DreamValue(" + Type + ", " + value + ")";
         }
 
-        public object GetValueExpectingType(DreamValueType type) {
+        [Obsolete("Deprecated. Use the relevant TryGetValueAs[Type]() instead.")]
+        private object GetValueExpectingType(DreamValueType type) {
             if (Type == type) {
                 return Value;
             }
@@ -103,6 +104,7 @@ namespace OpenDreamRuntime {
             throw new Exception("Value " + this + " was not the expected type of " + type + "");
         }
 
+        [Obsolete("Deprecated. Use TryGetValueAsString() instead.")]
         public string GetValueAsString() {
             return (string)GetValueExpectingType(DreamValueType.String);
         }
@@ -118,6 +120,7 @@ namespace OpenDreamRuntime {
         }
 
         //Casts a float value to an integer
+        [Obsolete("Deprecated. Use TryGetValueAsInteger() instead.")]
         public int GetValueAsInteger() {
             return (int)(float)GetValueExpectingType(DreamValueType.Float);
         }
@@ -132,6 +135,7 @@ namespace OpenDreamRuntime {
             }
         }
 
+        [Obsolete("Deprecated. Use TryGetValueAsFloat() instead.")]
         public float GetValueAsFloat() {
             return (float)GetValueExpectingType(DreamValueType.Float);
         }
@@ -146,6 +150,7 @@ namespace OpenDreamRuntime {
             }
         }
 
+        [Obsolete("Deprecated. Use TryGetValueAsDreamResource() instead.")]
         public DreamResource GetValueAsDreamResource() {
             return (DreamResource)GetValueExpectingType(DreamValueType.DreamResource);
         }
@@ -160,6 +165,7 @@ namespace OpenDreamRuntime {
             }
         }
 
+        [Obsolete("Deprecated. Use TryGetValueAsDreamObject() instead.")]
         public DreamObject GetValueAsDreamObject() {
             DreamObject dreamObject = (DreamObject)GetValueExpectingType(DreamValueType.DreamObject);
 
@@ -182,6 +188,7 @@ namespace OpenDreamRuntime {
             }
         }
 
+        [Obsolete("Deprecated. Use TryGetValueAsDreamObjectOfType() instead.")]
         public DreamObject GetValueAsDreamObjectOfType(DreamPath type) {
             DreamObject value = GetValueAsDreamObject();
 
@@ -196,6 +203,7 @@ namespace OpenDreamRuntime {
             return TryGetValueAsDreamObject(out dreamObject) && dreamObject != null && dreamObject.IsSubtypeOf(type);
         }
 
+        [Obsolete("Deprecated. Use TryGetValueAsDreamList() instead.")]
         public DreamList GetValueAsDreamList() {
             return (DreamList)GetValueAsDreamObject();
         }
@@ -212,6 +220,7 @@ namespace OpenDreamRuntime {
             }
         }
 
+        [Obsolete("Deprecated. Use TryGetValueAsPath() instead.")]
         public DreamPath GetValueAsPath() {
             return (DreamPath)GetValueExpectingType(DreamValueType.DreamPath);
         }
@@ -226,10 +235,6 @@ namespace OpenDreamRuntime {
 
                 return false;
             }
-        }
-
-        public DreamProc GetValueAsProc() {
-            return (DreamProc)GetValueExpectingType(DreamValueType.DreamProc);
         }
 
         public bool TryGetValueAsProc(out DreamProc proc) {
@@ -265,17 +270,21 @@ namespace OpenDreamRuntime {
         public string Stringify() {
             switch (Type) {
                 case DreamValueType.String:
-                    return GetValueAsString();
+                    TryGetValueAsString(out var stringString);
+                    return stringString;
                 case DreamValueType.Float:
-                    return GetValueAsFloat().ToString();
+                    TryGetValueAsFloat(out var floatString);
+                    return floatString.ToString();
                 case DreamValueType.DreamResource:
-                    return GetValueAsDreamResource().ResourcePath;
+                    TryGetValueAsDreamResource(out var rscPath);
+                    return rscPath.ResourcePath;
                 case DreamValueType.DreamPath:
-                    return GetValueAsPath().PathString;
+                    TryGetValueAsPath(out var path);
+                    return path.PathString;
                 case DreamValueType.DreamObject when Value == null:
                     return "";
                 case DreamValueType.DreamObject: {
-                    DreamObject dreamObject = GetValueAsDreamObject();
+                    TryGetValueAsDreamObject(out var dreamObject);
 
                     if (dreamObject.IsSubtypeOf(DreamPath.Atom)) {
                         return dreamObject.GetVariable("name").Stringify();

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -195,13 +195,20 @@ namespace OpenDreamRuntime.Objects {
 
         public override DreamValue GetValue(DreamValue key)
         {
-            key.TryGetValueAsString(out var val);
+            if (!key.TryGetValueAsString(out var val))
+            {
+                throw new Exception("Tried to get invalid key");
+            }
             return _dreamObject.GetVariable(val);
         }
 
         public override void SetValue(DreamValue key, DreamValue value) {
-            if (!key.TryGetValueAsString(out var varName) || _dreamObject.HasVariable(varName)) {
+            if (key.TryGetValueAsString(out var varName) && _dreamObject.HasVariable(varName)) {
                 _dreamObject.SetVariable(varName, value);
+            }
+            else
+            {
+                throw new Exception("Tried to set invalid key");
             }
         }
     }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -193,14 +193,14 @@ namespace OpenDreamRuntime.Objects {
             return _dreamObject.GetVariableNames();
         }
 
-        public override DreamValue GetValue(DreamValue key) {
-            return _dreamObject.GetVariable(key.GetValueAsString());
+        public override DreamValue GetValue(DreamValue key)
+        {
+            key.TryGetValueAsString(out var val);
+            return _dreamObject.GetVariable(val);
         }
 
         public override void SetValue(DreamValue key, DreamValue value) {
-            string varName = key.GetValueAsString();
-
-            if (_dreamObject.HasVariable(varName)) {
+            if (!key.TryGetValueAsString(out var varName) || _dreamObject.HasVariable(varName)) {
                 _dreamObject.SetVariable(varName, value);
             }
         }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -77,7 +77,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 case "pixel_y":
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
-                        appearance.PixelOffset.Y = variableValue.TryGetValueAsInteger(out var pixelY) ? pixelY : 0;
+                        variableValue.TryGetValueAsInteger(out appearance.PixelOffset.Y);
                     });
                     break;
                 case "layer":

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -82,7 +82,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 case "layer":
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
-                        appearance.Layer = variableValue.TryGetValueAsFloat(out var layer) ? layer : 0;
+                        variableValue.TryGetValueAsFloat(out appearance.Layer);
                     });
                     break;
                 case "invisibility":

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -86,14 +86,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     });
                     break;
                 case "invisibility":
-                    if (!variableValue.TryGetValueAsInteger(out int vis))
-                    {
-                        vis = 0;
-                    }
-                    else
-                    {
-                        Math.Clamp(vis, -127, 127); // DM ref says [0, 101]. BYOND compiler says [-127, 127]
-                    }
+                    variableValue.TryGetValueAsInteger(out int vis);
+                    vis = Math.Clamp(vis, -127, 127); // DM ref says [0, 101]. BYOND compiler says [-127, 127]
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
                         appearance.Invisibility = vis;
                     });

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -75,21 +75,28 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 case "pixel_x":
                     UpdateAppearance(dreamObject, appearance => {
-                        appearance.PixelOffset.X = variableValue.GetValueAsInteger();
+                        appearance.PixelOffset.X = variableValue.TryGetValueAsInteger(out var pixelX) ? pixelX : 0;
                     });
                     break;
                 case "pixel_y":
                     UpdateAppearance(dreamObject, appearance => {
-                        appearance.PixelOffset.Y = variableValue.GetValueAsInteger();
+                        appearance.PixelOffset.Y = variableValue.TryGetValueAsInteger(out var pixelY) ? pixelY : 0;
                     });
                     break;
                 case "layer":
                     UpdateAppearance(dreamObject, appearance => {
-                        appearance.Layer = variableValue.GetValueAsFloat();
+                        appearance.Layer = variableValue.TryGetValueAsFloat(out var layer) ? layer : 0;
                     });
                     break;
                 case "invisibility":
-                    variableValue.TryGetValueAsInteger(out int vis);
+                    if (!variableValue.TryGetValueAsInteger(out int vis))
+                    {
+                        vis = 0;
+                    }
+                    else
+                    {
+                        Math.Clamp(vis, -127, 127); // DM ref says [0, 101]. BYOND compiler says [-127, 127]
+                    }
                     UpdateAppearance(dreamObject, appearance => {
                         appearance.Invisibility = vis;
                     });
@@ -97,7 +104,12 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 case "mouse_opacity":
                     UpdateAppearance(dreamObject, appearance => {
-                        appearance.MouseOpacity = (MouseOpacity)variableValue.GetValueAsInteger();
+                        //TODO figure out the weird inconsistencies with this being internally clamped
+                        if (!variableValue.TryGetValueAsInteger(out var opacity))
+                        {
+                            opacity = 0;
+                        }
+                        appearance.MouseOpacity = (MouseOpacity)opacity;
                     });
                     break;
                 case "color":
@@ -109,7 +121,12 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 case "dir":
                     UpdateAppearance(dreamObject, appearance => {
-                        appearance.Direction = (AtomDirection)variableValue.GetValueAsInteger();
+                        //TODO figure out the weird inconsistencies with this being internally clamped
+                        if (!variableValue.TryGetValueAsInteger(out var dir))
+                        {
+                            dir = 2; // SOUTH
+                        }
+                        appearance.Direction = (AtomDirection)dir;
                     });
                     break;
                 case "transform":

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -96,10 +96,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 case "mouse_opacity":
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
                         //TODO figure out the weird inconsistencies with this being internally clamped
-                        if (!variableValue.TryGetValueAsInteger(out var opacity))
-                        {
-                            opacity = 0;
-                        }
+                        variableValue.TryGetValueAsInteger(out var opacity);
                         appearance.MouseOpacity = (MouseOpacity)opacity;
                     });
                     break;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -72,7 +72,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 case "pixel_x":
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
-                        appearance.PixelOffset.X = variableValue.TryGetValueAsInteger(out var pixelX) ? pixelX : 0;
+                        variableValue.TryGetValueAsInteger(out appearance.PixelOffset.X);
                     });
                     break;
                 case "pixel_y":

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -124,6 +124,10 @@ namespace OpenDreamShared.Dream {
             Normalize(false);
         }
 
+        /// <summary>
+        /// Checks if the DreamPath is a descendant of another. NOTE: For type inheritance, use IsSubtypeOf()
+        /// </summary>
+        /// <param name="path">Path to compare to.</param>
         public bool IsDescendantOf(DreamPath path) {
             if (path.Elements.Length > Elements.Length) return false;
 


### PR DESCRIPTION
I can't really tell if the methods should be kept for switch cases that check the type. Seems like it'd just tempt people to use it elsewhere IMO.

Anyways in _most_ cases the Try version should be used and changing the code will better replicate BYOND handling of bad values.