### PR TITLE
Adds `TryAsConstant()` override for derefs

### DIFF
--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -50,6 +50,19 @@ namespace DMCompiler.DM.Expressions {
             _expr.EmitPushValue(dmObject, proc);
             return (DMReference.CreateField(_propertyName), _conditional);
         }
+
+        public override bool TryAsConstant(out Constant constant)
+        {
+            var obj = DMObjectTree.GetDMObject(_expr.Path.GetValueOrDefault());
+            var variable = obj.GetVariable(_propertyName);
+            if (variable.IsConst)
+            {
+                return variable.Value.TryAsConstant(out constant);
+            }
+
+            constant = null;
+            return false;
+        }
     }
 
     // x.y.z()


### PR DESCRIPTION
Not fully tested because I still struggle with wrapping my brain around derefs, but it fixes the Eternia error.