### PR TITLE
Make `HandleMsgTopic()` cope with non-ints

### DIFF
--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -203,9 +203,7 @@ namespace OpenDreamRuntime
             DreamValue srcRefValue = hrefList.GetValue(new DreamValue("src"));
             DreamObject src = null;
 
-            if (srcRefValue.Value != null) {
-                int srcRef = int.Parse(srcRefValue.GetValueAsString());
-
+            if (srcRefValue.Value != null && int.TryParse(srcRefValue.GetValueAsString(), out var srcRef)) {
                 src = DreamObject.GetFromReferenceID(_dreamManager, srcRef);
             }
 


### PR DESCRIPTION
This came up during the whole trying to get Para's Declare Ready to work.