### PR TITLE
Adds `SEEMOBS` and `SEETURFS`

### DIFF
--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -57,9 +57,11 @@
 #define SEE_INFRA		(1<<6)     // can see infra-red objects
 #define SEE_SELF		(1<<5) // can see self, no matter what
 #define SEE_MOBS		(1<<2) // can see all mobs, no matter what
+#define SEEMOBS			(1<<2) // undocumented, identical to SEE_MOBS
 #define SEE_OBJS		(1<<3) // can see all objs, no matter what
 #define SEEOBJS			(1<<3) // undocumented, identical to SEE_OBJS
 #define SEE_TURFS		(1<<4) // can see all turfs (and areas), no matter what
+#define SEETURFS		(1<<4) // undocumented, identical to SEE_TURFS
 #define SEE_PIXELS		(1<<8) // if an object is located on an unlit area, but some of its pixels are in a lit area (via pixel_x,y or smooth movement), can see those pixels
 #define SEE_THRU		(1<<9) // can see through opaque objects
 #define SEE_BLACKNESS	(1<<10) // render dark tiles as blackness


### PR DESCRIPTION
I tried every flavor of the `SEE_` macros without underscores and these are all of the valid ones we were missing.