### PR TITLE
Implement world.GetConfig and SetConfig for environment variables

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/world_config.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/world_config.dm
@@ -14,3 +14,7 @@
 	ASSERT(retrieved != null)
 	world.SetConfig("env", env_var, null)
 	ASSERT(world.GetConfig("env", env_var) == null)
+
+	world.SetConfig("env", env_var, env_value)
+	world.SetConfig("env", env_var, 17)
+	ASSERT(world.GetConfig("env", env_var) == null)

--- a/Content.Tests/DMProject/Tests/Builtins/world_config.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/world_config.dm
@@ -1,8 +1,6 @@
 
 /proc/RunTest()
-	var/list/all = world.GetConfig("env")
-	ASSERT(islist(all))
-	ASSERT(all.len > 5)
+	ASSERT(isnull(world.GetConfig("env")))
 
 	var/path = world.GetConfig("env", "PATH")
 	ASSERT(istext(path) && length(path))

--- a/Content.Tests/DMProject/Tests/Builtins/world_config.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/world_config.dm
@@ -1,0 +1,14 @@
+
+/proc/RunTest()
+	var/path = world.GetConfig("env", "PATH")
+	ASSERT(istext(path) && length(path))
+
+	var/env_var = "SUPER_SPECIAL_DM_ENVIRONMENT_KEY_FOR_TESTING"
+	var/env_value = "test value"
+	ASSERT(world.GetConfig("env", env_var) == null)
+	world.SetConfig("env", env_var, env_value)
+	var/retrieved = world.GetConfig("env", env_var)
+	ASSERT(retrieved == env_value)
+	ASSERT(retrieved != null)
+	world.SetConfig("env", env_var, null)
+	ASSERT(world.GetConfig("env", env_var) == null)

--- a/Content.Tests/DMProject/Tests/Builtins/world_config.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/world_config.dm
@@ -1,5 +1,9 @@
 
 /proc/RunTest()
