### PR TITLE
Adds an OPENDREAM define

### DIFF
--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -1,6 +1,8 @@
 ﻿#define TRUE 1
 #define FALSE 0
 
+#define OPENDREAM 1
+
 #define NORTH 1
 #define SOUTH 2
 #define EAST 4


### PR DESCRIPTION
example usecase:
```
#idef OPENDREAM
var/rustg = "rustg_x64.dll"
#else
var/rustg = "rustg.dll"
#endif
```