### PR TITLE
Reduces `PushArguments` allocs

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -382,9 +382,10 @@ namespace DMCompiler.DM {
         }
 
         public void PushArguments(int argumentCount, DreamProcOpcodeParameterType[] parameterTypes = null, string[] parameterNames = null) {
-            ShrinkStack(argumentCount - 1); //Pops argumentCount, pushes 1
+            ShrinkStack(argumentCount - 2); //Pops argumentCount & parameterNames.Length, pushes 1
             WriteOpcode(DreamProcOpcode.PushArguments);
             WriteInt(argumentCount);
+            WriteInt(parameterNames?.Length ?? 0);
 
             if (argumentCount > 0) {
                 if (parameterTypes == null || parameterTypes.Length != argumentCount) {

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -382,7 +382,7 @@ namespace DMCompiler.DM {
         }
 
         public void PushArguments(int argumentCount, DreamProcOpcodeParameterType[] parameterTypes = null, string[] parameterNames = null) {
-            ShrinkStack(argumentCount - 2); //Pops argumentCount & parameterNames.Length, pushes 1
+            ShrinkStack(argumentCount - 1); //Pops argumentCount, pushes 1
             WriteOpcode(DreamProcOpcode.PushArguments);
             WriteInt(argumentCount);
             WriteInt(parameterNames?.Length ?? 0);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -248,7 +248,7 @@ namespace OpenDreamRuntime.Procs {
             int argumentCount = state.ReadInt();
             int namedCount = state.ReadInt();
             int unnamedCount = argumentCount - namedCount;
-            DreamProcArguments arguments = new DreamProcArguments(unnamedCount > 0 ? new List<DreamValue>(argumentCount - namedCount) : null, namedCount > 0 ? new Dictionary<string, DreamValue>(namedCount) : null);
+            DreamProcArguments arguments = new DreamProcArguments(unnamedCount > 0 ? new List<DreamValue>(unnamedCount) : null, namedCount > 0 ? new Dictionary<string, DreamValue>(namedCount) : null);
             DreamValue[]? argumentValues = argumentCount > 0 ? new DreamValue[argumentCount] : null;
 
             for (int i = argumentCount - 1; i >= 0; i--) {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -245,9 +245,11 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public static ProcStatus? PushArguments(DMProcState state) {
-            DreamProcArguments arguments = new DreamProcArguments(new List<DreamValue>(), new Dictionary<string, DreamValue>());
             int argumentCount = state.ReadInt();
-            DreamValue[] argumentValues = new DreamValue[argumentCount];
+            int namedCount = state.ReadInt();
+            int unnamedCount = argumentCount - namedCount;
+            DreamProcArguments arguments = new DreamProcArguments(unnamedCount > 0 ? new List<DreamValue>(argumentCount - namedCount) : null, namedCount > 0 ? new Dictionary<string, DreamValue>(namedCount) : null);
+            DreamValue[]? argumentValues = argumentCount > 0 ? new DreamValue[argumentCount] : null;
 
             for (int i = argumentCount - 1; i >= 0; i--) {
                 argumentValues[i] = state.Pop();


### PR DESCRIPTION
The list, dict, and array are allocated as-needed and as their necessary size. The number of named vars is passed to accommodate this.