### PR TITLE
Make global initialisers more permissive

### DIFF
--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -275,11 +275,9 @@ namespace DMCompiler.DM.Visitors {
                 Expressions.List => true,
                 Expressions.NewList => true,
                 Expressions.NewPath => true,
-                Expressions.GlobalField => variable.IsGlobal, // Global set to another global
-                Expressions.StringFormat => variable.IsGlobal,
-                Expressions.Add => variable.IsGlobal,
-                Expressions.Subtract => variable.IsGlobal,
-                _ => false
+                // TODO: Check for circular reference loops here
+                Expressions.GlobalField => variable.IsGlobal,
+                _ => variable.IsGlobal
             };
 
             if (isValid) {


### PR DESCRIPTION
Global initialisers effectively act like one-line procs with an implicit return; as such, basically anything you could put in a global proc works with them, except for circular reference loops. Currently, it's bizarrely restrictive compared to DM; this PR changes that.

Fixes #796.