### PR TITLE
Adds a new exception type

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -777,7 +777,9 @@ namespace DMCompiler.DM {
         private void ShrinkStack(int size) {
             _currentStackSize -= size;
             _maxStackSize = Math.Max(_currentStackSize, _maxStackSize);
-            if (_currentStackSize < 0) throw new Exception($"Negative stack size {Location}");
+            if (_currentStackSize < 0) {
+                throw new CompileAbortException(Location, $"Negative stack size in proc {_astDefinition.ObjectPath}.{Name}()");
+            }
         }
     }
 }

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -55,9 +55,18 @@ namespace DMCompiler.DM.Visitors {
 
         public void ProcessBlockInner(DMASTProcBlockInner block) {
             foreach (DMASTProcStatement statement in block.Statements) {
-                try {
+                try
+                {
                     ProcessStatement(statement);
-                } catch (CompileErrorException e) { //Retreat from the statement when there's an error
+                }
+                catch (CompileAbortException e)
+                {
+                    // The statement's location info isn't passed all the way down so change the error to make it more accurate
+                    e.Error.Location = statement.Location;
+                    DMCompiler.Error(e.Error);
+                    return; // Don't spam the error that will continue to exist
+                }
+                catch (CompileErrorException e) { //Retreat from the statement when there's an error
                     DMCompiler.Error(e.Error);
                 }
             }
@@ -187,7 +196,7 @@ namespace DMCompiler.DM.Visitors {
                     DMCompiler.Error(new CompilerError(varDeclaration.Location, "Const var must be set to a constant"));
                     return;
                 }
-                    
+
                 successful = _proc.TryAddLocalConstVariable(varDeclaration.Name, varDeclaration.Type, constValue);
             } else {
                 successful = _proc.TryAddLocalVariable(varDeclaration.Name, varDeclaration.Type);

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Robust.Shared.Analyzers;
 
 namespace OpenDreamShared.Compiler {
     public struct CompilerError {
@@ -39,20 +40,25 @@ namespace OpenDreamShared.Compiler {
         }
     }
 
+    [Virtual]
     public class CompileErrorException : Exception {
         public CompilerError Error;
-
         public CompileErrorException(CompilerError error) : base(error.Message)
         {
             Error = error;
         }
-
-        public CompileErrorException(Token token, string message) : base(message) {
-            Error = new CompilerError(token, message);
-        }
-
         public CompileErrorException(Location location, string message) : base(message) {
             Error = new CompilerError(location, message);
         }
+    }
+
+
+    /// <summary>
+    /// Represents an internal compiler error that should cause parsing for a particular block to cease.
+    /// </summary>
+    public sealed class CompileAbortException : CompileErrorException
+    {
+        public CompileAbortException(CompilerError error) : base(error) {}
+        public CompileAbortException(Location location, string message) : base(location, message) {}
     }
 }


### PR DESCRIPTION
Ideally nothing should ever outright kill compilation (except maybe a cap on error count like byond's) so I did this.

Also removes an unused constructor for CompileErrorException.

Not sure what other existing places should be changed to use this exception & handle it.