### PR TITLE
Implements `initial(list[idx])`

### DIFF
--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -116,5 +116,11 @@ namespace DMCompiler.DM.Expressions {
 
             return (DMReference.ListIndex, _conditional);
         }
+
+        public override void EmitPushInitial(DMObject dmObject, DMProc proc) {
+            // This happens silently in BYOND
+            DMCompiler.Warning(new CompilerWarning(Location, "calling initial() on a list index returns the current value"));
+            EmitPushValue(dmObject, proc);
+        }
     }
 }


### PR DESCRIPTION
For some reason I was convinced that calling `initial()` on a list index actually worked somehow, but it's just another case of https://github.com/wixoaGit/OpenDream/pull/581 where it just returns the current value.

Added a warning like we did for that case too.

Closes #522 

