### PR TITLE
Recompile DMMs without recompiling code

### DIFF
--- a/DMCompiler/DMCompiler.csproj
+++ b/DMCompiler/DMCompiler.csproj
@@ -10,20 +10,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DMStandard Include="DMStandard\**"/>
+    <DMStandard Include="DMStandard\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.Caching" Version="7.0.0-preview.2.22152.2" />
   </ItemGroup>
 
   <Target Name="CopyDMStandard" AfterTargets="AfterBuild">
-    <Copy
-      SourceFiles="@(DMStandard)"
-      DestinationFiles="@(DMStandard->'$(OutDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
+    <Copy SourceFiles="@(DMStandard)" DestinationFiles="@(DMStandard->'$(OutDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   <Target Name="CopyDMStandardOnPublish" AfterTargets="Publish">
-    <Copy
-      SourceFiles="@(DMStandard)"
-      DestinationFiles="@(DMStandard->'$(PublishDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
+    <Copy SourceFiles="@(DMStandard)" DestinationFiles="@(DMStandard->'$(PublishDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
 

--- a/DMCompiler/IncrementalDMM.cs
+++ b/DMCompiler/IncrementalDMM.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Caching;
+using OpenDreamShared.Json;
+
+namespace DMCompiler;
+
+public class IncrementalDMM
+{
+    // Use a cache to stop double FileSystemWatcher events from being problematic
+    private readonly MemoryCache _cache;
+    private const int CacheTimeMilliseconds = 500;
+    private readonly CacheItemPolicy _cachePolicy;
+    private readonly FileSystemWatcher _dmmWatcher; // The watcher needs to be saved somewhere
+
+    public IncrementalDMM()
+    {
+        Console.WriteLine("DMM recompilation (--incremental-dmm) is an experimental feature. Use at your own risk. Only edits to existing DMM files are currently supported.");
+        _cache = MemoryCache.Default;
+        _cachePolicy = new CacheItemPolicy()
+        {
+            RemovedCallback = HandleWatcherEvent
+        };
+        var path = Path.GetDirectoryName(DMCompiler.Settings.Files?[0]) ?? AppDomain.CurrentDomain.BaseDirectory;
+        _dmmWatcher = new FileSystemWatcher(path);
+        _dmmWatcher.Filter = "*.dmm";
+        _dmmWatcher.NotifyFilter = NotifyFilters.LastWrite;
+        _dmmWatcher.IncludeSubdirectories = true;
+        _dmmWatcher.EnableRaisingEvents = true;
+        _dmmWatcher.Changed += OnDMMEdit;
+    }
+    private void OnDMMEdit(object sender, FileSystemEventArgs e)
+    {
+        if (e.ChangeType != WatcherChangeTypes.Changed)
+        {
+            return;
+        }
+
+        _cachePolicy.AbsoluteExpiration = DateTimeOffset.Now.AddMilliseconds(CacheTimeMilliseconds);
+        _cache.AddOrGetExisting(e.Name, e, _cachePolicy);
+    }
+
+    private void HandleWatcherEvent(CacheEntryRemovedArguments args)
+    {
+        if (args.RemovedReason != CacheEntryRemovedReason.Expired) return;
+        var mapevent = (FileSystemEventArgs) args.CacheItem.Value;
+
+        // Only edits to existing files are supported right now
+        if (mapevent.ChangeType != WatcherChangeTypes.Changed) return;
+        DMMChanged(mapevent);
+    }
+
+    private void DMMChanged(FileSystemEventArgs args)
+    {
+        if (args.ChangeType != WatcherChangeTypes.Changed) return;
+
+        Console.WriteLine($"DMM Changed: {args.Name} ({args.FullPath})");
+        ReparseMaps();
+    }
+
+    private void ReparseMaps()
+    {
+        string outputFile = Path.ChangeExtension(DMCompiler.Settings.Files[0], "json");
+        List<DreamMapJson> maps = DMCompiler.ConvertMaps(DMCompiler.Preprocessor.IncludedMaps);
+
+        DMCompiler.SaveJson(maps, DMCompiler.Preprocessor.IncludedInterface, outputFile);
+    }
+}

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -11,6 +11,42 @@ namespace DMCompiler {
                 //Compile errors, exit with an error code
                 Environment.Exit(1);
             }
+
+            if (!DMCompiler.Settings.QuitOnCompletion)
+            {
+                var msg = "Enter 'exit' to quit or '--help' for more options";
+                string input;
+                do
+                {
+                    Console.WriteLine(msg);
+                    input = Console.ReadLine();
+                    HandleCommand(input);
+                } while (input != "exit");
+                Environment.Exit(0);
+            }
+        }
+
+        private static void HandleCommand(string input)
+        {
+            switch (input)
+            {
+                case "--help":
+                {
+                    Console.WriteLine("Valid commands:");
+                    Console.WriteLine("\t--help - See this info");
+                    Console.WriteLine("\t--exit - Exit the program. 'exit' also works");
+                    break;
+                }
+                case "--exit":
+                case "exit":
+                {
+                    Environment.Exit(0);
+                    break;
+                }
+                default:
+                    Console.WriteLine($"Unknown command '{input}'");
+                    break;
+            }
         }
 
         private static bool TryParseArguments(string[] args, out DMCompilerSettings settings) {
@@ -23,6 +59,12 @@ namespace DMCompiler {
                     case "--dump-preprocessor": settings.DumpPreprocessor = true; break;
                     case "--no-standard": settings.NoStandard = true; break;
                     case "--verbose": settings.Verbose = true; break;
+                    case "--incremental-dmm":
+                    {
+                        settings.IncrementalDMM = true;
+                        settings.QuitOnCompletion = false;
+                        break;
+                    }
                     default: {
                         string extension = Path.GetExtension(arg);
 


### PR DESCRIPTION
Adds the ability to recompile DMMs without recompiling game code.

Right now this is fairly limited, and only supports making edits to existing files. It also recompiles *all* maps instead of just the edited map. Detection also isn't instantaneous and can take a few seconds. But all of that can be improved in the future.

It also lays some groundwork for leaving the program running, which will only happen if the `--incremental-dmm` arg is passed. But this is needed to support features like actual incremental compilation, a REPL, hotloading(?), etc.