### PR TITLE
Hardens the loop stack against exceptions, reduces allocs

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -323,7 +323,7 @@ namespace DMCompiler.DM {
             }
             else
             {
-                DMCompiler.Error(new CompilerError(Location.Internal, "Cannot pop empty loop stack"));
+                DMCompiler.Error(new CompilerError(Location, "Cannot pop empty loop stack"));
             }
 
             EndScope();

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -373,7 +373,7 @@ namespace DMCompiler.DM {
             }
             else
             {
-                DMCompiler.Error(new CompilerError(Location.Internal, "Cannot peek empty loop stack"));
+                DMCompiler.Error(new CompilerError(Location, "Cannot peek empty loop stack"));
             }
         }
 

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -431,7 +431,7 @@ namespace DMCompiler.DM {
             }
             else
             {
-                DMCompiler.Error(new CompilerError(Location.Internal, "Cannot peek empty loop stack"));
+                DMCompiler.Error(new CompilerError(Location, "Cannot peek empty loop stack"));
             }
         }
 

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -419,7 +419,7 @@ namespace DMCompiler.DM {
                 }
                 else
                 {
-                    DMCompiler.Error(new CompilerError(Location.Internal, "Cannot peek empty loop stack"));
+                    DMCompiler.Error(new CompilerError(Location, "Cannot peek empty loop stack"));
                 }
             }
         }

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -384,7 +384,7 @@ namespace DMCompiler.DM {
             }
             else
             {
-                DMCompiler.Error(new CompilerError(Location.Internal, "Cannot peek empty loop stack"));
+                DMCompiler.Error(new CompilerError(Location, "Cannot peek empty loop stack"));
             }
         }
 


### PR DESCRIPTION
1. Loop stacks only allocate when needed, and set their capacity to 3 initially (start, continue, end)
2. Loop stacks will now throw a compiler error instead of an exception if you pop them while they're null. I'm not sure what in baycode is causing this but the compiler should *never* really throw exceptions.