### PR TITLE
Implements the addtext() proc

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -52,6 +52,7 @@ namespace DMCompiler.Compiler.DM {
         public void VisitStringFormat(DMASTStringFormat stringFormat) { throw new NotImplementedException(); }
         public void VisitList(DMASTList list) { throw new NotImplementedException(); }
         public void VisitNewList(DMASTNewList newList) { throw new NotImplementedException(); }
+        public void VisitAddText(DMASTAddText input) { throw new NotImplementedException(); }
         public void VisitInput(DMASTInput input) { throw new NotImplementedException(); }
         public void VisitInitial(DMASTInitial initial) { throw new NotImplementedException(); }
         public void VisitIsSaved(DMASTIsSaved isSaved) { throw new NotImplementedException(); }
@@ -855,14 +856,29 @@ namespace DMCompiler.Compiler.DM {
         }
     }
 
-    public class DMASTNewList : DMASTExpression {
+    public class DMASTAddText : DMASTExpression {
         public DMASTCallParameter[] Parameters;
 
-        public DMASTNewList(Location location, DMASTCallParameter[] parameters) : base(location) {
+        public DMASTAddText(Location location, DMASTCallParameter[] parameters) : base(location) {
             Parameters = parameters;
         }
 
         public override void Visit(DMASTVisitor visitor) {
+            visitor.VisitAddText(this);
+        }
+    }
+
+    public class DMASTNewList : DMASTExpression
+    {
+        public DMASTCallParameter[] Parameters;
+
+        public DMASTNewList(Location location, DMASTCallParameter[] parameters) : base(location)
+        {
+            Parameters = parameters;
+        }
+
+        public override void Visit(DMASTVisitor visitor)
+        {
             visitor.VisitNewList(this);
         }
     }

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2222,6 +2222,7 @@ namespace DMCompiler.Compiler.DM {
                 switch (identifier.Identifier) {
                     case "list": return new DMASTList(identifier.Location, callParameters);
                     case "newlist": return new DMASTNewList(identifier.Location, callParameters);
+                    case "addtext": return new DMASTAddText(identifier.Location, callParameters);
                     case "input": {
                         Whitespace();
                         DMValueType types = AsTypes(defaultType: DMValueType.Text);

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -773,6 +773,12 @@ namespace DMCompiler.DM {
             WriteInt(count);
         }
 
+        public void MassConcatenation(int count) {
+            ShrinkStack(count - 1);
+            WriteOpcode(DreamProcOpcode.MassConcatenation);
+            WriteInt(count);
+        }
+
         public void Locate() {
             ShrinkStack(1);
             WriteOpcode(DreamProcOpcode.Locate);

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -206,26 +206,22 @@ namespace DMCompiler.DM.Expressions {
     // https://www.byond.com/docs/ref/#/proc/addtext
     class AddText : DMExpression
     {
-        DMASTAddText _astNode;
-        public AddText(Location location, DMASTAddText astNode) : base(location)
+        readonly DMExpression[] parameters;
+        public AddText(Location location, DMExpression[] paras) : base(location)
         {
-            _astNode = astNode;
+            parameters = paras;
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc)
         {
-            if (_astNode.Parameters.Length == 0) throw new CompileErrorException(_astNode.Location, "Invalid addtext() parameter count");
+            //We don't have to do any checking of our parameters since that was already done by VisitAddText(), hopefully. :)
 
             //Push addtext's arguments (in reverse, otherwise the strings will be concatenated in reverse, lol)
-            for (int i = _astNode.Parameters.Length - 1; i >= 0; i--)
+            for (int i = parameters.Length - 1; i >= 0; i--) 
             {
-                DMASTCallParameter parameter = _astNode.Parameters[i];
-
-                if (parameter.Name != null) throw new CompileErrorException(parameter.Location, "addtext() does not take named arguments");
-                DMExpression.Create(dmObject, proc, parameter.Value).EmitPushValue(dmObject, proc);
+                parameters[i].EmitPushValue(dmObject, proc);
             }
-
-            proc.MassConcatenation(_astNode.Parameters.Length);
+            proc.MassConcatenation(parameters.Length);
         }
     }
 

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -202,6 +202,33 @@ namespace DMCompiler.DM.Expressions {
         }
     }
 
+    // addtext(...)
+    // https://www.byond.com/docs/ref/#/proc/addtext
+    class AddText : DMExpression
+    {
+        DMASTAddText _astNode;
+        public AddText(Location location, DMASTAddText astNode) : base(location)
+        {
+            _astNode = astNode;
+        }
+
+        public override void EmitPushValue(DMObject dmObject, DMProc proc)
+        {
+            if (_astNode.Parameters.Length == 0) throw new CompileErrorException(_astNode.Location, "Invalid addtext() parameter count");
+
+            //Push addtext's arguments (in reverse, otherwise the strings will be concatenated in reverse, lol)
+            for (int i = _astNode.Parameters.Length - 1; i >= 0; i--)
+            {
+                DMASTCallParameter parameter = _astNode.Parameters[i];
+
+                if (parameter.Name != null) throw new CompileErrorException(parameter.Location, "addtext() does not take named arguments");
+                DMExpression.Create(dmObject, proc, parameter.Value).EmitPushValue(dmObject, proc);
+            }
+
+            proc.MassConcatenation(_astNode.Parameters.Length);
+        }
+    }
+
     // issaved(x)
     class IsSaved : DMExpression {
         DMExpression _expr;

--- a/DMCompiler/DM/Visitors/DMASTSimplifier.cs
+++ b/DMCompiler/DM/Visitors/DMASTSimplifier.cs
@@ -526,6 +526,16 @@ namespace DMCompiler.DM.Visitors {
                 return;
             }
 
+            DMASTAddText addtext = expression as DMASTAddText;
+            if(addtext != null) {
+                foreach (DMASTCallParameter parameter in addtext.Parameters)
+                {
+                    SimplifyExpression(ref parameter.Value);
+                }
+
+                return;
+            }
+
             DMASTNewPath newPath = expression as DMASTNewPath;
             if (newPath != null) {
                 if (newPath.Parameters != null) {

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -565,7 +565,16 @@ namespace DMCompiler.DM.Visitors {
         }
 
         public void VisitAddText(DMASTAddText addText) {
-            Result = new Expressions.AddText(addText.Location, addText);
+            if (addText.Parameters.Length < 2) throw new CompileErrorException(addText.Location, "Invalid addtext() parameter count; expected 2 or more arguments");
+            DMExpression[] exp_arr = new DMExpression[addText.Parameters.Length];
+            for (int i = 0; i < exp_arr.Length; i++)
+            {
+                DMASTCallParameter parameter = addText.Parameters[i];
+                if(parameter.Name != null)
+                    throw new CompileErrorException(parameter.Location, "addtext() does not take named arguments");
+                exp_arr[i] = DMExpression.Create(_dmObject,_proc, parameter.Value, _inferredPath);
+            }
+            Result = new Expressions.AddText(addText.Location, exp_arr);
         }
 
         public void VisitInput(DMASTInput input) {

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -564,6 +564,10 @@ namespace DMCompiler.DM.Visitors {
             Result = new Expressions.NewList(newList.Location, expressions);
         }
 
+        public void VisitAddText(DMASTAddText addText) {
+            Result = new Expressions.AddText(addText.Location, addText);
+        }
+
         public void VisitInput(DMASTInput input) {
             Result = new Expressions.Input(input.Location, input);
         }

--- a/DMCompiler/DMStandard/UnsortedAdditions.dm
+++ b/DMCompiler/DMStandard/UnsortedAdditions.dm
@@ -1,6 +1,4 @@
 ﻿
-/proc/addtext(...)
-	set opendream_unimplemented = TRUE
 /proc/bounds(Ref=src, Dist=0)
 	set opendream_unimplemented = TRUE
 /proc/bounds_dist(Ref, Target)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -3,6 +3,7 @@
 /var/world/world = null
 
 proc/abs(A)
+proc/addtext(...)
 proc/alert(Usr = usr, Message, Title, Button1 = "Ok", Button2, Button3)
 proc/animate(Object, time, loop, easing, flags)
 proc/arccos(X)

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1484,10 +1484,10 @@ namespace OpenDreamRuntime.Procs {
         public static ProcStatus? MassConcatenation(DMProcState state)
         {
             int count = state.ReadInt();
-            if (count == 1) // One argument -- In this case it's just a stringification operation :^)
+            if (count < 2) // One or zero arguments -- shouldn't really ever happen. addtext() compiletimes with <2 args and stringification should probably be a different opcode
             {
-                string str = state.Pop().Stringify();
-                state.Push(new DreamValue(str));
+                Logger.Warning("addtext() called with " + count.ToString() + " arguments at runtime."); // TODO: tweak this warning if this ever gets used for other sorts of string concat
+                state.Push(DreamValue.Null);
                 return null;
             }
             int estimated_string_size = count * 10; // FIXME: We can do better with string size prediction here.

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1494,7 +1494,10 @@ namespace OpenDreamRuntime.Procs {
             StringBuilder builder = new StringBuilder(estimated_string_size); // An approximate guess at how big this string is going to be.
             for(int i = 0; i < count; ++i)
             {
-                builder.Append(state.Pop().Stringify());
+                if (state.Pop().TryGetValueAsString(out var addStr))
+                {
+                    builder.Append(addStr);
+                }
             }
             state.Push(new DreamValue(builder.ToString()));
             return null;

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1477,6 +1477,29 @@ namespace OpenDreamRuntime.Procs {
             return null;
         }
 
+        ///<summary>Right now this is used exclusively by addtext() calls, to concatenate its arguments together,
+        ///but later it might make sense to have this be a simplification path for detected repetitive additions of strings,
+        ///so as to slightly reduce the amount of re-allocation taking place.
+        ///</summary>.
+        public static ProcStatus? MassConcatenation(DMProcState state)
+        {
+            int count = state.ReadInt();
+            if (count == 1) // One argument -- In this case it's just a stringification operation :^)
+            {
+                string str = state.Pop().Stringify();
+                state.Push(new DreamValue(str));
+                return null;
+            }
+            int estimated_string_size = count * 10; // FIXME: We can do better with string size prediction here.
+            StringBuilder builder = new StringBuilder(estimated_string_size); // An approximate guess at how big this string is going to be.
+            for(int i = 0; i < count; ++i)
+            {
+                builder.Append(state.Pop().Stringify());
+            }
+            state.Push(new DreamValue(builder.ToString()));
+            return null;
+        }
+
         public static ProcStatus? IsSaved(DMProcState state) {
             DreamValue owner = state.Pop();
             string property = state.ReadString();

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -125,7 +125,8 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.CompareEquivalent,
             DMOpcodeHandlers.CompareNotEquivalent,
             DMOpcodeHandlers.Throw,
-            DMOpcodeHandlers.IsInRange
+            DMOpcodeHandlers.IsInRange,
+            DMOpcodeHandlers.MassConcatenation
         };
         #endregion
 

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -93,7 +93,8 @@ namespace OpenDreamShared.Dream.Procs {
         CompareEquivalent = 0x58,
         CompareNotEquivalent = 0x59,
         Throw = 0x5A,
-        IsInRange = 0x5B
+        IsInRange = 0x5B,
+        MassConcatenation = 0x5C
     }
 
     public enum DreamProcOpcodeParameterType {

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -84,6 +84,10 @@
 		set category = "Test"
 		usr << output("help sec griffing me", "honk.browser:foo")
 
+	verb/test_addtext()
+		set category = "Test"
+		usr << addtext("This text ", "was added together from ", 4 ," things!");
+
 /mob/Stat()
 	if (statpanel("Status"))
 		stat("tick_usage", world.tick_usage)

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -84,10 +84,6 @@
 		set category = "Test"
 		usr << output("help sec griffing me", "honk.browser:foo")
 
-	verb/test_addtext()
-		set category = "Test"
-		usr << addtext("This text ", "was added together from ", 4 ," things!");
-
 /mob/Stat()
 	if (statpanel("Status"))
 		stat("tick_usage", world.tick_usage)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/162566195-6929dcb6-9416-4cb9-a01e-e5c11c8f5aaa.png)

## Summary
Hi!

I'm not really a C# programmer, more of a C++ person, but I thought of this project again and decided to try to help out.

This PR implements the (seldom used) ``/proc/addtext(...)`` proc. Beyond that though, I've added a new opcode for doing the mass concatenation of a set of ``DreamValues``. I have not tried to make Add() expressions optimize into that, but doing so might be a good idea; right now it may be that calling addtext() on many concatenations is faster. I have had pleasant experiences [implementing such things](https://github.com/Altoids1/Joao/pull/10) in my own programming language.