### PR TITLE
Faster typechecking implementation

### DIFF
--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -161,7 +161,10 @@ namespace DMCompiler.DM {
         }
 
         public bool IsSubtypeOf(DreamPath path) {
-            return Path.IsDerivedFrom(path);
+            // return Path.IsDescendantOf(path);
+            if (Path.IsDescendantOf(path)) return true;
+            if (Parent != null) return Parent.IsSubtypeOf(path);
+            return false;
         }
     }
 }

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -161,9 +161,7 @@ namespace DMCompiler.DM {
         }
 
         public bool IsSubtypeOf(DreamPath path) {
-            if (Path.IsDescendantOf(path)) return true;
-            if (Parent != null) return Parent.IsSubtypeOf(path);
-            return false;
+            return Path.IsDerivedFrom(path);
         }
     }
 }

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -161,10 +161,7 @@ namespace DMCompiler.DM {
         }
 
         public bool IsSubtypeOf(DreamPath path) {
-            // return Path.IsDescendantOf(path);
-            if (Path.IsDescendantOf(path)) return true;
-            if (Parent != null) return Parent.IsSubtypeOf(path);
-            return false;
+            return Path.IsDescendantOf(path);
         }
     }
 }

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -104,10 +104,7 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public bool IsSubtypeOf(DreamPath path) {
-            // return Type.IsDescendantOf(path);
-            if (Type.IsDescendantOf(path)) return true;
-            else if (_parentObjectDefinition != null) return _parentObjectDefinition.IsSubtypeOf(path);
-            else return false;
+            return Type.IsDescendantOf(path);
         }
     }
 }

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -104,6 +104,7 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public bool IsSubtypeOf(DreamPath path) {
+            // return Type.IsDescendantOf(path);
             if (Type.IsDescendantOf(path)) return true;
             else if (_parentObjectDefinition != null) return _parentObjectDefinition.IsSubtypeOf(path);
             else return false;

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -16,7 +16,7 @@ namespace OpenDreamRuntime.Objects {
     public sealed class DreamObjectTree {
         public sealed class TreeEntry {
             public DreamPath Path;
-             public DreamObjectDefinition ObjectDefinition;
+            public DreamObjectDefinition ObjectDefinition;
             public TreeEntry? ParentEntry;
             public List<int> InheritingTypes = new();
 
@@ -85,7 +85,7 @@ namespace OpenDreamRuntime.Objects {
         /// </summary>
         /// <returns>IEnumerable of sorted TreeEntries</returns>
         /// <seealso cref="DreamPath.IsDescendantOf">IsDescendantOf</seealso>
-        private IEnumerable<TreeEntry> GetDFSSortedList() {
+        public IEnumerable<TreeEntry> GetDFSSortedTypeList() {
             List<TreeEntry> dfs_sorted_types = new();
             Stack<TreeEntry> dfs_sort_stack = new();
 
@@ -214,14 +214,13 @@ namespace OpenDreamRuntime.Objects {
 
             //Third pass: Create a DFS list of types so that all children of a parent type have contiguous indices,
             //so we can type-check by just checking in a range. See: DreamPath.IsDescendantOf
-            IEnumerable<TreeEntry> dfs_sorted_types = GetDFSSortedList();
+            IEnumerable<TreeEntry> dfs_sorted_types = GetDFSSortedTypeList();
             uint class_num = 0;
             foreach (TreeEntry type in dfs_sorted_types) {
-                type.Path.typeIndex = class_num;
+                type.Path.typeIndex = class_num++;
                 if (type.ParentEntry != null)
                     type.ParentEntry.Path.numChildren++;
                 type.Path.numChildren = (uint)type.InheritingTypes.Count;
-                class_num++;
             }
 
             //Fourth pass: Load each type's vars and procs

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -210,7 +210,7 @@ namespace OpenDreamRuntime.Objects {
                     type.ParentEntry.Path.numChildren++;
                 type.Path.numChildren = (uint)type.InheritingTypes.Count;
                 class_num++;
-                Logger.LogS(LogLevel.Info, "ZEWAKA", $"{type.Path.PathString} | #:{type.Path.typeIndex} | c: {type.Path.numChildren}");
+                //Logger.LogS(LogLevel.Info, "ZEWAKA", $"{type.Path.PathString} | #:{type.Path.typeIndex} | c: {type.Path.numChildren}");
 
             }
 

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -131,10 +131,10 @@ namespace OpenDreamShared.Dream {
             Normalize(false);
         }
 
-        public bool IsDerivedFrom(DreamPath ancestor)
-        {
-            return (typeIndex - ancestor.typeIndex) < ancestor.numChildren;
-        }
+        // public bool IsDescendantOf(DreamPath ancestor)
+        // {
+        //     return (typeIndex - ancestor.typeIndex) <= ancestor.numChildren;
+        // }
 
         public bool IsDescendantOf(DreamPath path) {
             if (path.Elements.Length > Elements.Length) return false;

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -133,6 +133,7 @@ namespace OpenDreamShared.Dream {
 
         public bool IsDescendantOf(DreamPath ancestor)
         {
+            // Unsigned overflow is desired, see: Doom3/unity's impl
             return (typeIndex - ancestor.typeIndex) <= ancestor.numChildren;
         }
 

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -26,6 +26,18 @@ namespace OpenDreamShared.Dream {
         public static readonly DreamPath Obj = new DreamPath("/obj");
         public static readonly DreamPath Mob = new DreamPath("/mob");
 
+        public PathType Type;
+        private string[] _elements;
+        private string _pathString;
+        /// <summary>
+        /// Internal type ID used for performant subclass checking
+        /// </summary>
+        public uint typeIndex = 0;
+        /// <summary>
+        /// Number of children for performant subclass checking
+        /// </summary>
+        public uint numChildren = 0;
+
         public enum PathType {
             Absolute,
             Relative,
@@ -68,11 +80,6 @@ namespace OpenDreamShared.Dream {
             }
             set => SetFromString(value);
         }
-
-        public PathType Type;
-
-        private string[] _elements;
-        private string _pathString;
 
         public DreamPath(string path) {
             Type = PathType.Absolute;
@@ -122,6 +129,11 @@ namespace OpenDreamShared.Dream {
 
             Elements = tempElements;
             Normalize(false);
+        }
+
+        public bool IsDerivedFrom(DreamPath ancestor)
+        {
+            return (typeIndex - ancestor.typeIndex) < ancestor.numChildren;
         }
 
         public bool IsDescendantOf(DreamPath path) {

--- a/OpenDreamShared/Dream/DreamPath.cs
+++ b/OpenDreamShared/Dream/DreamPath.cs
@@ -131,19 +131,9 @@ namespace OpenDreamShared.Dream {
             Normalize(false);
         }
 
-        // public bool IsDescendantOf(DreamPath ancestor)
-        // {
-        //     return (typeIndex - ancestor.typeIndex) <= ancestor.numChildren;
-        // }
-
-        public bool IsDescendantOf(DreamPath path) {
-            if (path.Elements.Length > Elements.Length) return false;
-
-            for (int i = 0; i < path.Elements.Length; i++) {
-                if (Elements[i] != path.Elements[i]) return false;
-            }
-
-            return true;
+        public bool IsDescendantOf(DreamPath ancestor)
+        {
+            return (typeIndex - ancestor.typeIndex) <= ancestor.numChildren;
         }
 
         public DreamPath AddToPath(string path) {

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -42,30 +42,49 @@
 	verb/move_down()
 		step(src, DOWN)
 
-/obj/a
-	name = "a"
+	verb/roll_dice(dice as text)
+		var/result = roll(dice)
+		usr << "The total shown on the dice is: [result]"
 
-/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p
-	name = "p"
+	verb/test_alert()
+		alert(usr, "Prepare to die.")
+		usr << "prompt done"
+
+	verb/input_num()
+		var/v = input("A") as num
+		usr << "you entered [v]"
+
+	verb/test_browse()
+		usr << browse({"
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Foo</title>
+	<style>
+	body {
+		background: red;
+	}
+	</style>
+	<script>
+	function foo(v) {
+		document.getElementById("mark").innerHTML = v;
+	}
+	</script>
+</head>
+<body>
+	<marquee id="mark">Honk</marquee>
+	<a href="?honk=1">click me</a>
+</body>
+</html>"},"window=honk")
+
+	verb/test_output()
+		usr << output("help sec griffing me", "honk.browser:foo")
+
+/mob/Stat()
+	if (statpanel("Status"))
+		stat("tick_usage", world.tick_usage)
+		stat("time", world.time)
 
 /world/New()
 	..()
 	world.log << "World loaded!"
-
-	var/obj/a/ancestor = new()
-	var/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/longancestor = new()
-	var/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/longchild = new()
-
-	var/t1
-	var/const/loops = 7000000
-
-	var/time1 = world.timeofday
-	for(var/i in 1 to loops)
-		istypetest(longchild, ancestor, longancestor)
-	t1 = world.timeofday-time1
-	world.log << "TOTAL TIME FOR [loops] LOOPS: [t1]"
-
-/proc/istypetest(longchild, ancestor, longancestor)
-	var/x = istype(longchild, ancestor)
-	var/y = istype(longchild, longancestor)
-	var/z = istype(longchild, longchild)

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -42,49 +42,29 @@
 	verb/move_down()
 		step(src, DOWN)
 
-	verb/roll_dice(dice as text)
-		var/result = roll(dice)
-		usr << "The total shown on the dice is: [result]"
+/obj/a
+	name = "a"
 
-	verb/test_alert()
-		alert(usr, "Prepare to die.")
-		usr << "prompt done"
-
-	verb/input_num()
-		var/v = input("A") as num
-		usr << "you entered [v]"
-
-	verb/test_browse()
-		usr << browse({"
-<!DOCTYPE html>
-<html>
-<head>
-	<title>Foo</title>
-	<style>
-	body {
-		background: red;
-	}
-	</style>
-	<script>
-	function foo(v) {
-		document.getElementById("mark").innerHTML = v;
-	}
-	</script>
-</head>
-<body>
-	<marquee id="mark">Honk</marquee>
-	<a href="?honk=1">click me</a>
-</body>
-</html>"},"window=honk")
-
-	verb/test_output()
-		usr << output("help sec griffing me", "honk.browser:foo")
-
-/mob/Stat()
-	if (statpanel("Status"))
-		stat("tick_usage", world.tick_usage)
-		stat("time", world.time)
+/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p
+	name = "p"
 
 /world/New()
 	..()
 	world.log << "World loaded!"
+
+	var/obj/a/ancestor = new()
+	var/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/longancestor = new()
+	var/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/longchild = new()
+
+	var/t1
+	var/const/loops = 4000000
+
+	var/time1 = world.timeofday
+	for(var/i in 1 to loops)
+		istypetest(longchild, ancestor, longancestor)
+	t1 = world.timeofday-time1
+	world.log << "TOTAL TIME FOR [loops] LOOPS: [t1]"
+
+/proc/istypetest(longchild, ancestor, longancestor)
+	var/x = istype(longchild, ancestor)
+	var/y = istype(longchild, longancestor)

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -57,7 +57,7 @@
 	var/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/longchild = new()
 
 	var/t1
-	var/const/loops = 4000000
+	var/const/loops = 7000000
 
 	var/time1 = world.timeofday
 	for(var/i in 1 to loops)
@@ -68,3 +68,4 @@
 /proc/istypetest(longchild, ancestor, longancestor)
 	var/x = istype(longchild, ancestor)
 	var/y = istype(longchild, longancestor)
+	var/z = istype(longchild, longchild)


### PR DESCRIPTION
Since our type tree in DM is single-inheritance, we can optimize as following:
> Types are enumerated in depth-first order so all children of a given parent type all have a contiguous indices; then check whether ID falls in that range.

This practice has been done in other game engines like DOOM 3, Roblox :godmode:, and Unity.

This is better than our existing approach of iterating through the whole path string looking if elements match. It'd also recurse through parents if `parent_type` was used or something also.
We could also use this DFS ordered list potentially for other things.

~11.1% speedup

Statistics & Profiling:
The primary thing you should pay attention to is the ratio (or difference between the trendlines).
![New, Old, Ratio (1)](https://user-images.githubusercontent.com/4741640/153775643-0c6f2709-289c-4c65-b9fa-ce4eb366fde8.png)


Multiple values were taken for each iteration count, for each category. Ran on Release.
The median was taken for the graph.

Test code:
```dm
/world/New()
    ..()

    var/obj/a/ancestor = new()
    var/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/longancestor = new()
    var/obj/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/longchild = new()

    var/t1
    var/const/loops = 3300000

    var/time1 = world.timeofday
    for(var/i in 1 to loops)
        istypetest(longchild, ancestor, longancestor)
    t1 = world.timeofday-time1
    world.log << "TOTAL TIME FOR [loops] LOOPS: [t1]"

/proc/istypetest(longchild, ancestor, longancestor)
    var/x = istype(longchild, ancestor)
    var/y = istype(longchild, longancestor)
	var/z = istype(longchild, longchild)
```