### PR TITLE
Seals some classes and cleans up some unused imports

### DIFF
--- a/OpenDreamClient/Audio/DreamSoundChannel.cs
+++ b/OpenDreamClient/Audio/DreamSoundChannel.cs
@@ -1,9 +1,8 @@
-using System;
 using Robust.Client.Graphics;
 
 namespace OpenDreamClient.Audio
 {
-    public class DreamSoundChannel : IDisposable {
+    public sealed class DreamSoundChannel : IDisposable {
         public IClydeAudioSource Source { get; }
 
         public DreamSoundChannel(IClydeAudioSource source) {

--- a/OpenDreamClient/Audio/DreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/DreamSoundEngine.cs
@@ -1,14 +1,13 @@
-using System;
 using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
 using OpenDreamShared.Network.Messages;
+using Robust.Client.Graphics;
 using Robust.Shared.Audio;
-using Robust.Shared.IoC;
 using Robust.Shared.Network;
 
 namespace OpenDreamClient.Audio
 {
-    public class DreamSoundEngine : IDreamSoundEngine
+    public sealed class DreamSoundEngine : IDreamSoundEngine
     {
         private const int SoundChannelLimit = 1024;
 
@@ -45,7 +44,8 @@ namespace OpenDreamClient.Audio
 
             StopChannel(channel);
 
-            var source = sound.Play(AudioParams.Default.WithVolume(20 * MathF.Log10(volume))); // convert from DM volume (0-100) to OpenAL volume (db)
+            // convert from DM volume (0-100) to OpenAL volume (db)
+            IClydeAudioSource source = sound.Play(AudioParams.Default.WithVolume(20 * MathF.Log10(volume)));
             _channels[channel - 1] = new DreamSoundChannel(source);
         }
 
@@ -54,7 +54,7 @@ namespace OpenDreamClient.Audio
         {
             if (_channels[channel - 1] != null)
             {
-                ref var ch = ref _channels[channel - 1];
+                ref DreamSoundChannel ch = ref _channels[channel - 1];
                 ch.Dispose();
                 // This will null the corresponding index in the array.
                 ch = null;
@@ -74,7 +74,7 @@ namespace OpenDreamClient.Audio
             if (!string.IsNullOrEmpty(msg.File))
             {
                 _resourceManager.LoadResourceAsync<ResourceSound>(msg.File,
-                    sound => { PlaySound(msg.Channel, sound, msg.Volume / 100.0f); });
+                    sound => PlaySound(msg.Channel, sound, msg.Volume / 100.0f));
             }
             else
             {

--- a/OpenDreamClient/Interface/BrowsePopup.cs
+++ b/OpenDreamClient/Interface/BrowsePopup.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using OpenDreamShared.Interface;
+﻿using OpenDreamShared.Interface;
 using OpenDreamClient.Interface.Controls;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 
 namespace OpenDreamClient.Interface
 {
-    class BrowsePopup {
+    sealed class BrowsePopup {
         public event Action Closed;
 
         public ControlBrowser Browser;

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Web;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream.Procs;
@@ -14,8 +12,6 @@ using OpenDreamShared.Compiler.DMF;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
@@ -23,7 +19,7 @@ using Robust.Shared.Timing;
 using SixLabors.ImageSharp;
 
 namespace OpenDreamClient.Interface {
-    class DreamInterfaceManager : IDreamInterfaceManager {
+    sealed class DreamInterfaceManager : IDreamInterfaceManager {
         [Dependency] private readonly IClyde _clyde = default!;
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private readonly IDreamMacroManager _macroManager = default!;

--- a/OpenDreamClient/Interface/DreamStylesheet.cs
+++ b/OpenDreamClient/Interface/DreamStylesheet.cs
@@ -3,8 +3,6 @@ using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 using static Robust.Client.UserInterface.StylesheetHelpers;
 
 namespace OpenDreamClient.Interface {

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -8,7 +8,7 @@ namespace OpenDreamClient.Interface
     /// <summary>
     /// Used in unit testing to run a headless client.
     /// </summary>
-    public class DummyDreamInterfaceManager : IDreamInterfaceManager
+    public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager
     {
         public string[] AvailableVerbs { get; }
         public Dictionary<string, ControlWindow> Windows { get; }

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using OpenDreamClient.Interface.Controls;
 using OpenDreamShared.Interface;
 using Robust.Shared.Timing;

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -1,5 +1,4 @@
 ﻿using OpenDreamShared.Interface;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Result;
 using Robust.Shared.Serialization.Markdown.Mapping;

--- a/OpenDreamClient/Interface/Prompts/AlertWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/AlertWindow.cs
@@ -6,7 +6,7 @@ using Robust.Shared.IoC;
 
 namespace OpenDreamClient.Interface.Prompts
 {
-    class AlertWindow : PromptWindow
+    sealed class AlertWindow : PromptWindow
     {
         public AlertWindow(int promptId, String title, String message, String button1, String button2, String button3) :
             base(promptId, title, message)

--- a/OpenDreamClient/Interface/Prompts/AlertWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/AlertWindow.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using OpenDreamShared.Dream.Procs;
+﻿using OpenDreamShared.Dream.Procs;
 using JetBrains.Annotations;
 using Robust.Shared.Console;
-using Robust.Shared.IoC;
 
 namespace OpenDreamClient.Interface.Prompts
 {

--- a/OpenDreamClient/Interface/Prompts/InputWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/InputWindow.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using OpenDreamShared.Dream.Procs;
+﻿using OpenDreamShared.Dream.Procs;
 using Robust.Client.UserInterface;
 
 namespace OpenDreamClient.Interface.Prompts

--- a/OpenDreamClient/Interface/Prompts/InputWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/InputWindow.cs
@@ -4,6 +4,7 @@ using Robust.Client.UserInterface;
 
 namespace OpenDreamClient.Interface.Prompts
 {
+    [Virtual]
     class InputWindow : PromptWindow {
         protected Control _inputControl;
 

--- a/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using OpenDreamShared.Dream.Procs;
+﻿using OpenDreamShared.Dream.Procs;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 

--- a/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Log;
 
 namespace OpenDreamClient.Interface.Prompts
 {
+    [Virtual]
     class NumberPrompt : InputWindow {
         public NumberPrompt(int promptId, String title, String message, String defaultValue, bool canCancel) : base(promptId, title, message, defaultValue, canCancel) { }
 

--- a/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using OpenDreamShared.Dream.Procs;
+﻿using OpenDreamShared.Dream.Procs;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.Log;
 
 namespace OpenDreamClient.Interface.Prompts
 {

--- a/OpenDreamClient/Interface/Prompts/PromptWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/PromptWindow.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using OpenDreamShared.Dream.Procs;
 using OpenDreamShared.Network.Messages;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 using Robust.Shared.Network;
 
 namespace OpenDreamClient.Interface.Prompts

--- a/OpenDreamClient/Interface/Prompts/TextPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/TextPrompt.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using OpenDreamShared.Dream.Procs;
+﻿using OpenDreamShared.Dream.Procs;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 

--- a/OpenDreamClient/Interface/Prompts/TextPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/TextPrompt.cs
@@ -5,6 +5,7 @@ using Robust.Client.UserInterface.Controls;
 
 namespace OpenDreamClient.Interface.Prompts
 {
+    [Virtual]
     class TextPrompt : InputWindow {
         public TextPrompt(int promptId, String title, String message, String defaultValue, bool canCancel) : base(promptId, title, message, defaultValue, canCancel) { }
 

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using OpenDreamShared;
+﻿using OpenDreamShared;
 using OpenDreamShared.Network.Messages;
 using OpenDreamClient.Resources.ResourceTypes;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
-using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;

--- a/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
+++ b/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using OpenDreamClient.Input;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Resources;
 using Robust.Client.Graphics;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace OpenDreamClient.Resources.ResourceTypes {
-    public class DMIResource : DreamResource {
+    public sealed class DMIResource : DreamResource {
         private readonly byte[] _pngHeader = { 0x89, 0x50, 0x4E, 0x47, 0xD, 0xA, 0x1A, 0xA };
 
         public Texture Texture;

--- a/OpenDreamClient/Resources/ResourceTypes/ResourceSound.cs
+++ b/OpenDreamClient/Resources/ResourceTypes/ResourceSound.cs
@@ -1,14 +1,12 @@
-using System;
 using System.IO;
 using Robust.Client.Audio;
 using Robust.Client.Graphics;
 using Robust.Shared.Audio;
-using Robust.Shared.IoC;
-using Robust.Shared.Log;
 
 namespace OpenDreamClient.Resources.ResourceTypes
 {
-    public class ResourceSound : DreamResource {
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public sealed class ResourceSound : DreamResource {
         private readonly AudioStream _stream;
 
         public ResourceSound(string resourcePath, byte[] data) : base(resourcePath, data) {


### PR DESCRIPTION
title

Reasons for not sealing:
NumberPrompt: people might want to make a binary-only or some other weird prompt??
TextPrompt: Could keep this single line, and extend another one to be multiline? unsure what TextPrompt and what MessagePrompt should cover
InputWindow: This can be instantiated, so it's not abstract.