### PR TITLE
Object can end with curly braket

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -252,7 +252,10 @@ namespace DMCompiler.Compiler.DM {
                         statement = new DMASTObjectDefinition(loc, _currentPath, null);
                     }
 
-                    if (requireDelimiter && !PeekDelimiter() && Current().Type != TokenType.DM_Dedent) {
+                    var currentType = Current().Type;
+                    if (requireDelimiter && !PeekDelimiter() &&
+                        currentType != TokenType.DM_Dedent &&
+                        currentType != TokenType.DM_RightCurlyBracket) {
                         Error("Expected end of object statement");
                     }
 


### PR DESCRIPTION
Ex:
```
turf
	start {icon = 'forest.dmi'}
```