### PR TITLE
Fixes writing to constants, adds readonly opendream pseudo-type, and makes var overrides respect their var's type

### DIFF
--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -89,7 +89,7 @@ namespace Content.Tests
         }
 
         private (bool Success, DreamValue Returned, Exception? except) RunTest() {
-            var prev = _dreamMan.LastException;
+            var prev = _dreamMan.LastDMException;
 
             var result = DreamThread.Run(async (state) => {
                 if (_dreamMan.ObjectTree.TryGetGlobalProc("RunTest", out DreamProc proc)) {
@@ -99,11 +99,11 @@ namespace Content.Tests
                     return DreamValue.Null;
                 }
             });
-            bool retSuccess = _dreamMan.LastException == prev;
+            bool retSuccess = _dreamMan.LastDMException == prev; // Works because "null == null" is true in this language.
             if (retSuccess)
                 return (retSuccess, result, null);
             else
-                return (false, result, _dreamMan.LastException);
+                return (false, result, _dreamMan.LastDMException);
         }
 
         private static IEnumerable<object[]> GetTests()

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -209,6 +209,9 @@ namespace DMCompiler.Compiler.DM {
     }
 
     public class DMASTObjectDefinition : DMASTStatement {
+        /// <summary> Unlike other Path variables stored by AST nodes, this path is guaranteed to be the real, absolute path of this object definition block. <br/>
+        /// That includes any inherited pathing from being tabbed into a different, base definition.
+        /// </summary>
         public DreamPath Path;
         public DMASTBlockInner InnerBlock;
 
@@ -224,7 +227,7 @@ namespace DMCompiler.Compiler.DM {
     }
 
     public class DMASTProcDefinition : DMASTStatement {
-        public DreamPath? ObjectPath;
+        public DreamPath ObjectPath;
         public string Name;
         public bool IsOverride = false;
         public bool IsVerb = false;
@@ -244,7 +247,7 @@ namespace DMCompiler.Compiler.DM {
 
             if (procElementIndex != -1) path = path.RemoveElement(procElementIndex);
 
-            ObjectPath = (path.Elements.Length > 1) ? path.FromElements(0, -2) : null;
+            ObjectPath = (path.Elements.Length > 1) ? path.FromElements(0, -2) : DreamPath.Root;
             Name = path.LastElement;
             Parameters = parameters;
             Body = body;

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -270,7 +270,9 @@ namespace DMCompiler.Compiler.DM {
     }
 
     public class DMASTObjectVarDefinition : DMASTStatement {
+        /// <summary>The path of the object that we are a property of.</summary>
         public DreamPath ObjectPath { get => _varDecl.ObjectPath; }
+        /// <summary>The actual type of the variable itself.</summary>
         public DreamPath? Type { get => _varDecl.IsList ? DreamPath.List : _varDecl.TypePath; }
         public string Name { get => _varDecl.VarName; }
         public DMASTExpression Value;

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2515,6 +2515,7 @@ namespace DMCompiler.Compiler.DM {
                         case "sound": type |= DMValueType.Sound; break;
                         case "icon": type |= DMValueType.Icon; break;
                         case "opendream_unimplemented": type |= DMValueType.Unimplemented; break;
+                        case "opendream_compiletimereadonly": type |= DMValueType.CompiletimeReadonly; break;
                         default: Error("Invalid value type '" + typeToken.Text + "'"); break;
                     }
 

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -25,7 +25,6 @@ namespace DMCompiler.DM {
             Conditional,
         }
 
-        public DMValueType ValType = DMValueType.Anything;
         public Location Location;
 
         public DMExpression(Location location) {

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -25,7 +25,6 @@ namespace DMCompiler.DM {
         public List<DMASTObjectVarOverride>? danglingOverrides = null; // Overrides waiting for the LateVarDef event to happen
         private bool _isSubscribedToVarDef = false;
         
-
         public DMObject(int id, DreamPath path, DMObject parent) {
             Id = id;
             Path = path;
@@ -45,12 +44,11 @@ namespace DMCompiler.DM {
                 var varOverride = danglingOverrides[i];
                 if (varOverride.VarName == varDefined.Name) // FINALLY we can do this
                 {
-                    if (IsSubtypeOf(maybeAncestor.Path))
+                    if (IsSubtypeOf(maybeAncestor.Path)) // Resolves the ambiguous var override
                     {
                         // Thank god DMObjectBuilder is static, amirite?
                         DMObjectBuilder.OverrideVariableValue(this, ref varDefined, varOverride.Value); // I'd like to mark DMObjectBuilder as a friend class but that's not a thing in C# so
                         VariableOverrides[varDefined.Name] = varDefined;
-                        //DMCompiler.Warning(new CompilerWarning(varOverride.Location, $"Resolved ambiguous var override for {varOverride.VarName}"));
                         danglingOverrides.RemoveAt(i);
                         break;
                     }

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -150,8 +150,8 @@ namespace DMCompiler.DM {
             return false;
         }
 
-        public DMVariable CreateGlobalVariable(DreamPath? type, string name, bool isConst) {
-            int id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst);
+        public DMVariable CreateGlobalVariable(DreamPath? type, string name, bool isConst, DMValueType valType = DMValueType.Anything) {
+            int id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst, valType);
 
             GlobalVariables[name] = id;
             return global;

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -14,11 +14,17 @@ namespace DMCompiler.DM {
         public DMObject Parent;
         public Dictionary<string, List<int>> Procs = new();
         public Dictionary<string, DMVariable> Variables = new();
-        public Dictionary<string, DMVariable> VariableOverrides = new(); //NOTE: The type of all these variables are null
+        /// <summary> It's OK if the override var is not literally the exact same object as what it overrides. </summary>
+        public Dictionary<string, DMVariable> VariableOverrides = new();
         public Dictionary<string, int> GlobalVariables = new();
+        /// <summary>A list of var and verb initializations implicitly done before the user's New() is called.</summary>
         public List<DMExpression> InitializationProcExpressions = new();
         public int? InitializationProc;
         private bool IAmRoot => Path == DreamPath.Root;
+
+        public List<DMASTObjectVarOverride>? danglingOverrides = null; // Overrides waiting for the LateVarDef event to happen
+        private bool _isSubscribedToVarDef = false;
+        
 
         public DMObject(int id, DreamPath path, DMObject parent) {
             Id = id;
@@ -31,8 +37,58 @@ namespace DMCompiler.DM {
             Procs[name].Add(proc.Id);
         }
 
+        private void HandleLateVarDef(object sender, DMVariable varDefined)
+        {
+            DMObject maybeAncestor = (DMObject)sender;
+            for(int i = 0; i < danglingOverrides.Count; ++i)
+            {
+                var varOverride = danglingOverrides[i];
+                if (varOverride.VarName == varDefined.Name) // FINALLY we can do this
+                {
+                    if (IsSubtypeOf(maybeAncestor.Path))
+                    {
+                        // Thank god DMObjectBuilder is static, amirite?
+                        DMObjectBuilder.OverrideVariableValue(this, ref varDefined, varOverride.Value); // I'd like to mark DMObjectBuilder as a friend class but that's not a thing in C# so
+                        VariableOverrides[varDefined.Name] = varDefined;
+                        //DMCompiler.Warning(new CompilerWarning(varOverride.Location, $"Resolved ambiguous var override for {varOverride.VarName}"));
+                        danglingOverrides.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+            if (danglingOverrides.Count == 0) // Unsubscribe if we're done doing this
+            {
+                Robust.Shared.Utility.DebugTools.Assert(danglingOverrides.Count == 0);
+                DMObjectBuilder.VarDefined -= this.HandleLateVarDef;
+                _isSubscribedToVarDef = false;
+            }
+        }
+
+        public void WaitForLateVarDefinition(DMASTObjectVarOverride varOverride)
+        {
+            if (danglingOverrides is null)
+                danglingOverrides = new List<DMASTObjectVarOverride>();
+            for(int i = 0; i < danglingOverrides.Count; ++i)
+            {
+                var otherOverride = danglingOverrides[i];
+                if(otherOverride.VarName == varOverride.VarName) // This looks like an override for ANOTHER override.
+                {   // Meaning we're probably already subscribed or... something?
+                    // Whatever. I guess we're the real override, now.
+                    danglingOverrides[i] = varOverride;
+                    // NOTE: This doesn't work quite right if DMObjectBuilder ever starts evaluating object definitions in a different order than how they appear in the source code.
+                    return;
+                }
+            }
+            danglingOverrides.Add(varOverride);
+            if (_isSubscribedToVarDef == false)
+            {
+                DMObjectBuilder.VarDefined += this.HandleLateVarDef; // GOD I hope this works
+                _isSubscribedToVarDef = true;
+            }
+        }
+
         ///<remarks> 
-        /// Note that this DOES NOT query our<see cref= "GlobalVariables" />. <br/>
+        /// Note that this DOES NOT query our <see cref= "GlobalVariables" />. <br/>
         /// <see langword="TODO:"/> Make this (and other things) match the nomenclature of <see cref="HasLocalVariable"/>
         /// </remarks>
         public DMVariable GetVariable(string name) {

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -132,10 +132,10 @@ namespace DMCompiler.DM {
             }
         }
 
-        public static int CreateGlobal(out DMVariable global, DreamPath? type, string name, bool isConst) {
+        public static int CreateGlobal(out DMVariable global, DreamPath? type, string name, bool isConst, DMValueType valType = DMValueType.Anything) {
             int id = Globals.Count;
 
-            global = new DMVariable(type, name, true, isConst);
+            global = new DMVariable(type, name, true, isConst, valType);
             Globals.Add(global);
             return id;
         }

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -19,6 +19,7 @@ namespace DMCompiler.DM {
         public static List<string> StringTable = new();
         public static Dictionary<string, int> StringToStringID = new();
         public static DMProc GlobalInitProc;
+        public static DMObject Root => GetDMObject(DreamPath.Root);
 
         private static Dictionary<DreamPath, List<(int GlobalId, DMExpression Value)>> _globalInitAssigns = new();
 

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -53,32 +53,32 @@ namespace DMCompiler.DM {
         public static DMObject GetDMObject(DreamPath path, bool createIfNonexistent = true) {
             if (_pathToTypeId.TryGetValue(path, out int typeId)) {
                 return AllObjects[typeId];
-            } else {
-                if (!createIfNonexistent) return null;
-
-                DMObject parent = null;
-                if (path.Elements.Length > 1) {
-                    parent = GetDMObject(path.FromElements(0, -2), true);
-                } else if (path.Elements.Length == 1) {
-                    switch (path.LastElement) {
-                        case "client":
-                        case "datum":
-                        case "list":
-                        case "savefile":
-                        case "world":
-                            parent = GetDMObject(DreamPath.Root);
-                            break;
-                        default:
-                            parent = GetDMObject(DMCompiler.Settings.NoStandard ? DreamPath.Root : DreamPath.Datum);
-                            break;
-                    }
-                }
-
-                DMObject dmObject = new DMObject(_dmObjectIdCounter++, path, parent);
-                AllObjects.Add(dmObject);
-                _pathToTypeId[path] = dmObject.Id;
-                return dmObject;
             }
+            if (!createIfNonexistent) return null;
+
+            DMObject parent = null;
+            if (path.Elements.Length > 1) {
+                parent = GetDMObject(path.FromElements(0, -2), true); // Create all parent classes as dummies, if we're being dummy-created too
+            } else if (path.Elements.Length == 1) {
+                switch (path.LastElement) {
+                    case "client":
+                    case "datum":
+                    case "list":
+                    case "savefile":
+                    case "world":
+                        parent = GetDMObject(DreamPath.Root);
+                        break;
+                    default:
+                        parent = GetDMObject(DMCompiler.Settings.NoStandard ? DreamPath.Root : DreamPath.Datum);
+                        break;
+                }
+            }
+            DebugTools.Assert(path == DreamPath.Root || parent != null); // Parent SHOULD NOT be null here! (unless we're root lol)
+
+            DMObject dmObject = new DMObject(_dmObjectIdCounter++, path, parent);
+            AllObjects.Add(dmObject);
+            _pathToTypeId[path] = dmObject.Id;
+            return dmObject;
         }
 
         public static bool TryGetGlobalProc(string name, [CanBeNull] out DMProc proc)

--- a/DMCompiler/DM/DMVariable.cs
+++ b/DMCompiler/DM/DMVariable.cs
@@ -1,19 +1,25 @@
 ﻿using OpenDreamShared.Dream;
+using OpenDreamShared.Dream.Procs;
 
 namespace DMCompiler.DM {
     class DMVariable {
         public DreamPath? Type;
         public string Name;
         public bool IsGlobal;
+        /// <remarks>
+        /// NOTE: This DMVariable may be forced constant through opendream_compiletimereadonly. This only marks that the variable has the DM quality of /const/ness.
+        /// </remarks>
         public bool IsConst;
         public DMExpression Value;
+        public DMValueType ValType;
 
-        public DMVariable(DreamPath? type, string name, bool isGlobal, bool isConst) {
+        public DMVariable(DreamPath? type, string name, bool isGlobal, bool isConst, DMValueType valType = DMValueType.Anything) {
             Type = type;
             Name = name;
             IsGlobal = isGlobal;
             IsConst = isConst;
             Value = null;
+            ValType = valType;
         }
 
 
@@ -29,7 +35,7 @@ namespace DMCompiler.DM {
                 Value = value;
                 return this;
             }
-            DMVariable clone = new DMVariable(Type,Name,IsGlobal,IsConst);
+            DMVariable clone = new DMVariable(Type,Name,IsGlobal,IsConst,ValType);
             clone.Value = value;
             return clone;
         }

--- a/DMCompiler/DM/DMVariable.cs
+++ b/DMCompiler/DM/DMVariable.cs
@@ -16,6 +16,24 @@ namespace DMCompiler.DM {
             Value = null;
         }
 
+
+        /// <summary>
+        /// This is a copy-on-write proc used to set the DMVariable to a constant value. <br/>
+        /// In some contexts, doing so would clobber pre-existing constants, <br/>
+        /// and so this sometimes creates a copy of <see langword="this"/>, with the new constant value.
+        /// </summary>
+        public DMVariable WriteToValue(Expressions.Constant value)
+        {
+            if(Value == null)
+            {
+                Value = value;
+                return this;
+            }
+            DMVariable clone = new DMVariable(Type,Name,IsGlobal,IsConst);
+            clone.Value = value;
+            return clone;
+        }
+
         public bool TryAsJsonRepresentation(out object valueJson) {
             return Value.TryAsJsonRepresentation(out valueJson);
         }

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -59,9 +59,15 @@ namespace DMCompiler.DM.Expressions {
             {
                 var obj = DMObjectTree.GetDMObject(_expr.Path.GetValueOrDefault());
                 var variable = obj.GetVariable(PropertyName);
-                if (variable != null && variable.IsConst)
+                if (variable != null)
                 {
-                    return variable.Value.TryAsConstant(out constant);
+                    if(variable.IsConst)
+                        return variable.Value.TryAsConstant(out constant);
+                    if((variable.ValType & DMValueType.CompiletimeReadonly) == DMValueType.CompiletimeReadonly)
+                    {
+                        variable.Value.TryAsConstant(out constant);
+                        return true; // MUST be true.
+                    }
                 }
             }
 

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -59,7 +59,7 @@ namespace DMCompiler.DM.Expressions {
             {
                 var obj = DMObjectTree.GetDMObject(_expr.Path.GetValueOrDefault());
                 var variable = obj.GetVariable(PropertyName);
-                if (variable.IsConst)
+                if (variable != null && variable.IsConst)
                 {
                     return variable.Value.TryAsConstant(out constant);
                 }

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -6,8 +6,8 @@ using OpenDreamShared.Dream.Procs;
 using System.Collections.Generic;
 
 namespace DMCompiler.DM.Visitors {
-    class DMObjectBuilder {
-        public void BuildObjectTree(DMASTFile astFile) {
+    static class DMObjectBuilder {
+        public static void BuildObjectTree(DMASTFile astFile) {
             DMObjectTree.Reset();
             ProcessFile(astFile);
 
@@ -22,11 +22,11 @@ namespace DMCompiler.DM.Visitors {
             DMObjectTree.CreateGlobalInitProc();
         }
 
-        private void ProcessFile(DMASTFile file) {
+        private static void ProcessFile(DMASTFile file) {
             ProcessBlockInner(file.BlockInner, DMObjectTree.Root);
         }
 
-        private void ProcessBlockInner(DMASTBlockInner blockInner, DMObject currentObject) {
+        private static void ProcessBlockInner(DMASTBlockInner blockInner, DMObject currentObject) {
             foreach (DMASTStatement statement in blockInner.Statements) {
                 try {
                     ProcessStatement(statement, ref currentObject);
@@ -36,7 +36,7 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
-        private void ProcessStatement(DMASTStatement statement, ref DMObject currentObject) {
+        private static void ProcessStatement(DMASTStatement statement, ref DMObject currentObject) {
             switch (statement) {
                 case DMASTObjectDefinition objectDefinition: ProcessObjectDefinition(objectDefinition, ref currentObject); break;
 
@@ -56,14 +56,14 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
-        private void ProcessObjectDefinition(DMASTObjectDefinition objectDefinition, ref DMObject currentObject) {
+        private static void ProcessObjectDefinition(DMASTObjectDefinition objectDefinition, ref DMObject currentObject) {
 
             DMCompiler.VerbosePrint($"Generating {objectDefinition.Path}");
             currentObject = DMObjectTree.GetDMObject(objectDefinition.Path);
             if (objectDefinition.InnerBlock != null) ProcessBlockInner(objectDefinition.InnerBlock, currentObject);
         }
 
-        private void ProcessVarDefinition(DMASTObjectVarDefinition varDefinition) {
+        private static void ProcessVarDefinition(DMASTObjectVarDefinition varDefinition) {
             DMVariable variable;
             DMObject varObject = DMObjectTree.GetDMObject(varDefinition.ObjectPath);
             //DMObjects store two bundles of variables; the statics in GlobalVariables and the non-statics in Variables.
@@ -102,7 +102,7 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
-        private void ProcessVarOverride(DMASTObjectVarOverride varOverride) {
+        private static void ProcessVarOverride(DMASTObjectVarOverride varOverride) {
             DMObject varObject = DMObjectTree.GetDMObject(varOverride.ObjectPath);
 
             try
@@ -143,7 +143,7 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
-        private void ProcessProcDefinition(DMASTProcDefinition procDefinition, DMObject currentObject) {
+        private static void ProcessProcDefinition(DMASTProcDefinition procDefinition, DMObject currentObject) {
             string procName = procDefinition.Name;
             DMObject dmObject = currentObject; // Default value if we can't discern its object
 
@@ -236,7 +236,7 @@ namespace DMCompiler.DM.Visitors {
         /// A snowflake helper proc which determines whether the given definition would be a duplication definition of global.vars.<br/>
         /// It exists because global.vars is not a "real" global but rather a construct indirectly implemented via PushGlobals et al.
         /// </summary>
-        private bool DoesOverrideGlobalVars(DMASTObjectVarDefinition varDefinition)
+        private static bool DoesOverrideGlobalVars(DMASTObjectVarDefinition varDefinition)
         {
             if (varDefinition == null) return false;
             return varDefinition.IsStatic && varDefinition.Name == "vars" && varDefinition.ObjectPath == DreamPath.Root;
@@ -246,7 +246,7 @@ namespace DMCompiler.DM.Visitors {
         /// A filter proc above <see cref="SetVariableValue"/> <br/>
         /// which checks first to see if overriding this thing's value is valid (as in the case of const and <see cref="DMValueType.CompiletimeReadonly"/>)
         /// </summary>
-        private void OverrideVariableValue(DMObject currentObject, DMVariable variable, DMASTExpression value, DMValueType valType = DMValueType.Anything)
+        private static void OverrideVariableValue(DMObject currentObject, DMVariable variable, DMASTExpression value, DMValueType valType = DMValueType.Anything)
         {
             if(variable.IsConst)
             {
@@ -264,7 +264,7 @@ namespace DMCompiler.DM.Visitors {
         /// Handles setting a variable to a value (when called by itself, this assumes the statement is a declaration and not a re-assignment)
         /// </summary>
         /// <exception cref="CompileErrorException"></exception>
-        private void SetVariableValue(DMObject currentObject, DMVariable variable, DMASTExpression value, DMValueType valType = DMValueType.Anything) {
+        private static void SetVariableValue(DMObject currentObject, DMVariable variable, DMASTExpression value, DMValueType valType = DMValueType.Anything) {
             DMVisitorExpression._scopeMode = variable.IsGlobal ? "static" : "normal";
             DMExpression expression = DMExpression.Create(currentObject, variable.IsGlobal ? DMObjectTree.GlobalInitProc : null, value, variable.Type);
             DMVisitorExpression._scopeMode = "normal";
@@ -310,7 +310,7 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
-        private void EmitInitializationAssign(DMObject currentObject, DMVariable variable, DMExpression expression) {
+        private static void EmitInitializationAssign(DMObject currentObject, DMVariable variable, DMExpression expression) {
             if (variable.IsGlobal) {
                 int? globalId = currentObject.GetGlobalVariableId(variable.Name);
                 if (globalId == null) throw new Exception($"Invalid global {currentObject.Path}.{variable.Name}");

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -126,6 +126,11 @@ namespace DMCompiler.DM.Visitors {
                 {
                     variable = varObject.GetVariable(varOverride.VarName);
                 }
+                else if (varObject.HasGlobalVariable(varOverride.VarName))
+                {
+                    variable = varObject.GetGlobalVariable(varOverride.VarName);
+                    DMCompiler.Error(new CompilerError(varOverride.Location, $"var \"{varOverride.VarName}\" cannot be overridden - it is a global var"));
+                }
                 else // Shouldn't happen, ideally
                 {
                     DMCompiler.Warning(new CompilerWarning(varOverride.Location, $"Override of var {varOverride.VarName} found before variable declaration. This isn't supposed to happen!"));

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -8,8 +8,8 @@ using OpenDreamShared.Dream.Procs;
 
 namespace DMCompiler.DM.Visitors {
     class DMProcBuilder {
-        private DMObject _dmObject;
-        private DMProc _proc;
+        private readonly DMObject _dmObject;
+        private readonly DMProc _proc;
 
         public DMProcBuilder(DMObject dmObject, DMProc proc) {
             _dmObject = dmObject;

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -192,7 +192,7 @@ namespace DMCompiler.DM.Visitors {
         public void VisitAssign(DMASTAssign assign) {
             var lhs = DMExpression.Create(_dmObject, _proc, assign.Expression, _inferredPath);
             var rhs = DMExpression.Create(_dmObject, _proc, assign.Value, lhs.Path);
-            if(lhs.TryAsConstant(out var _) || ((lhs.ValType & DMValueType.CompiletimeReadonly) == DMValueType.CompiletimeReadonly))
+            if(lhs.TryAsConstant(out var _))
             {
                 DMCompiler.Error(new CompilerError(assign.Expression.Location, "Cannot write to const var"));
             }
@@ -450,7 +450,7 @@ namespace DMCompiler.DM.Visitors {
                     throw new CompileErrorException(dereference.Location, $"Invalid property \"{dereference.Property}\" on type {dmObject.Path}");
                 }
 
-                if ((property.Value?.ValType & DMValueType.Unimplemented) == DMValueType.Unimplemented) {
+                if ((property.ValType & DMValueType.Unimplemented) == DMValueType.Unimplemented) {
                     DMCompiler.UnimplementedWarning(dereference.Location, $"{dmObject.Path}.{dereference.Property} is not implemented and will have unexpected behavior");
                 }
             } else {

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -192,6 +192,10 @@ namespace DMCompiler.DM.Visitors {
         public void VisitAssign(DMASTAssign assign) {
             var lhs = DMExpression.Create(_dmObject, _proc, assign.Expression, _inferredPath);
             var rhs = DMExpression.Create(_dmObject, _proc, assign.Value, lhs.Path);
+            if(lhs.TryAsConstant(out var _) || ((lhs.ValType & DMValueType.CompiletimeReadonly) == DMValueType.CompiletimeReadonly))
+            {
+                DMCompiler.Error(new CompilerError(assign.Expression.Location, "Cannot write to const var"));
+            }
             Result = new Expressions.Assignment(assign.Location, lhs, rhs);
         }
 

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -143,8 +143,7 @@ namespace DMCompiler {
             VerbosePrint("Constant folding");
             astSimplifier.SimplifyAST(astFile);
 
-            DMObjectBuilder dmObjectBuilder = new DMObjectBuilder();
-            dmObjectBuilder.BuildObjectTree(astFile);
+            DMObjectBuilder.BuildObjectTree(astFile);
 
             if (ErrorCount > 0) {
                 return false;

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -24,17 +24,7 @@ namespace OpenDreamRuntime {
 
         public DreamObjectTree ObjectTree { get; private set; } = new();
         public DreamObject WorldInstance { get; private set; }
-        public Exception LastException { get
-            {
-                if (_lastException == null) // Lazy init
-                    return _lastException = new Exception();
-                return _lastException;
-            }
-            set
-            {
-                _lastException = value;
-            }
-        }
+        public Exception? LastDMException { get; set; }
 
         // Global state that may not really (really really) belong here
         public List<DreamValue> Globals { get; set; } = new();
@@ -48,7 +38,6 @@ namespace OpenDreamRuntime {
         public Dictionary<string, List<DreamObject>> Tags { get; set; } = new();
 
         private DreamCompiledJson _compiledJson;
-        private Exception? _lastException;
 
         //TODO This arg is awful and temporary until RT supports cvar overrides in unit tests
         public void Initialize(string jsonPath) {

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -20,10 +20,21 @@ namespace OpenDreamRuntime {
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
         [Dependency] private readonly IProcScheduler _procScheduler = default!;
         [Dependency] private readonly DreamResourceManager _dreamResourceManager = default!;
+        
 
         public DreamObjectTree ObjectTree { get; private set; } = new();
         public DreamObject WorldInstance { get; private set; }
-        public int DMExceptionCount { get; set; }
+        public Exception LastException { get
+            {
+                if (_lastException == null) // Lazy init
+                    return _lastException = new Exception();
+                return _lastException;
+            }
+            set
+            {
+                _lastException = value;
+            }
+        }
 
         // Global state that may not really (really really) belong here
         public List<DreamValue> Globals { get; set; } = new();
@@ -37,6 +48,7 @@ namespace OpenDreamRuntime {
         public Dictionary<string, List<DreamObject>> Tags { get; set; } = new();
 
         private DreamCompiledJson _compiledJson;
+        private Exception? _lastException;
 
         //TODO This arg is awful and temporary until RT supports cvar overrides in unit tests
         public void Initialize(string jsonPath) {

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -267,7 +267,7 @@ namespace OpenDreamRuntime {
                 state.ReturnPools();
             }
             var dreamMan = IoCManager.Resolve<IDreamManager>();
-            dreamMan.DMExceptionCount += 1;
+            dreamMan.LastException = exception;
 
             StringBuilder builder = new();
             builder.AppendLine($"Exception Occured: {exception.Message}");

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -267,7 +267,7 @@ namespace OpenDreamRuntime {
                 state.ReturnPools();
             }
             var dreamMan = IoCManager.Resolve<IDreamManager>();
-            dreamMan.LastException = exception;
+            dreamMan.LastDMException = exception;
 
             StringBuilder builder = new();
             builder.AppendLine($"Exception Occured: {exception.Message}");

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -21,7 +21,7 @@ namespace OpenDreamRuntime {
             Reference = 64
         }
 
-        public static readonly DreamValue Null = new DreamValue((DreamObject)null);
+        public static readonly DreamValue Null = new DreamValue((DreamObject?)null);
 
         public DreamValueType Type { get; private set; }
         public object Value { get; private set; }
@@ -47,7 +47,8 @@ namespace OpenDreamRuntime {
             Value = value;
         }
 
-        public DreamValue(DreamObject value) {
+        /// <remarks> This constructor is also how one creates nulls. </remarks>
+        public DreamValue(DreamObject? value) {
             Type = DreamValueType.DreamObject;
             Value = value;
         }

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -11,7 +11,7 @@ namespace OpenDreamRuntime {
         /// <summary>
         /// A black box (as in, on an airplane) variable currently only used by the test suite to help harvest runtime error info.
         /// </summary>
-        public Exception LastException { get; set; }
+        public Exception? LastDMException { get; set; }
 
         public List<DreamValue> Globals { get; set; }
         public DreamList WorldContentsList { get; set; }

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -7,7 +7,11 @@ namespace OpenDreamRuntime {
     public interface IDreamManager {
         public DreamObjectTree ObjectTree { get; }
         public DreamObject WorldInstance { get; }
-        public int DMExceptionCount { get; set; }
+
+        /// <summary>
+        /// A black box (as in, on an airplane) variable currently only used by the test suite to help harvest runtime error info.
+        /// </summary>
+        public Exception LastException { get; set; }
 
         public List<DreamValue> Globals { get; set; }
         public DreamList WorldContentsList { get; set; }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1455,7 +1455,7 @@ namespace OpenDreamRuntime.Procs {
 
         public static ProcStatus? Prompt(DMProcState state) {
             DMValueType types = (DMValueType)state.ReadInt();
-            DreamObject recipientMob;
+            DreamObject? recipientMob;
             DreamValue title, message, defaultValue;
 
             DreamValue firstArg = state.Pop();
@@ -1472,7 +1472,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             DreamObject clientObject;
-            if (recipientMob != null && recipientMob.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out clientObject)) {
+            if (recipientMob != null && recipientMob.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out clientObject!)) {
                 DreamConnection connection = state.DreamManager.GetConnectionFromClient(clientObject);
                 Task<DreamValue> promptTask = connection.Prompt(types, title.Stringify(), message.Stringify(), defaultValue.Stringify());
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1471,8 +1471,8 @@ namespace OpenDreamRuntime.Procs {
                 state.Pop(); //Fourth argument, should be null
             }
 
-            DreamObject clientObject;
-            if (recipientMob != null && recipientMob.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out clientObject!)) {
+            DreamObject? clientObject;
+            if (recipientMob != null && recipientMob.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out clientObject)) {
                 DreamConnection connection = state.DreamManager.GetConnectionFromClient(clientObject);
                 Task<DreamValue> promptTask = connection.Prompt(types, title.Stringify(), message.Stringify(), defaultValue.Stringify());
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -151,7 +151,7 @@ namespace OpenDreamRuntime.Procs {
         public override DreamProc Proc => _proc;
 
         /// <param name="instance">This is our 'src'.</param>
-        /// <exception cref="Exception"></exception>
+        /// <exception cref="Exception">Thrown, at time of writing, when an invalid named arg is given</exception>
         public DMProcState(DMProc proc, DreamThread thread, int maxStackSize, DreamObject? instance, DreamObject? usr, DreamProcArguments arguments)
             : base(thread)
         {
@@ -417,7 +417,7 @@ namespace OpenDreamRuntime.Procs {
         public DreamValue GetReferenceValue(DMReference reference, bool peek = false) {
             switch (reference.RefType) {
                 case DMReference.Type.Src: return new(Instance);
-                case DMReference.Type.Usr: return Usr != null ? new(Usr) : DreamValue.Null;
+                case DMReference.Type.Usr: return new(Usr);
                 case DMReference.Type.Self: return Result;
                 case DMReference.Type.Global: return DreamManager.Globals[reference.Index];
                 case DMReference.Type.Argument: return _localVariables[reference.Index];

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -17,7 +17,7 @@ namespace OpenDreamRuntime.Procs {
             _maxStackSize = maxStackSize;
         }
 
-        public override DMProcState CreateState(DreamThread thread, DreamObject src, DreamObject usr, DreamProcArguments arguments)
+        public override DMProcState CreateState(DreamThread thread, DreamObject? src, DreamObject? usr, DreamProcArguments arguments)
         {
             return new DMProcState(this, thread, _maxStackSize, src, usr, arguments);
         }
@@ -134,8 +134,10 @@ namespace OpenDreamRuntime.Procs {
         #endregion
 
         public readonly IDreamManager DreamManager = IoCManager.Resolve<IDreamManager>();
-        public DreamObject Instance;
-        public readonly DreamObject Usr;
+
+        /// <summary> This stores our 'src' value. May be null!</summary>
+        public DreamObject? Instance;
+        public readonly DreamObject? Usr;
         public readonly int ArgumentCount;
         private Stack<IEnumerator<DreamValue>>? _enumeratorStack;
         public Stack<IEnumerator<DreamValue>> EnumeratorStack => _enumeratorStack ??= new Stack<IEnumerator<DreamValue>>(1);
@@ -148,7 +150,9 @@ namespace OpenDreamRuntime.Procs {
         private readonly DMProc _proc;
         public override DreamProc Proc => _proc;
 
-        public DMProcState(DMProc proc, DreamThread thread, int maxStackSize, DreamObject instance, DreamObject usr, DreamProcArguments arguments)
+        /// <param name="instance">This is our 'src'.</param>
+        /// <exception cref="Exception"></exception>
+        public DMProcState(DMProc proc, DreamThread thread, int maxStackSize, DreamObject? instance, DreamObject? usr, DreamProcArguments arguments)
             : base(thread)
         {
             _proc = proc;
@@ -241,7 +245,7 @@ namespace OpenDreamRuntime.Procs {
             Result = value;
         }
 
-        public void Call(DreamProc proc, DreamObject src, DreamProcArguments arguments) {
+        public void Call(DreamProc proc, DreamObject? src, DreamProcArguments arguments) {
             var state = proc.CreateState(Thread, src, Usr, arguments);
             Thread.PushProcState(state);
         }
@@ -413,7 +417,7 @@ namespace OpenDreamRuntime.Procs {
         public DreamValue GetReferenceValue(DMReference reference, bool peek = false) {
             switch (reference.RefType) {
                 case DMReference.Type.Src: return new(Instance);
-                case DMReference.Type.Usr: return new(Usr);
+                case DMReference.Type.Usr: return Usr != null ? new(Usr) : DreamValue.Null;
                 case DMReference.Type.Self: return Result;
                 case DMReference.Type.Global: return DreamManager.Globals[reference.Index];
                 case DMReference.Type.Argument: return _localVariables[reference.Index];
@@ -449,8 +453,10 @@ namespace OpenDreamRuntime.Procs {
                     return fieldValue;
                 }
                 case DMReference.Type.SrcField: {
+                    if (Instance == null)
+                        throw new Exception($"Cannot get field src.{reference.Name} in global proc");
                     if (!Instance.TryGetVariable(reference.Name, out var fieldValue))
-                        throw new Exception($"Type {Instance.ObjectDefinition.Type} has no field called \"{reference.Name}\"");
+                        throw new Exception($"Type {Instance.ObjectDefinition!.Type} has no field called \"{reference.Name}\"");
 
                     return fieldValue;
                 }

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -142,7 +142,10 @@ namespace OpenDreamShared.Dream.Procs {
         Bold = 0x1B,
         Italic = 0x1C
     }
-
+    ///<summary>
+    ///Stores any explicit casting done via the "as" keyword. Also stores compiler hints for DMStandard.<br/>
+    ///is a [Flags] enum because it's hypothetically possible for something to have multiple values (especially with the quirky DMStandard ones)
+    /// </summary>
     [Flags]
     public enum DMValueType {
         Anything = 0x0,
@@ -159,7 +162,9 @@ namespace OpenDreamShared.Dream.Procs {
         CommandText = 0x400,
         Sound = 0x800,
         Icon = 0x1000,
-        Unimplemented = 0x2000
+        //Byond here be dragons
+        Unimplemented = 0x2000, // Marks that a method or property is not implemented. Throws a compiler warning if accessed.
+        CompiletimeReadonly = 0x4000, // Marks that a property can only ever be read from, never written to. This is a const-ier version of const, for certain standard values like list.type
     }
 
     public struct DMReference {

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -144,7 +144,7 @@ namespace OpenDreamShared.Dream.Procs {
     }
     ///<summary>
     ///Stores any explicit casting done via the "as" keyword. Also stores compiler hints for DMStandard.<br/>
-    ///is a [Flags] enum because it's hypothetically possible for something to have multiple values (especially with the quirky DMStandard ones)
+    ///is a [Flags] enum because it's possible for something to have multiple values (especially with the quirky DMStandard ones)
     /// </summary>
     [Flags]
     public enum DMValueType {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/185770932-4621ac60-7771-478a-b5e5-180b3674dc9f.png)


Fixes #738, fixes #702, and fixes #535.

## Summary
This bugfix stuff comes with a refactor of `DMObjectBuilder` into the `static class` it probably should be.

As a treat, this PR also has a commit that amends Content.Test so that it actually prints the message of any unexpected runtime into the log file, instead of just declaring that there was a runtime. Should be helpful :)

## Changelog
- `const` now works as an effective keyword, preventing writing of values, within both procs and object definitions.
- Assignments now consistently remember the type of what they're assigning to (for implicit `new` calls)
- Variable overrides in object definitions now work correctly, remembering their initial type and preferring overrides that occur later in the source code, as per DM parity.
- `opendream_compiletimereadonly` is now a valid type marker. Allows for marking something as unwriteable, while also not requiring the value to be literally a `const`.
- Type markers have been slightly reworked so that they are parented to the `DMVariable` they modify, rather than the expression.
- Content.Test now logs the message of any unexpected runtime discovered during testing.
- Fixed statics being overridable in derived classes.
- Fixed vars named `tag` not being overridable in objects that don't inherit from /datum.
- Miscellaneous null-safety improvements!