### PR TITLE
Use OverrideDefault to disable net.predict.

### DIFF
--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -20,7 +20,7 @@ namespace OpenDreamClient {
         private readonly IDreamResourceManager _dreamResource = default!;
 
         public override void Init() {
-            IoCManager.Resolve<IConfigurationManager>().SetCVar(CVars.NetPredict, false);
+            IoCManager.Resolve<IConfigurationManager>().OverrideDefault(CVars.NetPredict, false);
 
             IComponentFactory componentFactory = IoCManager.Resolve<IComponentFactory>();
             componentFactory.DoAutoRegistrations();


### PR DESCRIPTION
This is a relatively new API addition. It means that you can still pass `--cvar net.predict=true` to force it on for testing, which is pretty nice.