### PR TITLE
Two small fixes

### DIFF
--- a/DMCompiler/Compiler/DM/DMLexer.cs
+++ b/DMCompiler/Compiler/DM/DMLexer.cs
@@ -25,7 +25,8 @@ namespace DMCompiler.Compiler.DM {
             "red", "blue", "green", "black",
             "bold", "b",
             "italic",
-            "..."            //TODO: ASCII/Unicode values
+            "u", "U", "x",  //TODO: ASCII/Unicode values *properly*
+            "..."
         };
 
         public static Dictionary<string, TokenType> Keywords = new() {

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1362,6 +1362,7 @@ namespace DMCompiler.Compiler.DM {
         public DMASTCallParameter[] CallParameters() {
             List<DMASTCallParameter> parameters = new();
             DMASTCallParameter parameter = CallParameter();
+            BracketWhitespace();
 
             while (Check(TokenType.DM_Comma)) {
                 BracketWhitespace();

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1369,6 +1369,7 @@ namespace DMCompiler.Compiler.DM {
                 var loc = Current().Location;
                 parameters.Add(parameter ?? new DMASTCallParameter(loc, new DMASTConstantNull(loc)));
                 parameter = CallParameter();
+                BracketWhitespace();
             }
 
             if (parameter != null) {


### PR DESCRIPTION
1. Fixes whitespace between the first proccall param and first comma.
2. Adds the unicode escape chars.