### PR TITLE
fixes if statement bracket bodies ending in ;

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -831,7 +831,7 @@ namespace DMCompiler.Compiler.DM {
 
                 if (body == null) body = new DMASTProcBlockInner(loc, new DMASTProcStatement[0]);
                 Token afterIfBody = Current();
-                bool newLineAfterIf = Newline();
+                bool newLineAfterIf = Delimiter();
                 if (newLineAfterIf) Whitespace();
                 if (Check(TokenType.DM_Else)) {
                     Whitespace();


### PR DESCRIPTION
SET_ADJ_IN_DIR() was being parsed incorrectly because it was getting to
```
var/turf/neighbor = get_step(source, direction); \
		if(!neighbor) { \
			if(source.smoothing_flags & SMOOTH_BORDER) { \
				junction |= direction_flag; \
			}; \
		}; \
```
the ending bracket of if(!neighbor) {...}; then skipping the else statement because it only checked for a newline when the next token was a semicolon. now it checks for a newline and a semicolon.