### PR TITLE
Fixes misc baystation issues

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -96,7 +96,8 @@ namespace DMCompiler.Compiler.DM {
             TokenType.DM_Proc,
             TokenType.DM_Step,
             TokenType.DM_Throw,
-            TokenType.DM_Null
+            TokenType.DM_Null,
+            TokenType.DM_Switch
         };
 
         public DMASTFile File() {
@@ -479,7 +480,13 @@ namespace DMCompiler.Compiler.DM {
                         Whitespace();
                         procStatements.Add(statement);
                     } else {
-                        if (procStatements.Count == 0) return null;
+                        if (procStatements.Count == 0)
+                        {
+                            // Sometimes ';' gets used in NOP blocks
+                            Delimiter();
+                            Whitespace();
+                            return null;
+                        }
                     }
                 } catch (CompileErrorException) {
                     LocateNextStatement();
@@ -1916,7 +1923,8 @@ namespace DMCompiler.Compiler.DM {
 
                         while (Current().Type != TokenType.DM_RightCurlyBracket && !Check(TokenType.EndOfFile)) Advance();
                         Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
-                        Newline(); //The lexer tosses in a newline after }
+                        //The lexer tosses in a newline after '}', but we avoid Newline() because we only want to remove the extra newline, not all of them
+                        Check(TokenType.Newline);
                     }
                 }
             }

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -97,7 +97,8 @@ namespace DMCompiler.Compiler.DM {
             TokenType.DM_Step,
             TokenType.DM_Throw,
             TokenType.DM_Null,
-            TokenType.DM_Switch
+            TokenType.DM_Switch,
+            TokenType.DM_Spawn
         };
 
         public DMASTFile File() {

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -480,14 +480,6 @@ namespace DMCompiler.Compiler.DM {
                     if (statement != null) {
                         Whitespace();
                         procStatements.Add(statement);
-                    } else {
-                        if (procStatements.Count == 0)
-                        {
-                            // Sometimes ';' gets used in NOP blocks
-                            Delimiter();
-                            Whitespace();
-                            return null;
-                        }
                     }
                 } catch (CompileErrorException) {
                     LocateNextStatement();
@@ -499,6 +491,7 @@ namespace DMCompiler.Compiler.DM {
             } while (Delimiter() || statement is DMASTProcStatementLabel);
             Whitespace();
 
+            if (procStatements.Count == 0) return null;
             return procStatements;
         }
 


### PR DESCRIPTION
1. Adds `switch` and `spawn` to the list of tokens you can use in a typepath
2. Copes with NOP switch cases like
```
if("No")
    ; // do nothing
```
3. Fixes an issue with modified types