### PR TITLE
Fix proc definitions not passing current obj properly

### DIFF
--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -147,7 +147,7 @@ namespace DMCompiler.DM.Visitors {
 
                             if (varDeclaration.Value != null) {
                                 DMVisitorExpression._scopeMode = "static";
-                                DMExpression expression = DMExpression.Create(dmObject, DMObjectTree.GlobalInitProc, varDeclaration.Value, varDeclaration.Type);
+                                DMExpression expression = DMExpression.Create(dmObject, null, varDeclaration.Value, varDeclaration.Type);
                                 DMVisitorExpression._scopeMode = "normal";
                                 DMObjectTree.AddGlobalInitAssign(dmObject, proc.GetGlobalVariableId(varDeclaration.Name).Value, expression);
                             }

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -147,7 +147,7 @@ namespace DMCompiler.DM.Visitors {
 
                             if (varDeclaration.Value != null) {
                                 DMVisitorExpression._scopeMode = "static";
-                                DMExpression expression = DMExpression.Create(_currentObject, DMObjectTree.GlobalInitProc, varDeclaration.Value, varDeclaration.Type);
+                                DMExpression expression = DMExpression.Create(dmObject, DMObjectTree.GlobalInitProc, varDeclaration.Value, varDeclaration.Type);
                                 DMVisitorExpression._scopeMode = "normal";
                                 DMObjectTree.AddGlobalInitAssign(dmObject, proc.GetGlobalVariableId(varDeclaration.Name).Value, expression);
                             }


### PR DESCRIPTION
I don't think there is an issue for this but it does fix a bug with paradise.