### PR TITLE
Fix for without condition

### DIFF
--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -374,8 +374,11 @@ namespace DMCompiler.DM.Visitors {
                 string loopLabel = _proc.NewLabelName();
                 _proc.LoopStart(loopLabel);
                 {
-                    DMExpression.Emit(_dmObject, _proc, statementForStandard.Comparator);
-                    _proc.BreakIfFalse();
+                    if (statementForStandard.Comparator != null)
+                    {
+                        DMExpression.Emit(_dmObject, _proc, statementForStandard.Comparator);
+                        _proc.BreakIfFalse();
+                    }
 
                     ProcessBlockInner(statementForStandard.Body);
 


### PR DESCRIPTION
Fixes this crash, not really sure if I need to do anything else.
```
/proc/main()
	for(n=1,,n++)
		world<<n
		break
```

```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at DMCompiler.DM.DMExpression.Create(DMObject dmObject, DMProc proc, DMASTExpression expression, Nullable`1 inferredPath) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\DMExpression.cs:line 37
   at DMCompiler.DM.DMExpression.Emit(DMObject dmObject, DMProc proc, DMASTExpression expression, Nullable`1 inferredPath) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\DMExpression.cs:line 42
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessStatementForStandard(DMASTProcStatementForStandard statementForStandard) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 377
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessStatement(DMASTProcStatement statement) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 106
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessBlockInner(DMASTProcBlockInner block) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 80
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessStatementIf(DMASTProcStatementIf statement) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 347
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessStatement(DMASTProcStatement statement) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 105
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessBlockInner(DMASTProcBlockInner block) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 80
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessStatementForList(DMASTProcStatementForList statementForList) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 422
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessStatement(DMASTProcStatement statement) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 107
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessBlockInner(DMASTProcBlockInner block) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 80
   at DMCompiler.DM.Visitors.DMProcBuilder.ProcessProcDefinition(DMASTProcDefinition procDefinition) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMProcBuilder.cs:line 46
   at DMCompiler.DM.DMProc.Compile() in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\DMProc.cs:line 94
   at DMCompiler.DM.Visitors.DMObjectBuilder.BuildObjectTree(DMASTFile astFile) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DM\Visitors\DMObjectBuilder.cs:line 22
   at DMCompiler.DMCompiler.Compile(IEnumerable`1 preprocessedTokens) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DMCompiler.cs:line 143
   at DMCompiler.DMCompiler.Compile(DMCompilerSettings settings) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\DMCompiler.cs:line 44
   at DMCompiler.Program.Main(String[] args) in C:\Users\Wrexbe2\RiderProjects\OpenDream\DMCompiler\Program.cs:line 12
   ```