### PR TITLE
Removes some unnecessary/off-parity double-to-float conversions in the code

### DIFF
--- a/DMCompiler/DM/Visitors/DMASTSimplifier.cs
+++ b/DMCompiler/DM/Visitors/DMASTSimplifier.cs
@@ -461,7 +461,7 @@ namespace DMCompiler.DM.Visitors {
                 DMASTConstantInteger aInteger = power.A as DMASTConstantInteger;
                 DMASTConstantInteger bInteger = power.B as DMASTConstantInteger;
 
-                if (aInteger != null && bInteger != null) expression = new DMASTConstantInteger(expression.Location, (int)Math.Pow(aInteger.Value, bInteger.Value));
+                if (aInteger != null && bInteger != null) expression = new DMASTConstantInteger(expression.Location, (int)MathF.Pow(aInteger.Value, bInteger.Value));
 
                 return;
             }

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -247,7 +247,7 @@ namespace DMCompiler.DM.Visitors {
                         throw new CompileErrorException(statementSet.Location, "invisibility attribute must be an int");
                     }
 
-                    _proc.Invisibility = Convert.ToSByte(Math.Clamp(Math.Floor(invisNum.Value), 0, 100));
+                    _proc.Invisibility = Convert.ToSByte(Math.Clamp(MathF.Floor(invisNum.Value), 0f, 100f));
                     DMCompiler.UnimplementedWarning(statementSet.Location, "set invisibility is not implemented");
                     break;
                 case "src":

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -996,8 +996,8 @@ namespace OpenDreamRuntime.Procs {
             DreamValue second = state.Pop();
             DreamValue first = state.Pop();
 
-            if (first.Type == DreamValue.DreamValueType.Float && second.Type == DreamValue.DreamValueType.Float) {
-                state.Push(new DreamValue((float)Math.Pow(first.GetValueAsFloat(), second.GetValueAsFloat())));
+            if (first.TryGetValueAsFloat(out var floatFirst) && second.TryGetValueAsFloat(out var floatSecond)) {
+                state.Push(new DreamValue(MathF.Pow(floatFirst, floatSecond)));
             } else {
                 throw new Exception("Invalid power operation on " + first + " and " + second);
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -103,6 +103,16 @@ namespace OpenDreamRuntime.Procs.Native {
             return DreamValue.Null;
         }
 
+        /* NOTE ABOUT THE TRIG FUNCTIONS:
+         * If you have a sharp eye, you may notice that our trignometry functions make use of the *double*-precision versions of those functions,
+         * even though this is a single-precision language.
+         * 
+         * DO NOT replace them with the single-precision ones in MathF!!!
+         * 
+         * BYOND erroneously calls the double-precision versions in its code, in a way that does honestly affect behaviour in some circumstances.
+         * Replicating that REQUIRES us to do the same error! You will break a unit test or two if you try to change this.
+         */
+
         [DreamProc("arccos")]
         [DreamProcParameter("X", Type = DreamValueType.Float)]
         public static DreamValue NativeProc_arccos(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {


### PR DESCRIPTION
## Summary
Previously, our exponent implementation would use the double-precision version of `Pow()`, despite this being a single-precision language. That has been fixed.

NOTE that our trig functions (plus `/proc/log()` and so on) still make use of the double-precision variants. **This is intentional,** as BYOND has the same bug and changing this literally breaks a few unit tests. I put a warning near where the trig functions are defined to stop anyone else who may think of the same thing.

## Changelog
- Fixed some unnecessarily-precise floating point operations throughout the codebase.