### PR TITLE
Reduce `DreamList` allocs + misc cleanup

### DIFF
--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -5,14 +5,14 @@ using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 
 namespace DMCompiler.DM.Visitors {
-    class DMVisitorExpression : DMASTVisitor {
+    sealed class DMVisitorExpression : DMASTVisitor {
         DMObject _dmObject { get; }
         DMProc _proc { get; }
         DreamPath? _inferredPath { get; }
         internal DMExpression Result { get; private set; }
 
         // NOTE This needs to be turned into a Stack of modes if more complicated scope changes are added in the future
-        static public string _scopeMode;
+        public static string _scopeMode;
 
         internal DMVisitorExpression(DMObject dmObject, DMProc proc, DreamPath? inferredPath)
         {

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -251,6 +251,10 @@ namespace OpenDreamRuntime {
 
         public void HandleException(Exception exception)
         {
+            if(_current is DMProcState state)
+            {
+                state.ReturnPools();
+            }
             var dreamMan = IoCManager.Resolve<IDreamManager>();
             dreamMan.DMExceptionCount += 1;
 

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -1,22 +1,25 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenDreamRuntime.Procs;
-using Robust.Shared.IoC;
+using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Objects {
     delegate void DreamListValueAssignedEventHandler(DreamList list, DreamValue key, DreamValue value);
     delegate void DreamListBeforeValueRemovedEventHandler(DreamList list, DreamValue key, DreamValue value);
 
-    public class DreamList : DreamObject {
-        internal event DreamListValueAssignedEventHandler ValueAssigned;
-        internal event DreamListBeforeValueRemovedEventHandler BeforeValueRemoved;
+    [Virtual]
+    public class DreamList : DreamObject
+    {
+        private static DreamObjectDefinition? _listDef;
+
+        internal event DreamListValueAssignedEventHandler? ValueAssigned;
+        internal event DreamListBeforeValueRemovedEventHandler? BeforeValueRemoved;
 
         private List<DreamValue> _values = new();
         private Dictionary<DreamValue, DreamValue> _associativeValues = null;
 
-        protected DreamList() : base(null) {
-            ObjectDefinition = IoCManager.Resolve<IDreamManager>().ObjectTree.List.ObjectDefinition;
+        protected DreamList() : base(null)
+        {
+            ObjectDefinition = _listDef ??= IoCManager.Resolve<IDreamManager>().ObjectTree.GetObjectDefinition(DreamPath.List);
         }
 
         public static DreamList CreateUninitialized() {
@@ -176,7 +179,7 @@ namespace OpenDreamRuntime.Objects {
     }
 
     // /datum.vars list
-    class DreamListVars : DreamList {
+    sealed class DreamListVars : DreamList {
         private DreamObject _dreamObject;
 
         private DreamListVars(DreamObject dreamObject) : base() {

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -4,13 +4,14 @@ using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Objects {
+    [Virtual]
     public class DreamObject {
-        public DreamObjectDefinition ObjectDefinition { get; protected set; }
+        public DreamObjectDefinition? ObjectDefinition { get; protected set; }
         public bool Deleted = false;
 
         private Dictionary<string, DreamValue> _variables = new();
 
-        public DreamObject(DreamObjectDefinition objectDefinition) {
+        public DreamObject(DreamObjectDefinition? objectDefinition) {
             ObjectDefinition = objectDefinition;
         }
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -23,7 +23,6 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public TreeEntry[] Types;
-        public TreeEntry List;
         public List<string> Strings; //TODO: Store this somewhere else
 
         private Dictionary<DreamPath, TreeEntry> _pathToType = new();
@@ -32,7 +31,6 @@ namespace OpenDreamRuntime.Objects {
             Strings = json.Strings;
 
             LoadTypesFromJson(json.Types);
-            List = GetTreeEntry(DreamPath.List);
         }
 
         public bool HasTreeEntry(DreamPath path) {


### PR DESCRIPTION
`EnumeratorStack` now only allocs when it's needed (we should copy maxstack logic for these at some point).

Every `DreamList` no longer tries to resolve `IDreamManager` in its constructor, instead the first one does and caches the list definition in a static var. Resolves are relatively expensive.

The two arraypool returns are now in a method and it's been added to `HandleException()`

Misc additions of `sealed`, etc.