### PR TITLE
Fixes duplicate definitions of statics and object properties not causing a compile-time error

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -278,8 +278,7 @@ namespace DMCompiler.Compiler.DM {
         private ObjVarDeclInfo _varDecl;
 
         public bool IsStatic { get => _varDecl.IsStatic; }
-        public bool IsToplevel { get => _varDecl.IsToplevel; }
-        public bool IsGlobal { get => _varDecl.IsStatic || _varDecl.IsToplevel; }
+        public bool IsGlobal { get => _varDecl.IsStatic; }  // TODO: Standardize our phrasing in the codebase. Are we calling these Statics or Globals?
         public bool IsConst { get => _varDecl.IsConst; }
         public bool IsTmp { get => _varDecl.IsTmp; }
 

--- a/DMCompiler/Compiler/DM/DMPath.cs
+++ b/DMCompiler/Compiler/DM/DMPath.cs
@@ -9,8 +9,10 @@ namespace DMCompiler.Compiler.DM
     {
         public DreamPath? TypePath;
         public string VarName;
-        public bool IsGlobal;
+
+        ///<summary>Marks whether the variable is /global/ or /static/. (These are seemingly interchangeable keywords in DM and so are under this same boolean)</summary>
         public bool IsStatic;
+
         public bool IsConst;
         public bool IsList;
     }
@@ -63,7 +65,6 @@ namespace DMCompiler.Compiler.DM
     {
         public DreamPath ObjectPath;
         public bool IsTmp;
-        public bool IsToplevel;
 
         public ObjVarDeclInfo(DreamPath path)
         {
@@ -76,9 +77,9 @@ namespace DMCompiler.Compiler.DM
                 readIdx += 1;
             }
             ObjectPath = new DreamPath(path.Type, currentPath.ToArray());
-            if (ObjectPath.Elements.Length == 0)
+            if (ObjectPath.Elements.Length == 0) // Variables declared in the root scope are inherently static.
             {
-                IsToplevel = true;
+                IsStatic = true;
             }
             currentPath.Clear();
             readIdx += 1;

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -37,6 +37,17 @@ namespace DMCompiler.DM {
             return Parent?.GetVariable(name);
         }
 
+        /// <summary>
+        /// Does a recursive search through self and parents to check if we already contain this variable.
+        /// </summary>
+        public bool HasVariable(string name) {
+            if (Variables.ContainsKey(name))
+                return true;
+            if (Parent == null)
+                return false;
+            return Parent.HasVariable(name);
+        }
+
         public bool HasProc(string name) {
             if (Procs.ContainsKey(name)) return true;
 
@@ -68,6 +79,10 @@ namespace DMCompiler.DM {
             return global;
         }
 
+        /// <summary>
+        /// Recursively searches for a global/static with the given name.
+        /// </summary>
+        /// <returns>Either the ID or null if no such global exists.</returns>
         public int? GetGlobalVariableId(string name) {
             if (GlobalVariables.TryGetValue(name, out int id)) {
                 return id;

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -48,8 +48,6 @@
 	var/step_x as opendream_unimplemented
 	var/step_y as opendream_unimplemented
 	var/render_source as opendream_unimplemented
-	var/bound_width as opendream_unimplemented
-	var/bound_height as opendream_unimplemented
 	var/mouse_drag_pointer as opendream_unimplemented
 	var/mouse_drop_pointer as opendream_unimplemented
 	var/mouse_over_pointer as opendream_unimplemented

--- a/DMCompiler/DMStandard/Types/Image.dm
+++ b/DMCompiler/DMStandard/Types/Image.dm
@@ -42,11 +42,9 @@
 
 	var/bound_width as opendream_unimplemented
 	var/bound_height as opendream_unimplemented
-	var/name
 	var/x
 	var/y
 	var/z
-	var/list/filters = list() as opendream_unimplemented
 	var/list/vis_contents = list() as opendream_unimplemented
 
 	var/dir = SOUTH


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/185002691-77f36356-ae81-4b9f-8378-85cb5bae64be.png)

## Summary
Fixes #742 and fixes #770 by implementing some duplication detection in `DMObjectBuilder`. 

While investigating `global.vars`, I realized that DMObjectBuilder just doesn't do any dupe checking for ANY variable it makes, so I added that.

In addition, I noticed that the `IsGlobal` and `IsTopLevel` booleans for VarDeclInfo weren't really useful for anything, since both end up being grammatically synonymous with being a static.

Adding this new error detection actually *discovered* a couple duped definitions in the DMStandard, so I cleaned those up too.

## Changelog
- Fixed duplicated definitions of statics or properties not causing a compile error
- Fixed duplicated definition of `global.vars` not causing an error, despite its special implementation
- Removed duplicate definitions in the DMStandard files
- Removed superfluous booleans in the `VarDeclinfo` class.