### PR TITLE
Cope with whitespace in ExpressionPrimary

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1891,10 +1891,9 @@ namespace DMCompiler.Compiler.DM {
         public DMASTExpression ExpressionPrimary(bool allowParentheses = true) {
             if (allowParentheses && Check(TokenType.DM_LeftParenthesis))
             {
-                Whitespace();
+                BracketWhitespace();
                 DMASTExpression inner = Expression();
-                Newline();
-                Whitespace(includeIndentation: true);
+                BracketWhitespace();
                 ConsumeRightParenthesis();
 
                 return inner;

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1889,9 +1889,12 @@ namespace DMCompiler.Compiler.DM {
         }
 
         public DMASTExpression ExpressionPrimary(bool allowParentheses = true) {
-            if (allowParentheses && Check(TokenType.DM_LeftParenthesis)) {
+            if (allowParentheses && Check(TokenType.DM_LeftParenthesis))
+            {
                 Whitespace();
                 DMASTExpression inner = Expression();
+                Newline();
+                Whitespace(includeIndentation: true);
                 ConsumeRightParenthesis();
 
                 return inner;


### PR DESCRIPTION
Paradise:
```
/proc/is_surgery_tool(obj/item/W as obj)
	return (	\
	istype(W, /obj/item/scalpel)			||	\
	istype(W, /obj/item/hemostat)		||	\
	istype(W, /obj/item/retractor)		||	\
	istype(W, /obj/item/cautery)			||	\
	istype(W, /obj/item/bonegel)			||	\
	istype(W, /obj/item/bonesetter)
	)
```