### PR TITLE
Fix `dotnet test Content.Tests` not copying DMStandard

### DIFF
--- a/Content.IntegrationTests/Content.IntegrationTests.csproj
+++ b/Content.IntegrationTests/Content.IntegrationTests.csproj
@@ -27,10 +27,22 @@
     <ProjectReference Include="..\RobustToolbox\Robust.UnitTesting\Robust.UnitTesting.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Copy DMProject to output directory. !-->
+    <!-- Copy DMProject to output directory. -->
     <None Include="$(ProjectDir)\DMProject\**" CopyToOutputDirectory="PreserveNewest" LinkBase="DMProject\" />
-    <!-- Copy DMStandard to output directory. !-->
-    <None Include="$(SolutionDir)\DMCompiler\DMStandard\**" CopyToOutputDirectory="PreserveNewest" LinkBase="DMStandard\" />
+    <!-- Copy DMStandard to output directory. -->
+    <DMStandard Include="..\DMCompiler\DMStandard\**"/>
   </ItemGroup>
+  <Target Name="CopyDMStandard" AfterTargets="AfterBuild">
+    <Copy
+      SourceFiles="@(DMStandard)"
+      DestinationFiles="@(DMStandard->'$(OutDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+  </Target>
+  <Target Name="CopyDMStandardOnPublish" AfterTargets="Publish">
+    <Copy
+      SourceFiles="@(DMStandard)"
+      DestinationFiles="@(DMStandard->'$(PublishDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+  </Target>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Analyzers.targets" />
 </Project>

--- a/Content.Tests/Content.Tests.csproj
+++ b/Content.Tests/Content.Tests.csproj
@@ -28,12 +28,26 @@
     <ProjectReference Include="..\RobustToolbox\Robust.Shared\Robust.Shared.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.UnitTesting\Robust.UnitTesting.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <!-- Copy DMProject to output directory. !-->
+    <!-- Copy DMProject to output directory. -->
     <None Include="$(ProjectDir)\DMProject\**" CopyToOutputDirectory="PreserveNewest" LinkBase="DMProject\" />
-    <!-- Copy DMStandard to output directory. !-->
-    <None Include="$(SolutionDir)\DMCompiler\DMStandard\**" CopyToOutputDirectory="PreserveNewest" LinkBase="DMStandard\" />
+    <!-- Copy DMStandard to output directory. -->
+    <DMStandard Include="..\DMCompiler\DMStandard\**"/>
   </ItemGroup>
+
+  <Target Name="CopyDMStandard" AfterTargets="AfterBuild">
+    <Copy
+      SourceFiles="@(DMStandard)"
+      DestinationFiles="@(DMStandard->'$(OutDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+  </Target>
+  <Target Name="CopyDMStandardOnPublish" AfterTargets="Publish">
+    <Copy
+      SourceFiles="@(DMStandard)"
+      DestinationFiles="@(DMStandard->'$(PublishDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+  </Target>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Analyzers.targets" />
 
 </Project>


### PR DESCRIPTION
Tested on Linux, don't know if other platforms were affected.

`dotnet build` then `dotnet test --no-build Content.Tests` would work, but `dotnet test Content.Tests` wouldn't, because `dotnet build Content.Tests` alone was removing the copied DMStandard files.

Per ike, instead use the CopyDMStandard targets from DMCompiler.