### PR TITLE
Nuke `list()` allocs and fix `del()`

### DIFF
--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -56,7 +56,7 @@ namespace OpenDreamRuntime.Objects {
             for (int i = start; i < end; i++) {
                 DreamValue value = _values[i - 1];
 
-                copy._values[i - 1] = value;
+                copy._values.Add(value);
                 if (ContainsKey(value)) {
                     copy.SetValue(value, _associativeValues[value]);
                 }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -31,8 +31,8 @@ namespace OpenDreamRuntime.Objects {
             return new DreamList(size);
         }
 
-        public static DreamList Create(IEnumerable<object> collection) {
-            var list = new DreamList();
+        public static DreamList Create(string[] collection) {
+            var list = new DreamList(collection.Length);
 
             foreach (object value in collection) {
                 list._values.Add(new DreamValue(value));

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -14,20 +14,21 @@ namespace OpenDreamRuntime.Objects {
         internal event DreamListValueAssignedEventHandler? ValueAssigned;
         internal event DreamListBeforeValueRemovedEventHandler? BeforeValueRemoved;
 
-        private List<DreamValue> _values = new();
-        private Dictionary<DreamValue, DreamValue> _associativeValues = null;
+        private List<DreamValue> _values;
+        private Dictionary<DreamValue, DreamValue>? _associativeValues;
 
-        protected DreamList() : base(null)
+        protected DreamList(int size = 0) : base(null)
         {
+            _values = new List<DreamValue>(size);
             ObjectDefinition = _listDef ??= IoCManager.Resolve<IDreamManager>().ObjectTree.GetObjectDefinition(DreamPath.List);
         }
 
-        public static DreamList CreateUninitialized() {
-            return new DreamList();
+        public static DreamList CreateUninitialized(int size = 0) {
+            return new DreamList(size);
         }
 
-        public static DreamList Create() {
-            return new DreamList();
+        public static DreamList Create(int size = 0) {
+            return new DreamList(size);
         }
 
         public static DreamList Create(IEnumerable<object> collection) {
@@ -45,16 +46,17 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public DreamList CreateCopy(int start = 1, int end = 0) {
-            DreamList copy = Create();
 
             if (start == 0) ++start; //start being 0 and start being 1 are equivalent
             if (end > _values.Count + 1) throw new Exception("list index out of bounds");
             if (end == 0) end = _values.Count + 1;
 
+            DreamList copy = Create(end);
+
             for (int i = start; i < end; i++) {
                 DreamValue value = _values[i - 1];
 
-                copy._values.Add(value);
+                copy._values[i - 1] = value;
                 if (ContainsKey(value)) {
                     copy.SetValue(value, _associativeValues[value]);
                 }

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -57,8 +57,8 @@ namespace OpenDreamRuntime.Objects {
 
         public void Delete(IDreamManager manager) {
             if (Deleted) return;
+            ObjectDefinition?.MetaObject?.OnObjectDeleted(this);
             Deleted = true;
-            ObjectDefinition.MetaObject?.OnObjectDeleted(this);
             //we release all relevant information, making this a very tiny object
             _variables = null;
             ObjectDefinition = null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -588,7 +588,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             DMIParser.ParsedDMIDescription parsedDMI = DMIParser.ParseDMI(new MemoryStream(resource.ResourceData));
 
-            return new DreamValue(DreamList.Create(parsedDMI.States.Keys));
+            return new DreamValue(DreamList.Create(parsedDMI.States.Keys.ToArray()));
         }
 
         [DreamProc("image")]

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -99,14 +99,18 @@ namespace OpenDreamRuntime.Resources
             return true;
         }
 
-        public IEnumerable<string> EnumerateListing(string path) {
+        public string[] EnumerateListing(string path)
+        {
             string directory = Path.Combine(RootPath, Path.GetDirectoryName(path));
             string searchPattern = Path.GetFileName(path);
 
-            var entries = Directory.EnumerateFileSystemEntries(directory, searchPattern);
-            foreach (string entry in entries) {
-                yield return Path.GetRelativePath(directory, entry);
+            var entries = Directory.GetFileSystemEntries(directory, searchPattern);
+            for (var i = 0; i < entries.Length; i++) {
+                var relPath = Path.GetRelativePath(directory, entries[i]);
+                if (Directory.Exists(entries[i])) relPath += "/";
+                entries[i] = relPath;
             }
+            return entries;
         }
     }
 }


### PR DESCRIPTION
- Lists can now allocate the correct size initially
- `EnumerateListing()` now returns a string array and as a bonus I made it append `/` to dirs like the ref says `flist()` does.
- `public static DreamList Create(IEnumerable<object> collection)` is now `public static DreamList Create(string[] collection)` since they're all string arrays anyways
- `del()` no longer throws an exception. `OnObjectDeleted()` tries to access the `loc` variable, so it needs to not be `Deleted` yet.