### PR TITLE
Fix semicolons between variable declarations

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -624,12 +624,11 @@ namespace DMCompiler.Compiler.DM {
                     if (varDecl == null) Error("Expected a var declaration");
 
                     varDeclarations.AddRange(varDecl);
-                    while (Whitespace() ||
-                             Newline() ||
-                             Check(TokenType.DM_Semicolon))
-                    {
-                        //eat the junk
-                    }
+
+                    Whitespace();
+                    Check(TokenType.DM_Semicolon);
+                    Whitespace();
+                    Newline();
                 }
 
                 return varDeclarations.ToArray();

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -626,9 +626,8 @@ namespace DMCompiler.Compiler.DM {
                     varDeclarations.AddRange(varDecl);
 
                     Whitespace();
-                    Check(TokenType.DM_Semicolon);
+                    Delimiter();
                     Whitespace();
-                    Newline();
                 }
 
                 return varDeclarations.ToArray();

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -624,7 +624,12 @@ namespace DMCompiler.Compiler.DM {
                     if (varDecl == null) Error("Expected a var declaration");
 
                     varDeclarations.AddRange(varDecl);
-                    Newline();
+                    while (Whitespace() ||
+                             Newline() ||
+                             Check(TokenType.DM_Semicolon))
+                    {
+                        //eat the junk
+                    }
                 }
 
                 return varDeclarations.ToArray();


### PR DESCRIPTION
Make these work
```
/proc/main()
    var
        A;B;C;
```
```
/proc/main()
    var
        A; B; C;
```
```
/proc/main()
    var
        A;/*this is A*/ B;C;
```