### PR TITLE
Improve error catching for embedded expressions

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/EmbeddedExpressionPassesErrors.dm
+++ b/Content.Tests/DMProject/Tests/Text/EmbeddedExpressionPassesErrors.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR
+
+/proc/RunTest()
+	var/test1 = "["["a""b"]"]" // 'expected end of embedded statement' from inner interpolation

--- a/Content.Tests/DMProject/Tests/Text/EndOfEmbeddedExpression.dm
+++ b/Content.Tests/DMProject/Tests/Text/EndOfEmbeddedExpression.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR
+
+/proc/RunTest()
+	var/test1 = "["a""b"]" // expected end of embedded expression

--- a/Content.Tests/DMProject/Tests/Text/ExpectedEmbeddedExpression.dm
+++ b/Content.Tests/DMProject/Tests/Text/ExpectedEmbeddedExpression.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR
+
+/proc/RunTest()
+	var/test1 = "[;]" // expected an expression

--- a/Content.Tests/DMProject/Tests/Text/HoleEmbeddedExpression.dm
+++ b/Content.Tests/DMProject/Tests/Text/HoleEmbeddedExpression.dm
@@ -1,0 +1,3 @@
+/proc/RunTest()
+	ASSERT(text("[]", "TEST") == "TEST")
+	ASSERT(text("[ ]", "TEST") == "TEST")

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2040,7 +2040,7 @@ namespace DMCompiler.Compiler.DM {
                                     insideBrackets.Remove(insideBrackets.Length - 1, 1); //Remove the ending bracket
 
                                     string insideBracketsText = insideBrackets?.ToString();
-                                    if (insideBracketsText != String.Empty) {
+                                    if (!String.IsNullOrWhiteSpace(insideBracketsText)) {
                                         DMPreprocessorLexer preprocLexer = new DMPreprocessorLexer(null, constantToken.Location.SourceFile, insideBracketsText);
                                         List<Token> preprocTokens = new();
                                         Token preprocToken;
@@ -2058,10 +2058,11 @@ namespace DMCompiler.Compiler.DM {
                                             expressionParser.Whitespace(true);
                                             expression = expressionParser.Expression();
                                             if (expression == null) Error("Expected an expression");
-                                        } catch (CompileErrorException e) {
-                                            Errors.Add(e.Error);
+                                            if (expressionParser.Current().Type != TokenType.EndOfFile) Error("Expected end of embedded statement");
+                                        } catch (CompileErrorException) {
                                         }
 
+                                        if (expressionParser.Errors.Count > 0) Errors.AddRange(expressionParser.Errors);
                                         if (expressionParser.Warnings.Count > 0) Warnings.AddRange(expressionParser.Warnings);
                                         interpolationValues.Add(expression);
                                     } else {


### PR DESCRIPTION
- Errors inside embedded expressions are no longer printed twice.
- Putting multiple expressions inside interpolation brackets now emits an error. (e.g. `"["a""b"]"` emits `Expected end of embedded expression`)
- Adds unit tests for bad embedded expressions (expressionless but non-empty/multiple expressions)