### PR TITLE
Change switch elseif error message

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1213,7 +1213,7 @@ namespace DMCompiler.Compiler.DM {
                 Whitespace();
                 if (Check(TokenType.DM_If))
                 {
-                    Error("Expected \"if\" or \"else\"");
+                    Error("Expected \"if\" or \"else\", \"else if\" is not permitted as a switch case");
                 }
                 DMASTProcBlockInner body = ProcBlock();
 


### PR DESCRIPTION
Make it more clear the compiler is raising an error for "else if" on a switch intentionally.