### PR TITLE
Adds support for creating an overlay from a typepath

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -120,5 +120,45 @@ namespace OpenDreamRuntime {
 
             return appearance;
         }
+
+        public IconAppearance CreateAppearanceFromAtom(DreamObjectDefinition def) {
+            IconAppearance appearance = new IconAppearance();
+
+            if (def.TryGetVariable("icon", out var iconVar) && iconVar.TryGetValueAsDreamResource(out DreamResource icon)) {
+                appearance.Icon = icon.ResourcePath;
+            }
+
+            if (def.TryGetVariable("icon_state", out var stateVar) && stateVar.TryGetValueAsString(out string iconState)) {
+                appearance.IconState = iconState;
+            }
+
+            if (def.TryGetVariable("color", out var colorVar) && colorVar.TryGetValueAsString(out string color)) {
+                appearance.SetColor(color);
+            }
+
+            if (def.TryGetVariable("dir", out var dirVar) && dirVar.TryGetValueAsInteger(out int dir)) {
+                appearance.Direction = (AtomDirection)dir;
+            }
+
+            if (def.TryGetVariable("invisibility", out var invisVar) && invisVar.TryGetValueAsInteger(out int invisibility)) {
+                appearance.Invisibility = invisibility;
+            }
+
+            if (def.TryGetVariable("mouse_opacity", out var mouseVar) && mouseVar.TryGetValueAsInteger(out int mouseOpacity)) {
+                appearance.MouseOpacity = (MouseOpacity)mouseOpacity;
+            }
+
+            def.TryGetVariable("pixel_x", out var xVar);
+            xVar.TryGetValueAsInteger(out int pixelX);
+            def.TryGetVariable("pixel_y", out var yVar);
+            yVar.TryGetValueAsInteger(out int pixelY);
+            appearance.PixelOffset = new Vector2i(pixelX, pixelY);
+
+            if (def.TryGetVariable("layer", out var layerVar) && layerVar.TryGetValueAsFloat(out float layer)) {
+                appearance.Layer = layer;
+            }
+
+            return appearance;
+        }
     }
 }

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -121,7 +121,7 @@ namespace OpenDreamRuntime {
             return appearance;
         }
 
-        public IconAppearance CreateAppearanceFromAtom(DreamObjectDefinition def) {
+        public IconAppearance CreateAppearanceFromDefinition(DreamObjectDefinition def) {
             IconAppearance appearance = new IconAppearance();
 
             if (def.TryGetVariable("icon", out var iconVar) && iconVar.TryGetValueAsDreamResource(out DreamResource icon)) {

--- a/OpenDreamRuntime/IAtomManager.cs
+++ b/OpenDreamRuntime/IAtomManager.cs
@@ -14,6 +14,6 @@ namespace OpenDreamRuntime {
         public void UpdateAppearance(DreamObject atom, Action<IconAppearance> update);
         public void AnimateAppearance(DreamObject atom, TimeSpan duration, Action<IconAppearance> animate);
         public IconAppearance CreateAppearanceFromAtom(DreamObject atom);
-        public IconAppearance CreateAppearanceFromAtom(DreamObjectDefinition def);
+        public IconAppearance CreateAppearanceFromDefinition(DreamObjectDefinition def);
     }
 }

--- a/OpenDreamRuntime/IAtomManager.cs
+++ b/OpenDreamRuntime/IAtomManager.cs
@@ -14,5 +14,6 @@ namespace OpenDreamRuntime {
         public void UpdateAppearance(DreamObject atom, Action<IconAppearance> update);
         public void AnimateAppearance(DreamObject atom, TimeSpan duration, Action<IconAppearance> animate);
         public IconAppearance CreateAppearanceFromAtom(DreamObject atom);
+        public IconAppearance CreateAppearanceFromAtom(DreamObjectDefinition def);
     }
 }

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -103,6 +103,16 @@ namespace OpenDreamRuntime.Objects {
             return Variables.ContainsKey(variableName);
         }
 
+        public bool TryGetVariable(string varName, out DreamValue value) {
+            if (Variables.TryGetValue(varName, out value)) {
+                return true;
+            } else if (_parentObjectDefinition != null) {
+                return _parentObjectDefinition.TryGetVariable(varName, out value);
+            } else {
+                return false;
+            }
+        }
+
         public bool IsSubtypeOf(DreamPath path) {
             if (Type.IsDescendantOf(path)) return true;
             else if (_parentObjectDefinition != null) return _parentObjectDefinition.IsSubtypeOf(path);

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -253,7 +253,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             } else if (value.TryGetValueAsPath(out DreamPath path))
             {
                 var def = _dreamManager.ObjectTree.GetObjectDefinition(path);
-                appearance = _atomManager.CreateAppearanceFromAtom(def);
+                appearance = _atomManager.CreateAppearanceFromDefinition(def);
             }
             else {
                 throw new Exception($"Invalid overlay {value}");

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -247,9 +247,15 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 appearance.Layer = image.GetVariable("layer").GetValueAsFloat();
                 appearance.PixelOffset.X = image.GetVariable("pixel_x").GetValueAsInteger();
                 appearance.PixelOffset.Y = image.GetVariable("pixel_y").GetValueAsInteger();
-            } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Atom, out DreamObject overlayAtom)) {
+            } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Atom, out DreamObject overlayAtom))
+            {
                 appearance = _atomManager.CreateAppearanceFromAtom(overlayAtom);
-            } else {
+            } else if (value.TryGetValueAsPath(out DreamPath path))
+            {
+                var def = _dreamManager.ObjectTree.GetObjectDefinition(path);
+                appearance = _atomManager.CreateAppearanceFromAtom(def);
+            }
+            else {
                 throw new Exception($"Invalid overlay {value}");
             }
 


### PR DESCRIPTION
Per the ref you can do `overlays += /path/of/type`

http://www.byond.com/docs/ref/#/atom/var/overlays

According to Nadrew, this doesn't actually instantiate the type and is equivalent to `initial()`ing the relevant vars