### PR TITLE
Error tolerance refactor for map parsing/saving

### DIFF
--- a/DMCompiler/Compiler/DMM/DMMParser.cs
+++ b/DMCompiler/Compiler/DMM/DMMParser.cs
@@ -68,11 +68,14 @@ namespace DMCompiler.Compiler.DMM {
                         while (statement != null) {
                             DMASTObjectVarOverride varOverride = statement as DMASTObjectVarOverride;
                             if (varOverride == null) Error("Expected a var override");
-                            if (!varOverride.ObjectPath.Equals(DreamPath.Root)) Error("Invalid var name");
-                            DMExpression value = DMExpression.Create(null, null, varOverride.Value);
-                            if (!value.TryAsJsonRepresentation(out var valueJson)) Error($"Failed to serialize value to json ({value})");
+                            if (!varOverride.ObjectPath.Equals(DreamPath.Root)) DMCompiler.Error(new CompilerError(statement.Location, $"Invalid var name '{varOverride.VarName}' in DMM on type {objectType.Path}"));
+                            DMExpression value = DMExpression.Create(DMObjectTree.GetDMObject(objectType.Path), null, varOverride.Value);
+                            if (!value.TryAsJsonRepresentation(out var valueJson)) DMCompiler.Error(new CompilerError(statement.Location, $"Failed to serialize value to json ({value})"));
 
-                            mapObject.AddVarOverride(varOverride.VarName, valueJson);
+                            if(!mapObject.AddVarOverride(varOverride.VarName, valueJson))
+                            {
+                                DMCompiler.Warning(new CompilerWarning(statement.Location, $"Duplicate var override '{varOverride.VarName}' in DMM on type {objectType.Path}"));
+                            }
 
                             if (Check(TokenType.DM_Semicolon)) {
                                 statement = Statement(requireDelimiter: false);
@@ -93,7 +96,7 @@ namespace DMCompiler.Compiler.DMM {
                             cellDefinition.Objects.Add(mapObject);
                         }
                     }
-                    
+
 
                     if (Check(TokenType.DM_Comma)) {
                         objectType = Path();

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -362,7 +362,7 @@ namespace DMCompiler.DM.Expressions {
             json = null;
             if (!DMCompiler.Settings.SuppressUnimplementedWarnings)
             {
-                DMCompiler.Warning(new CompilerWarning(Location, $"DMM overrides for expression {GetType()} are not implemented"));
+                DMCompiler.Warning(new CompilerWarning(Location, "DMM overrides for newlist() are not implemented"));
             }
             return true; //TODO
         }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -360,6 +360,10 @@ namespace DMCompiler.DM.Expressions {
 
         public override bool TryAsJsonRepresentation(out object json) {
             json = null;
+            if (!DMCompiler.Settings.SuppressUnimplementedWarnings)
+            {
+                DMCompiler.Warning(new CompilerWarning(Location, $"DMM overrides for expression {GetType()} are not implemented"));
+            }
             return true; //TODO
         }
     }

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -109,7 +109,7 @@ namespace DMCompiler.DM.Expressions {
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
             (DMObject procOwner, DMProc targetProc) = GetTargetProc(dmObject);
             if (!DMCompiler.Settings.SuppressUnimplementedWarnings && (targetProc?.Attributes & ProcAttributes.Unimplemented) == ProcAttributes.Unimplemented) {
-                DMCompiler.Warning(new CompilerWarning(Location, $"{procOwner.Path}.{targetProc.Name}() is not implemented"));
+                DMCompiler.Warning(new CompilerWarning(Location, $"{procOwner?.Path.ToString() ?? "/"}{targetProc.Name}() is not implemented"));
             }
 
             (DMReference procRef, bool conditional) = _target.EmitReference(dmObject, proc);
@@ -132,6 +132,15 @@ namespace DMCompiler.DM.Expressions {
                 }
                 proc.Call(procRef);
             }
+        }
+
+        public override bool TryAsJsonRepresentation(out object json) {
+            json = null;
+            if (!DMCompiler.Settings.SuppressUnimplementedWarnings)
+            {
+                DMCompiler.Warning(new CompilerWarning(Location, $"DMM overrides for expression {GetType()} are not implemented"));
+            }
+            return true; //TODO
         }
     }
 }

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -241,7 +241,7 @@ namespace DMCompiler {
             });
 
             // Successful serialization
