### PR TITLE
Fixes setting a global to a global

### DIFF
--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -229,7 +229,7 @@ namespace DMCompiler.DM.Visitors {
                     variable.Value = new Expressions.Null(Location.Unknown);
                     EmitInitializationAssign(variable, expression);
                     break;
-
+                case Expressions.GlobalField: // Global set to another global
                 case Expressions.StringFormat:
                 case Expressions.ProcCall:
                     if (!variable.IsGlobal) throw new CompileErrorException(value.Location,$"Invalid initial value for \"{variable.Name}\"");


### PR DESCRIPTION
This outputs 5 in BYOND and now OD:
```
var/global/G1 = 5
var/global/G2 = G1
/proc/main()
    world.log << G2
```