+	var/list/all = world.GetConfig("env")
+	ASSERT(islist(all))
+	ASSERT(all.len > 5)
+
 	var/path = world.GetConfig("env", "PATH")
 	ASSERT(istext(path) && length(path))
 

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -60,7 +60,7 @@ namespace Content.Tests
         [Test, TestCaseSource(nameof(GetTests))]
         public void TestFiles(string sourceFile, DMTestFlags testFlags)
         {
-            string compiledFile = Compile(sourceFile);
+            string compiledFile = Compile(Path.Join(Directory.GetCurrentDirectory(), "Tests", sourceFile));
             if (testFlags.HasFlag(DMTestFlags.CompileError)) {
                 Assert.IsNull(compiledFile, $"Expected an error during DM compilation");
                 Cleanup(compiledFile);
@@ -111,12 +111,13 @@ namespace Content.Tests
             Directory.SetCurrentDirectory(TestProject);
 
             foreach (string sourceFile in Directory.GetFiles("Tests", "*.dm", SearchOption.AllDirectories)) {
+                string sourceFile2 = sourceFile.Substring("Tests/".Length);
                 DMTestFlags testFlags = GetDMTestFlags(sourceFile);
                 if (testFlags.HasFlag(DMTestFlags.Ignore))
                     continue;
 
                 yield return new object[] {
-                    Path.GetFullPath(sourceFile),
+                    sourceFile2,
                     testFlags
                 };
             }

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -35,6 +35,7 @@ namespace DMCompiler.DM {
         public static void Reset() {
             AllObjects.Clear();
             AllProcs.Clear();
+            Globals.Clear();
             GlobalProcs.Clear();
             _pathToTypeId.Clear();
             _dmObjectIdCounter = 0;

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -52,9 +52,7 @@
 	proc/Profile(command, type, format)
 		set opendream_unimplemented = TRUE
 	proc/GetConfig(config_set,param)
-		set opendream_unimplemented = TRUE
 	proc/SetConfig(config_set,param,value)
-		set opendream_unimplemented = TRUE
 	proc/OpenPort(port)
 		set opendream_unimplemented = TRUE
 	proc/IsSubscribed(player, type)

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -20,7 +20,7 @@ namespace OpenDreamRuntime {
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
         [Dependency] private readonly IProcScheduler _procScheduler = default!;
         [Dependency] private readonly DreamResourceManager _dreamResourceManager = default!;
-        
+
 
         public DreamObjectTree ObjectTree { get; private set; } = new();
         public DreamObject WorldInstance { get; private set; }
@@ -92,6 +92,7 @@ namespace OpenDreamRuntime {
 
             if (_compiledJson.Globals != null) {
                 var jsonGlobals = _compiledJson.Globals;
+                Globals.Clear();
                 Globals.EnsureCapacity(jsonGlobals.GlobalCount);
 
                 for (int i = 0; i < jsonGlobals.GlobalCount; i++) {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1828,10 +1828,13 @@ namespace OpenDreamRuntime.Procs {
         }
 
         private static DreamValue DivideValues(DreamValue first, DreamValue second) {
-            if (first.Value == null) {
+            if (first == DreamValue.Null) {
                 return new(0);
-            } else if (first.Type == DreamValue.DreamValueType.Float && second.Type == DreamValue.DreamValueType.Float) {
-                return new(first.GetValueAsFloat() / second.GetValueAsFloat());
+            } else if (first.TryGetValueAsFloat(out var firstFloat) && second.TryGetValueAsFloat(out var secondFloat)) {
+                if (secondFloat == 0) {
+                    throw new Exception("Division by zero");
+                }
+                return new(firstFloat / secondFloat);
             } else {
                 throw new Exception("Invalid divide operation on " + first + " and " + second);
             }

--- a/OpenDreamRuntime/Procs/DreamProcAttribute.cs
+++ b/OpenDreamRuntime/Procs/DreamProcAttribute.cs
@@ -12,7 +12,7 @@
     sealed class DreamProcParameterAttribute : Attribute {
         public string Name;
         public DreamValue.DreamValueType Type;
-        public object DefaultValue;
+        public object? DefaultValue;
 
         public DreamProcParameterAttribute(string name) {
             Name = name;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -125,6 +125,8 @@ namespace OpenDreamRuntime.Procs.Native {
 
             DreamObjectDefinition world = objectTree.GetObjectDefinition(DreamPath.World);
             world.SetNativeProc(DreamProcNativeWorld.NativeProc_Export);
+            world.SetNativeProc(DreamProcNativeWorld.NativeProc_GetConfig);
+            world.SetNativeProc(DreamProcNativeWorld.NativeProc_SetConfig);
         }
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -9,9 +9,9 @@ namespace OpenDreamRuntime.Procs.Native
     {
         [DreamProc("Export")]
         [DreamProcParameter("Addr", Type = DreamValue.DreamValueType.String)]
-        [DreamProcParameter("File", Type = DreamValue.DreamValueType.DreamObject, DefaultValue = null)]
+        [DreamProcParameter("File", Type = DreamValue.DreamValueType.DreamObject)]
         [DreamProcParameter("Persist", Type = DreamValue.DreamValueType.Float, DefaultValue = 0)]
-        [DreamProcParameter("Clients", Type = DreamValue.DreamValueType.DreamObject, DefaultValue = null)]
+        [DreamProcParameter("Clients", Type = DreamValue.DreamValueType.DreamObject)]
         public static async Task<DreamValue> NativeProc_Export(AsyncNativeProc.State state)
         {
             var addr = state.Arguments.GetArgument(0, "Addr").Stringify();
@@ -41,19 +41,19 @@ namespace OpenDreamRuntime.Procs.Native
 
         [DreamProc("GetConfig")]
         [DreamProcParameter("config_set", Type = DreamValue.DreamValueType.String)]
-        [DreamProcParameter("param", Type = DreamValue.DreamValueType.String, DefaultValue = null)]
+        [DreamProcParameter("param", Type = DreamValue.DreamValueType.String)]
         public static DreamValue NativeProc_GetConfig(DreamObject src, DreamObject usr, DreamProcArguments arguments)
         {
-            var config_set = arguments.GetArgument(0, "config_set").Stringify();
+            arguments.GetArgument(0, "config_set").TryGetValueAsString(out string config_set);
             var param = arguments.GetArgument(1, "param");
 
             switch (config_set) {
                 case "env":
                     if (param == DreamValue.Null) {
                         // DM ref says: "If no parameter is specified, a list of the names of all available parameters is returned."
-                        // but apparently it's actually just null.
+                        // but apparently it's actually just null for "env".
                         return DreamValue.Null;
-                    } else if (Environment.GetEnvironmentVariable(param.Stringify()) is string strValue) {
+                    } else if (param.TryGetValueAsString(out string paramString) && Environment.GetEnvironmentVariable(paramString) is string strValue) {
                         return new DreamValue(strValue);
                     } else {
                         return DreamValue.Null;
@@ -72,20 +72,17 @@ namespace OpenDreamRuntime.Procs.Native
         [DreamProc("SetConfig")]
         [DreamProcParameter("config_set", Type = DreamValue.DreamValueType.String)]
         [DreamProcParameter("param", Type = DreamValue.DreamValueType.String)]
-        [DreamProcParameter("value", Type = DreamValue.DreamValueType.String, DefaultValue = null)]
+        [DreamProcParameter("value", Type = DreamValue.DreamValueType.String)]
         public static DreamValue NativeProc_SetConfig(DreamObject src, DreamObject usr, DreamProcArguments arguments)
         {
-            var config_set = arguments.GetArgument(0, "config_set").Stringify();
-            var param = arguments.GetArgument(1, "param").Stringify();
+            arguments.GetArgument(0, "config_set").TryGetValueAsString(out string config_set);
+            arguments.GetArgument(1, "param").TryGetValueAsString(out string param);
             var value = arguments.GetArgument(2, "value");
 
             switch (config_set) {
                 case "env":
-                    if (value == DreamValue.Null) {
-                        Environment.SetEnvironmentVariable(param, null);
-                    } else {
-                        Environment.SetEnvironmentVariable(param, value.Stringify());
-                    }
+                    value.TryGetValueAsString(out string valueString);
+                    Environment.SetEnvironmentVariable(param, valueString);
                     return DreamValue.Null;
                 case "admin":
                     throw new NotSupportedException("Unsupported SetConfig config_set: " + config_set);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -41,15 +41,22 @@ namespace OpenDreamRuntime.Procs.Native
 
         [DreamProc("GetConfig")]
         [DreamProcParameter("config_set", Type = DreamValue.DreamValueType.String)]
-        [DreamProcParameter("param", Type = DreamValue.DreamValueType.String)]
+        [DreamProcParameter("param", Type = DreamValue.DreamValueType.String, DefaultValue = null)]
         public static DreamValue NativeProc_GetConfig(DreamObject src, DreamObject usr, DreamProcArguments arguments)
         {
             var config_set = arguments.GetArgument(0, "config_set").Stringify();
-            var param = arguments.GetArgument(1, "param").Stringify();
+            var param = arguments.GetArgument(1, "param");
 
             switch (config_set) {
                 case "env":
-                    if (Environment.GetEnvironmentVariable(param) is string strValue) {
+                    if (param == DreamValue.Null) {
+                        var keys = Environment.GetEnvironmentVariables().Keys;
+                        var list = DreamList.Create(keys.Count);
+                        foreach (var key in keys) {
+                            list.AddValue(new DreamValue((string)key));
+                        }
+                        return new DreamValue(list);
+                    } else if (Environment.GetEnvironmentVariable(param.Stringify()) is string strValue) {
                         return new DreamValue(strValue);
                     } else {
                         return DreamValue.Null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -50,12 +50,9 @@ namespace OpenDreamRuntime.Procs.Native
             switch (config_set) {
                 case "env":
                     if (param == DreamValue.Null) {
-                        var keys = Environment.GetEnvironmentVariables().Keys;
-                        var list = DreamList.Create(keys.Count);
-                        foreach (var key in keys) {
-                            list.AddValue(new DreamValue((string)key));
-                        }
-                        return new DreamValue(list);
+                        // DM ref says: "If no parameter is specified, a list of the names of all available parameters is returned."
+                        // but apparently it's actually just null.
+                        return DreamValue.Null;
                     } else if (Environment.GetEnvironmentVariable(param.Stringify()) is string strValue) {
                         return new DreamValue(strValue);
                     } else {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -38,5 +38,60 @@ namespace OpenDreamRuntime.Procs.Native
 
             return new DreamValue(list);
         }
+
+        [DreamProc("GetConfig")]
+        [DreamProcParameter("config_set", Type = DreamValue.DreamValueType.String)]
+        [DreamProcParameter("param", Type = DreamValue.DreamValueType.String)]
+        public static DreamValue NativeProc_GetConfig(DreamObject src, DreamObject usr, DreamProcArguments arguments)
+        {
+            var config_set = arguments.GetArgument(0, "config_set").Stringify();
+            var param = arguments.GetArgument(1, "param").Stringify();
+
+            switch (config_set) {
+                case "env":
+                    if (Environment.GetEnvironmentVariable(param) is string strValue) {
+                        return new DreamValue(strValue);
+                    } else {
+                        return DreamValue.Null;
+                    }
+                case "admin":
+                    throw new NotSupportedException("Unsupported GetConfig config_set: " + config_set);
+                case "ban":
+                case "keyban":
+                case "ipban":
+                    throw new NotSupportedException("Unsupported GetConfig config_set: " + config_set);
+                default:
+                    throw new ArgumentException("Incorrect GetConfig config_set: " + config_set);
+            }
+        }
+
+        [DreamProc("SetConfig")]
+        [DreamProcParameter("config_set", Type = DreamValue.DreamValueType.String)]
+        [DreamProcParameter("param", Type = DreamValue.DreamValueType.String)]
+        [DreamProcParameter("value", Type = DreamValue.DreamValueType.String, DefaultValue = null)]
+        public static DreamValue NativeProc_SetConfig(DreamObject src, DreamObject usr, DreamProcArguments arguments)
+        {
+            var config_set = arguments.GetArgument(0, "config_set").Stringify();
+            var param = arguments.GetArgument(1, "param").Stringify();
+            var value = arguments.GetArgument(2, "value");
+
+            switch (config_set) {
+                case "env":
+                    if (value == DreamValue.Null) {
+                        Environment.SetEnvironmentVariable(param, null);
+                    } else {
+                        Environment.SetEnvironmentVariable(param, value.Stringify());
+                    }
+                    return DreamValue.Null;
+                case "admin":
+                    throw new NotSupportedException("Unsupported SetConfig config_set: " + config_set);
+                case "ban":
+                case "keyban":
+                case "ipban":
+                    throw new NotSupportedException("Unsupported SetConfig config_set: " + config_set);
+                default:
+                    throw new ArgumentException("Incorrect SetConfig config_set: " + config_set);
+            }
+        }
     }
 }

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -21,7 +21,7 @@ namespace OpenDreamRuntime.Resources
 
         public void SetDirectory(string directory) {
             RootPath = directory;
-            //Directory.SetCurrentDirectory(RootPath);
+            Directory.SetCurrentDirectory(RootPath);
 
             Logger.DebugS("opendream.res", $"Resource root path set to {RootPath}");
         }

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -21,6 +21,7 @@ namespace OpenDreamRuntime.Resources
 
         public void SetDirectory(string directory) {
             RootPath = directory;
+            // Used to ensure external DLL calls see a consistent current directory.
             Directory.SetCurrentDirectory(RootPath);
 
             Logger.DebugS("opendream.res", $"Resource root path set to {RootPath}");

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -21,7 +21,7 @@ namespace OpenDreamRuntime.Resources
 
         public void SetDirectory(string directory) {
             RootPath = directory;
-            Directory.SetCurrentDirectory(RootPath);
+            //Directory.SetCurrentDirectory(RootPath);
 
             Logger.DebugS("opendream.res", $"Resource root path set to {RootPath}");
         }


### PR DESCRIPTION
"env" is implemented but "admin" and "ban" are not. Pursuant to #289 and #290.

To test those changes, the following test suite fixes were made:
- Reset `DMObjectTree.Globals` between compilations so references to `world` are correct
- Reset `DreamManager.Globals` between runs to match
- Add runtime when dividing by zero; Const3.dm previously passed because of global confusion
- Use relative paths to `.dm` files to make test explorer easier to read