### PR TITLE
Check for a semicolon trailing a bracketed If() body

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -828,6 +828,7 @@ namespace DMCompiler.Compiler.DM {
                 if (body == null) body = new DMASTProcBlockInner(loc, new DMASTProcStatement[0]);
                 Token afterIfBody = Current();
                 bool newLineAfterIf = Newline();
+                Check(TokenType.DM_Semicolon);
                 if (newLineAfterIf) Whitespace();
                 if (Check(TokenType.DM_Else)) {
                     Whitespace();


### PR DESCRIPTION
Code (inside a macro):
```
if(!neighbor) { \
	if(source.smoothing_flags & SMOOTH_BORDER) { \
		junction |= direction_flag; \
	}; \
}; \ 			// Problematic semicolon
else { \
			// SNIPPED
```