### PR TITLE
Adds a cvar to always print exceptions to console

### DIFF
--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -151,6 +151,10 @@ namespace OpenDreamRuntime {
             else
             {
                 logRsc.Output(new DreamValue($"[{LogMessage.LogLevelToName(level)}] world.log: {message}"));
+                if (_configManager.GetCVar(OpenDreamCVars.AlwaysShowExceptions))
+                {
+                    Logger.LogS(level, "world.log", message);
+                }
             }
         }
     }

--- a/OpenDreamServer/server_config.toml
+++ b/OpenDreamServer/server_config.toml
@@ -42,6 +42,8 @@ welcomemsg = "Welcome to the server!"
 [opendream]
 # The path to DMCompiler's output
 json_path = ""
+# If true, exceptions will always print to the console in addition to the world.log file (if set)
+always_show_exceptions = false
 
 # These are actually client cvars that, currently, have to be passed as program args.
 # Documented here in hopes that we'll have a client_config.toml without using the launcher one day

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -10,5 +10,8 @@ namespace OpenDreamShared {
 
         public static readonly CVarDef<int> DownloadTimeout =
             CVarDef.Create("opendream.download_timeout", 30, CVar.CLIENTONLY);
+
+        public static readonly CVarDef<bool> AlwaysShowExceptions =
+            CVarDef.Create("opendream.always_show_exceptions", false, CVar.SERVERONLY);
     }
 }


### PR DESCRIPTION
This doesn't interfere with `world.log` logging besides *also* printing to the terminal if `world.log` is a file.