### PR TITLE
Adds a merge conflict Github Action

### DIFF
--- a/.github/workflows/conflict-labeler.yml
+++ b/.github/workflows/conflict-labeler.yml
@@ -1,0 +1,18 @@
+name: Add Extra PR labels
+
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+
+jobs:
+  Label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Merge Conflicts
+        uses: eps1lon/actions-label-merge-conflict@513a24fc7dca40990863be2935e059e650728400
+        with:
+          dirtyLabel: "Merge Conflict"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."


### PR DESCRIPTION
The problem with the old merge conflict action was that the lack of any notification for the PR author made it largely useless.

This action is directly copied from BeeStation here: https://github.com/BeeStation/BeeStation-Hornet/blob/master/.github/workflows/extra_pr_labels.yml 

The workflow notifies the PR author by leaving a comment like so: https://github.com/BeeStation/BeeStation-Hornet/pull/6125#issuecomment-1032996734

It also adds the Merge Conflict label. When the conflicts are fixed it'll remove the label.