### PR TITLE
Adds var/vars to /world and /client, fixes several bugs with all var/vars implementations

### DIFF
--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -2,6 +2,7 @@
 	var/list/verbs = list()
 	var/list/screen = list()
 	var/list/images = list() as opendream_unimplemented
+	var/list/vars
 
 	var/atom/statobj
 	var/statpanel

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -1,5 +1,6 @@
 ﻿/world
 	var/list/contents = list()
+	var/list/vars
 
 	var/log = null
 

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -97,7 +97,8 @@ namespace OpenDreamRuntime.Objects {
                 throw new Exception("Cannot get variable names of a deleted object");
             }
             List<DreamValue> list = new(_variables.Count);
-            foreach (String key in _variables.Keys) {
+            // This is only ever called on a few specific types, none of them /list, so ObjectDefinition must be non-null.
+            foreach (String key in ObjectDefinition!.Variables.Keys) { 
                 list.Add(new(key));
             }
             return list;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -129,6 +129,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 }
                 case "connection":
                     return new DreamValue("seeker");
+                case "vars": // /client has this too!
+                    return new DreamValue(DreamListVars.Create(dreamObject));
                 default:
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
             }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -122,6 +122,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                         return new DreamValue(_viewRange.ToString());
                     }
                 }
+                case "vars":
+                    return new DreamValue(DreamListVars.Create(dreamObject));
                 default:
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -831,42 +831,61 @@ namespace OpenDreamRuntime.Procs.Native {
             }
         }
 
-        public static object CreateJsonElementFromValue(DreamValue value) {
-            if (value.TryGetValueAsFloat(out float floatValue)) {
+        /// <summary>
+        /// A helper function for /proc/json_encode(). Takes in a value and returns its json-able equivalent.
+        /// </summary>
+        /// <returns>Something that <see cref="JsonSerializer.Serialize"/> can parse.</returns>
+        public static object? CreateJsonElementFromValue(DreamValue value) {
+            return CreateJsonElementFromValueRecursive(value, 0);
+        }
+
+        /// <remarks> This exists to allow for some control over the recursion.<br/>
+        /// DM is actually not very smart about deep recursion or lists referencing their parents; it just goes to ~19 depth and gives up.</remarks>
+        private static object? CreateJsonElementFromValueRecursive(DreamValue value, int recursionLevel) {
+            const int maximumRecursions = 20; // In parity with DM, we give up and just print a 'null' at the maximum recursion.
+            if (recursionLevel == maximumRecursions)
+                return null; // This will be turned into the string "null" higher up in the stack.
+
+            if(value.TryGetValueAsFloat(out float floatValue))
                 return floatValue;
-            } else if (value.TryGetValueAsString(out string text)) {
+            if (value.TryGetValueAsString(out string text))
                 return HttpUtility.JavaScriptStringEncode(text);
-            } else if (value.TryGetValueAsPath(out var path)) {
-                return path.ToString();
-            } else if (value.TryGetValueAsDreamList(out DreamList list)) {
-                if (list.IsAssociative()) {
+            if (value.TryGetValueAsPath(out var path))
+                return HttpUtility.JavaScriptStringEncode(path.ToString());
+            if (value.TryGetValueAsDreamList(out DreamList list)) {
+                if (list.IsAssociative) {
                     Dictionary<Object, Object?> jsonObject = new(list.GetLength());
 
                     foreach (DreamValue listValue in list.GetValues()) {
                         if (list.ContainsKey(listValue)) {
-                            jsonObject.Add(listValue.Stringify(), CreateJsonElementFromValue(list.GetValue(listValue)));
+                            jsonObject.Add(HttpUtility.JavaScriptStringEncode(listValue.Stringify()), // key
+                                           CreateJsonElementFromValueRecursive(list.GetValue(listValue), recursionLevel+1)); // value
                         } else {
-                            jsonObject.Add(CreateJsonElementFromValue(listValue), null); // list[x] = null
+                            jsonObject.Add(CreateJsonElementFromValueRecursive(listValue, recursionLevel + 1), null); // list[x] = null
                         }
                     }
 
                     return jsonObject;
-                } else {
-                    List<Object> jsonObject = new();
-
-                    foreach (DreamValue listValue in list.GetValues()) {
-                        jsonObject.Add(CreateJsonElementFromValue(listValue));
-                    }
-
-                    return jsonObject;
                 }
-            } else if (value.Type == DreamValueType.DreamObject) {
-                if (value.Value == null) return null;
+                List<Object?> jsonArray = new();
+                foreach (DreamValue listValue in list.GetValues()) {
+                    jsonArray.Add(CreateJsonElementFromValueRecursive(listValue, recursionLevel + 1));
+                }
 
-                return value.Stringify();
-            } else {
-                throw new Exception("Cannot json_encode " + value);
+                return jsonArray;
             }
+            if (value.Type == DreamValueType.DreamObject) {
+                if (value.Value == null) return null;
+                return value.Stringify();
+            }
+            if(value.Type == DreamValueType.DreamResource) {
+                DreamResource dreamResource = (DreamResource)value.Value;
+                string? output = dreamResource.ReadAsString();
+                if (output == null)
+                    return "";
+                return output;
+            }
+            throw new Exception("Cannot json_encode " + value);
         }
 
         [DreamProc("json_decode")]
@@ -884,7 +903,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("json_encode")]
         [DreamProcParameter("Value")]
         public static DreamValue NativeProc_json_encode(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            object jsonObject = CreateJsonElementFromValue(arguments.GetArgument(0, "Value"));
+            object? jsonObject = CreateJsonElementFromValue(arguments.GetArgument(0, "Value"));
             string result = JsonSerializer.Serialize(jsonObject);
 
             return new DreamValue(result);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/191658384-1439c96c-3891-4361-8f98-603d882c335e.png)
Fixes #805.
## Summary
At first I thought this would just be an easy thing where I can, like, slap some stuff in DMStandard and call it a bug fixed.

However, while testing that solution, I found some bugginess in how var/vars works for all types, including /datum and everything else.

The classes that inherit from `DreamList` were not overriding some methods that procs like `json_encode` were using to find the associative values of the list, so I also fixed that.

## Changelog
- `json_encode()` is now better at encoding `vars` and `global.vars`.
- Fixed `vars` accesses not including any variables which have not been locally overwritten for the DMObject that is accessed.
- `json_encode()` no longer causes stack overflows when encoding data with cyclical or deep references.
- `/client` and `/world` now have a `vars` var.
- DreamValues of type `DreamResource` now actually attempt to encode themselves when json_encode()'d.