### PR TITLE
Fixes dereferencing an assignment

### DIFF
--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -1,4 +1,5 @@
 using OpenDreamShared.Compiler;
+using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 
 namespace DMCompiler.DM.Expressions {

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -439,6 +439,8 @@ namespace DMCompiler.DM.Expressions {
 
     // x = y
     class Assignment : AssignmentBinaryOp {
+        public override DreamPath? Path => LHS.Path;
+        
         public Assignment(Location location, DMExpression lhs, DMExpression rhs)
             : base(location, lhs, rhs) { }
 


### PR DESCRIPTION
Closes #524

DM code: `(T = get_turf(H)).z` where `T` is the local `var/turf/T`