### PR TITLE
Implement regex `\l`

### DIFF
--- a/Content.Tests/DMProject/Tests/Regex/regex_l_test.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_l_test.dm
@@ -1,0 +1,5 @@
+
+/proc/RunTest()
+	var/regex/R = regex(@"\l")
+	var/meep = R.Find("0abc123def")
+	ASSERT(meep == 2)

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRegex.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRegex.cs
@@ -31,6 +31,19 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     if (flagsString.Contains("g")) regex.IsGlobal = true;
                 }
 
+                // TODO Make this more Robust(TM)
+                var anyLetterIdx = patternString.IndexOf("\\l"); // From the ref: \l = Any letter A through Z, case-insensitive
+                while (anyLetterIdx >= 0) {
+                    if (anyLetterIdx == 0 || patternString[anyLetterIdx - 1] != '\\') { // TODO Need to make this handle an arbitrary number of escape chars
+                            patternString = patternString.Remove(anyLetterIdx, 2).Insert(anyLetterIdx, "[A-Za-z]");
+                    }
+
+                    var nextIdx = anyLetterIdx + 1;
+                    if(nextIdx >= patternString.Length) break;
+
+                    anyLetterIdx = patternString.IndexOf("\\l", nextIdx);
+                }
+
                 regex.Regex = new Regex(patternString, options);
             } else {
                 throw new System.Exception("Invalid regex pattern " + pattern);


### PR DESCRIPTION
It could stand to be more robust (mainly parsing an arbitrary number of preceding escapes) but it's good enough for most usecases