### PR TITLE
Make list.Remove remove the last match instead of the first

### DIFF
--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -95,7 +95,7 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public void RemoveValue(DreamValue value) {
-            int valueIndex = _values.IndexOf(value);
+            int valueIndex = _values.LastIndexOf(value);
 
             if (valueIndex != -1) {
                 BeforeValueRemoved?.Invoke(this, new DreamValue(valueIndex), _values[valueIndex]);


### PR DESCRIPTION
In DM, removing from a list always removes the last match, not the first.