-            if (ErrorCount > 0)
+            if (ErrorCount == 0)
             {
                 File.WriteAllText(outputFile, json);
                 return "Saved to " + outputFile;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -58,15 +58,22 @@ namespace DMCompiler {
                 string outputFile = Path.ChangeExtension(settings.Files[0], "json");
                 List<DreamMapJson> maps = ConvertMaps(preprocessor.IncludedMaps);
 
-                var output = SaveJson(maps, preprocessor.IncludedInterface, outputFile);
                 if (ErrorCount > 0)
                 {
                     successfulCompile = false;
                 }
                 else
                 {
-                    Console.WriteLine($"Compilation succeeded with {WarningCount} warnings");
-                    Console.WriteLine(output);
+                    var output = SaveJson(maps, preprocessor.IncludedInterface, outputFile);
+                    if (ErrorCount > 0)
+                    {
+                        successfulCompile = false;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Compilation succeeded with {WarningCount} warnings");
+                        Console.WriteLine(output);
+                    }
                 }
             }
             if (!successfulCompile) {

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -241,7 +241,7 @@ namespace DMCompiler {
             });
 
             // Successful serialization
-            if (DMCompiler.ErrorCount == beforeErrorCount)
+            if (ErrorCount > 0)
             {
                 File.WriteAllText(outputFile, json);
                 return "Saved to " + outputFile;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -199,7 +199,6 @@ namespace DMCompiler {
 
         private static string SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile)
         {
-            var beforeErrorCount = DMCompiler.ErrorCount;
             DreamCompiledJson compiledDream = new DreamCompiledJson();
             compiledDream.Strings = DMObjectTree.StringTable;
             compiledDream.Maps = maps;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -52,15 +52,24 @@ namespace DMCompiler {
 
             bool successfulCompile = preprocessor is not null && Compile(preprocessor.GetResult());
 
-            if (successfulCompile) {
-                Console.WriteLine($"Compilation succeeded with {WarningCount} warnings");
-
+            if (successfulCompile)
+            {
                 //Output file is the first file with the extension changed to .json
                 string outputFile = Path.ChangeExtension(settings.Files[0], "json");
                 List<DreamMapJson> maps = ConvertMaps(preprocessor.IncludedMaps);
 
-                SaveJson(maps, preprocessor.IncludedInterface, outputFile);
-            } else {
+                var output = SaveJson(maps, preprocessor.IncludedInterface, outputFile);
+                if (ErrorCount > 0)
+                {
+                    successfulCompile = false;
+                }
+                else
+                {
+                    Console.WriteLine($"Compilation succeeded with {WarningCount} warnings");
+                    Console.WriteLine(output);
+                }
+            }
+            if (!successfulCompile) {
                 Console.WriteLine($"Compilation failed with {ErrorCount} errors and {WarningCount} warnings");
             }
 
@@ -181,7 +190,9 @@ namespace DMCompiler {
             return maps;
         }
 
-        private static void SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile) {
+        private static string SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile)
+        {
+            var beforeErrorCount = DMCompiler.ErrorCount;
             DreamCompiledJson compiledDream = new DreamCompiledJson();
             compiledDream.Strings = DMObjectTree.StringTable;
             compiledDream.Maps = maps;
@@ -199,7 +210,7 @@ namespace DMCompiler {
                 for (int i = 0; i < DMObjectTree.Globals.Count; i++) {
                     DMVariable global = DMObjectTree.Globals[i];
                     if (!global.TryAsJsonRepresentation(out var globalJson))
-                        throw new Exception($"Failed to serialize global {global.Name}");
+                        DMCompiler.Error(new CompilerError(global.Value.Location, $"Failed to serialize global {global.Name}"));
 
                     if (globalJson != null) {
                         globalListJson.Globals.Add(i, globalJson);
@@ -223,8 +234,13 @@ namespace DMCompiler {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
             });
 
-            File.WriteAllText(outputFile, json);
-            Console.WriteLine("Saved to " + outputFile);
+            // Successful serialization
+            if (DMCompiler.ErrorCount == beforeErrorCount)
+            {
+                File.WriteAllText(outputFile, json);
+                return "Saved to " + outputFile;
+            }
+            return string.Empty;
         }
     }
 

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -75,7 +75,7 @@ namespace OpenDreamRuntime {
             if (maps.Count == 0) throw new ArgumentException("No maps were given");
             else if (maps.Count > 1)
             {
-                Logger.Error("Loading more than one map is not implemented, skipping additional maps");
+                Logger.Warning("Loading more than one map is not implemented, skipping additional maps");
             }
             DreamMapJson map = maps[0];
 

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -73,7 +73,10 @@ namespace OpenDreamRuntime {
 
         public void LoadMaps(List<DreamMapJson> maps) {
             if (maps.Count == 0) throw new ArgumentException("No maps were given");
-            else if (maps.Count > 1) throw new NotImplementedException("Loading more than one map is not implemented");
+            else if (maps.Count > 1)
+            {
+                Logger.Error("Loading more than one map is not implemented, skipping additional maps");
+            }
             DreamMapJson map = maps[0];
 
             Size = new Vector2i(map.MaxX, map.MaxY);

--- a/OpenDreamShared/Json/DreamMapJson.cs
+++ b/OpenDreamShared/Json/DreamMapJson.cs
@@ -29,10 +29,16 @@ namespace OpenDreamShared.Json {
             Type = type;
         }
 
-        public void AddVarOverride(string varName, object varValue) {
+        public bool AddVarOverride(string varName, object varValue) {
             if (VarOverrides == null) VarOverrides = new Dictionary<string, object>();
 
+            if (VarOverrides.ContainsKey(varName))
+            {
+                VarOverrides[varName] = varValue;
+                return false;
+            }
             VarOverrides.Add(varName, varValue);
+            return true;
         }
     }
 


### PR DESCRIPTION
Things this does:

- DMMParser has been edited to use normal compiler errors/warnings in several places
- The maps are now parsed & serialized _before_ compilation is considered successful, since it can fail
- The JSON is no longer saved if map parsing fails
- DMMParser now passes type info to DMExpression.Create()
- DMMParser can now cope with duplicate var overrides in a modified type, and will create a warning about it. The last parsed value will be used as the true override, not sure if this matches BYOND behavior.
- TryAsJsonRepresentation() now throws an unimplemented warning when it's unimplemented
- TryAsJsonRepresentation() for ProcCall has been stubbed
- Fixed a null reference exception with printing unimplemented warnings for global procs
- Trying to load multiple maps is now a logger error rather than a not implemented exception

Once the Eternia compiler fixes are merged, this PR will make it also survive map parsing, saving, & loading.