### PR TITLE
Adds `Location.Internal`

### DIFF
--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -35,7 +35,7 @@ namespace DMCompiler {
             _compileStartTime = DateTime.Now;
 
             if (settings.SuppressUnimplementedWarnings) {
-                Warning(new CompilerWarning(Location.Unknown, "Unimplemented proc & var warnings are currently suppressed"));
+                Warning(new CompilerWarning(Location.Internal, "Unimplemented proc & var warnings are currently suppressed"));
             }
 
             DMPreprocessor preprocessor = Preprocess(settings.Files);

--- a/OpenDreamShared/Compiler/Location.cs
+++ b/OpenDreamShared/Compiler/Location.cs
@@ -4,7 +4,14 @@ namespace OpenDreamShared.Compiler
 {
     public readonly struct Location
     {
+        /// <summary>
+        /// For when DM location information can't be determined.
+        /// </summary>
         public static readonly Location Unknown = new Location();
+        /// <summary>
+        /// For when internal OpenDream warnings/errors are raised.
+        /// </summary>
+        public static readonly Location Internal = new Location("<internal>", null, null);
 
         public Location(string filePath, int? line, int? column) {
             SourceFile = filePath;

--- a/OpenDreamShared/Compiler/Location.cs
+++ b/OpenDreamShared/Compiler/Location.cs
@@ -9,7 +9,7 @@ namespace OpenDreamShared.Compiler
         /// </summary>
         public static readonly Location Unknown = new Location();
         /// <summary>
-        /// For when internal OpenDream warnings/errors are raised.
+        /// For when internal OpenDream warnings/errors are raised or something internal needs to be passed a location.
         /// </summary>
         public static readonly Location Internal = new Location("<internal>", null, null);
 


### PR DESCRIPTION
IMO it's a good idea to differentiate between explicit warnings/errors raised internally by OD and actual unknown loc warnings/errors. There's probably more places that should be changed but the unimplemented warning is the most apparent.

Ex:
```
Compiling paradise.dme
Warning at <internal>: Unimplemented proc & var warnings are currently suppressed
```