### PR TITLE
Fixes `||=` on a dereference causing a shrinkstack exception

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -211,10 +211,10 @@ namespace DMCompiler.DM {
             WriteOpcode(DreamProcOpcode.Error);
         }
 
-        public void PushReferenceValue(DMReference reference) {
+        public void PushReferenceValue(DMReference reference, bool affectStack = true) {
             GrowStack(1);
             WriteOpcode(DreamProcOpcode.PushReferenceValue);
-            WriteReference(reference);
+            WriteReference(reference, affectStack);
         }
 
         public void CreateListEnumerator() {

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -500,7 +500,7 @@ namespace DMCompiler.DM.Expressions {
             string skipLabel = proc.NewLabelName();
             string endLabel = proc.NewLabelName();
 
-            proc.PushReferenceValue(reference);
+            proc.PushReferenceValue(reference, false);
             proc.JumpIfFalse(skipLabel);
 
             RHS.EmitPushValue(dmObject, proc);
@@ -521,7 +521,7 @@ namespace DMCompiler.DM.Expressions {
             string skipLabel = proc.NewLabelName();
             string endLabel = proc.NewLabelName();
 
-            proc.PushReferenceValue(reference);
+            proc.PushReferenceValue(reference, false);
             proc.JumpIfTrue(skipLabel);
 
             RHS.EmitPushValue(dmObject, proc);


### PR DESCRIPTION
Fixes #598 

Not sure if this is the best way to fix it, but it works.