### PR TITLE
Fixes `||=` not including path info

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -515,9 +515,8 @@ namespace DMCompiler.Compiler.DM {
                     case DMASTIdentifier identifier:
                         Check(TokenType.DM_Colon);
                         return Label(identifier);
-                    case DMASTLeftShift shift:
+                    case DMASTLeftShift leftShift:
                     {
-                        DMASTLeftShift leftShift = shift;
                         DMASTProcCall procCall = leftShift.B as DMASTProcCall;
 
                         if (procCall != null && procCall.Callable is DMASTCallableProcIdentifier identifier) {

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -306,7 +306,7 @@ namespace DMCompiler.Compiler.DM {
         public bool PathArray(ref DreamPath path, out DMASTExpression implied_value) {
             //TODO: Multidimensional lists
             implied_value = null;
-            if (Check(TokenType.DM_LeftBracket)) 
+            if (Check(TokenType.DM_LeftBracket))
             {
                 var loc = Current().Location;
                 if (!path.IsDescendantOf(DreamPath.List)) {
@@ -508,34 +508,41 @@ namespace DMCompiler.Compiler.DM {
                 Error("Expected a label identifier");
             }
 
-            if (expression != null) {
-                if (expression is DMASTIdentifier) {
-                    Check(TokenType.DM_Colon);
-                    return Label((DMASTIdentifier)expression);
-                } else if (expression is DMASTLeftShift) {
-                    DMASTLeftShift leftShift = (DMASTLeftShift)expression;
-                    DMASTProcCall procCall = leftShift.B as DMASTProcCall;
+            if (expression != null)
+            {
+                switch (expression)
+                {
+                    case DMASTIdentifier identifier:
+                        Check(TokenType.DM_Colon);
+                        return Label(identifier);
+                    case DMASTLeftShift shift:
+                    {
+                        DMASTLeftShift leftShift = shift;
+                        DMASTProcCall procCall = leftShift.B as DMASTProcCall;
 
-                    if (procCall != null && procCall.Callable is DMASTCallableProcIdentifier identifier) {
-                        if (identifier.Identifier == "browse") {
-                            if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2) Error("browse() requires 1 or 2 parameters");
+                        if (procCall != null && procCall.Callable is DMASTCallableProcIdentifier identifier) {
+                            if (identifier.Identifier == "browse") {
+                                if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2) Error("browse() requires 1 or 2 parameters");
 
-                            DMASTExpression body = procCall.Parameters[0].Value;
-                            DMASTExpression options = (procCall.Parameters.Length == 2) ? procCall.Parameters[1].Value : new DMASTConstantNull(loc);
-                            return new DMASTProcStatementBrowse(loc, leftShift.A, body, options);
-                        } else if (identifier.Identifier == "browse_rsc") {
-                            if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2) Error("browse_rsc() requires 1 or 2 parameters");
+                                DMASTExpression body = procCall.Parameters[0].Value;
+                                DMASTExpression options = (procCall.Parameters.Length == 2) ? procCall.Parameters[1].Value : new DMASTConstantNull(loc);
+                                return new DMASTProcStatementBrowse(loc, leftShift.A, body, options);
+                            } else if (identifier.Identifier == "browse_rsc") {
+                                if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2) Error("browse_rsc() requires 1 or 2 parameters");
 
-                            DMASTExpression file = procCall.Parameters[0].Value;
-                            DMASTExpression filepath = (procCall.Parameters.Length == 2) ? procCall.Parameters[1].Value : new DMASTConstantNull(loc);
-                            return new DMASTProcStatementBrowseResource(loc, leftShift.A, file, filepath);
-                        } else if (identifier.Identifier == "output") {
-                            if (procCall.Parameters.Length != 2) Error("output() requires 2 parameters");
+                                DMASTExpression file = procCall.Parameters[0].Value;
+                                DMASTExpression filepath = (procCall.Parameters.Length == 2) ? procCall.Parameters[1].Value : new DMASTConstantNull(loc);
+                                return new DMASTProcStatementBrowseResource(loc, leftShift.A, file, filepath);
+                            } else if (identifier.Identifier == "output") {
+                                if (procCall.Parameters.Length != 2) Error("output() requires 2 parameters");
 
-                            DMASTExpression msg = procCall.Parameters[0].Value;
-                            DMASTExpression control = procCall.Parameters[1].Value;
-                            return new DMASTProcStatementOutputControl(loc, leftShift.A, msg, control);
+                                DMASTExpression msg = procCall.Parameters[0].Value;
+                                DMASTExpression control = procCall.Parameters[1].Value;
+                                return new DMASTProcStatementOutputControl(loc, leftShift.A, msg, control);
+                            }
                         }
+
+                        break;
                     }
                 }
 

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -1,3 +1,4 @@
+using System;
 using DMCompiler.DM.Expressions;
 using OpenDreamShared.Compiler;
 using DMCompiler.Compiler.DM;
@@ -256,12 +257,12 @@ namespace DMCompiler.DM.Visitors {
 
         public void VisitLogicalAndAssign(DMASTLogicalAndAssign land) {
             var lhs = DMExpression.Create(_dmObject, _proc, land.A, _inferredPath);
-            var rhs = DMExpression.Create(_dmObject, _proc, land.B, _inferredPath);
+            var rhs = DMExpression.Create(_dmObject, _proc, land.B, lhs.Path ?? _inferredPath);
             Result = new Expressions.LogicalAndAssign(land.Location, lhs, rhs);
         }
         public void VisitLogicalOrAssign(DMASTLogicalOrAssign lor) {
             var lhs = DMExpression.Create(_dmObject, _proc, lor.A, _inferredPath);
-            var rhs = DMExpression.Create(_dmObject, _proc, lor.B, _inferredPath);
+            var rhs = DMExpression.Create(_dmObject, _proc, lor.B, lhs.Path ?? _inferredPath);
             Result = new Expressions.LogicalOrAssign(lor.Location, lhs, rhs);
         }
 
@@ -494,7 +495,7 @@ namespace DMCompiler.DM.Visitors {
 
             if (locate.Expression == null) {
                 if (_inferredPath == null) {
-                    throw new CompileErrorException(locate.Location, "inferred lcoate requires a type");
+                    throw new CompileErrorException(locate.Location, "inferred locate requires a type");
                 }
                 Result = new Expressions.LocateInferred(locate.Location, _inferredPath.Value, container);
                 return;

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -257,7 +257,7 @@ namespace DMCompiler.DM.Visitors {
 
         public void VisitLogicalAndAssign(DMASTLogicalAndAssign land) {
             var lhs = DMExpression.Create(_dmObject, _proc, land.A, _inferredPath);
-            var rhs = DMExpression.Create(_dmObject, _proc, land.B, lhs.Path ?? _inferredPath);
+            var rhs = DMExpression.Create(_dmObject, _proc, land.B, lhs.Path);
             Result = new Expressions.LogicalAndAssign(land.Location, lhs, rhs);
         }
         public void VisitLogicalOrAssign(DMASTLogicalOrAssign lor) {

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -262,7 +262,7 @@ namespace DMCompiler.DM.Visitors {
         }
         public void VisitLogicalOrAssign(DMASTLogicalOrAssign lor) {
             var lhs = DMExpression.Create(_dmObject, _proc, lor.A, _inferredPath);
-            var rhs = DMExpression.Create(_dmObject, _proc, lor.B, lhs.Path ?? _inferredPath);
+            var rhs = DMExpression.Create(_dmObject, _proc, lor.B, lhs.Path);
             Result = new Expressions.LogicalOrAssign(lor.Location, lhs, rhs);
         }
 


### PR DESCRIPTION
I'm not entirely sure this is the most correct way to do this, but it fixes #611 

Also changed a random bit of code to a switch and fixed a typo.