### PR TITLE
Fixes `fcopy()` not working if the dest directory doesn't exist

### DIFF
--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -89,7 +89,9 @@ namespace OpenDreamRuntime.Resources
 
         public bool CopyFile(string sourceFilePath, string destinationFilePath) {
             try {
-                File.Copy(Path.Combine(RootPath, sourceFilePath), Path.Combine(RootPath, destinationFilePath));
+                var dest = Path.Combine(RootPath, destinationFilePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(dest));
+                File.Copy(Path.Combine(RootPath, sourceFilePath), dest);
             } catch (Exception) {
                 return false;
             }


### PR DESCRIPTION
BYOND automatically creates nonexistent dirs, so now we do too.

`CreateDirectory()` won't error if the dir already exists so there's no reason to add a check.