### PR TITLE
Implements the <> operator

### DIFF
--- a/DMCompiler/Compiler/DM/DMLexer.cs
+++ b/DMCompiler/Compiler/DM/DMLexer.cs
@@ -174,6 +174,7 @@ namespace DMCompiler.Compiler.DM {
                                 case "=": token = CreateToken(TokenType.DM_Equals, c); break;
                                 case "==": token = CreateToken(TokenType.DM_EqualsEquals, c); break;
                                 case "!": token = CreateToken(TokenType.DM_Exclamation, c); break;
+                                case "<>": // This is syntactically equivalent to the below so why not the same token
                                 case "!=": token = CreateToken(TokenType.DM_ExclamationEquals, c); break;
                                 case "^": token = CreateToken(TokenType.DM_Xor, c); break;
                                 case "^=": token = CreateToken(TokenType.DM_XorEquals, c); break;

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -88,6 +88,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                                 break;
                             }
                             case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "<="); break;
+                            case '>': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "<>"); break;
                             default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '<'); break;
                         }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/187056483-40ba91e5-6fc4-4ea6-8f21-6a4b739a57f6.png)

I don't know what ancient TI-BASIC stans are still using this operator in Current Year, but, whatever, it's supported now.

It looks like it's completely equivalent to != so I just implemented it as being read the same way. An easy patch.