### PR TITLE
Improve browse() functionality

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlOutput.cs
+++ b/OpenDreamClient/Interface/Controls/ControlOutput.cs
@@ -29,7 +29,7 @@ namespace OpenDreamClient.Interface.Controls {
         {
             var msg = new FormattedMessage(2);
             msg.PushColor(Color.Black);
-            msg.AddText(value);
+            msg.AddText(value.Replace("\t", "        "));
             _textBox.AddMessage(msg);
         }
     }

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -404,20 +404,22 @@ namespace OpenDreamRuntime
             string? window = null;
             Vector2i size = (480, 480);
 
-            string[] separated = (options ?? "").Split(',', ';', '&');
-            foreach (string option in separated) {
-                string optionTrimmed = option.Trim();
+            if (options != null) {
+                foreach (string option in options.Split(',', ';', '&')) {
+                    string optionTrimmed = option.Trim();
 
-                if (optionTrimmed != String.Empty) {
-                    string[] optionSeparated = optionTrimmed.Split("=");
-                    string key = optionSeparated[0];
-                    string value = optionSeparated[1];
+                    if (optionTrimmed != String.Empty) {
+                        string[] optionSeparated = optionTrimmed.Split("=", 2);
+                        string key = optionSeparated[0];
+                        string value = optionSeparated[1];
 
-                    if (key == "window") window = value;
-                    if (key == "size") {
-                        string[] sizeSeparated = value.Split("x");
+                        if (key == "window") {
+                            window = value;
+                        } else if (key == "size") {
+                            string[] sizeSeparated = value.Split("x", 2);
 
-                        size = (int.Parse(sizeSeparated[0]), int.Parse(sizeSeparated[1]));
+                            size = (int.Parse(sizeSeparated[0]), int.Parse(sizeSeparated[1]));
+                        }
                     }
                 }
             }

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -400,11 +400,11 @@ namespace OpenDreamRuntime
             Session.ConnectedClient.SendMessage(msg);
         }
 
-        public void Browse(string body, string options) {
-            string window = null;
+        public void Browse(string body, string? options) {
+            string? window = null;
             Vector2i size = (480, 480);
 
-            string[] separated = options.Split(',', ';', '&');
+            string[] separated = (options ?? "").Split(',', ';', '&');
             foreach (string option in separated) {
                 string optionTrimmed = option.Trim();
 

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -134,13 +134,8 @@ namespace OpenDreamRuntime
 
         public DreamConnection? GetConnectionFromClient(DreamObject client)
         {
-            foreach (var connection in _connections.Values)
-            {
-                if (connection.ClientDreamObject == client)
-                    return connection;
-            }
-
-            return null;
+            _clientToConnection.TryGetValue(client, out var connection);
+            return connection;
         }
     }
 }

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -110,7 +110,7 @@ namespace OpenDreamRuntime {
             return (string)GetValueExpectingType(DreamValueType.String);
         }
 
-        public bool TryGetValueAsString(out string value) {
+        public bool TryGetValueAsString([NotNullWhen(true)] out string? value) {
             if (Type == DreamValueType.String) {
                 value = (string)Value;
                 return true;

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -84,17 +84,16 @@ namespace OpenDreamRuntime {
         }
 
         public override string ToString() {
-            string value;
+            string strValue;
             if (Value == null) {
-                value = "null";
-            } else
-                value = Type switch {
-                    DreamValueType.String => "\"" + Value + "\"",
-                    DreamValueType.DreamResource => "'" + ((DreamResource)Value).ResourcePath + "'",
-                    _ => Value.ToString()
-                };
+                strValue = "null";
+            } else if (Type == DreamValueType.String) {
+                strValue = $"\"{Value}\"";
+            } else {
+                strValue = Value.ToString() ?? "<ToString() = null>";
+            }
 
-            return "DreamValue(" + Type + ", " + value + ")";
+            return "DreamValue(" + Type + ", " + strValue + ")";
         }
 
         [Obsolete("Deprecated. Use the relevant TryGetValueAs[Type]() instead.")]

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1470,13 +1470,13 @@ namespace OpenDreamRuntime.Procs {
             DreamValue body = state.Pop();
             DreamObject receiver = state.Pop().GetValueAsDreamObject();
 
-            IEnumerable<DreamObject> clients;
+            IEnumerable<DreamConnection> clients;
             if (receiver.IsSubtypeOf(DreamPath.Mob)) {
-                clients = new[] { receiver.GetVariable("client").GetValueAsDreamObject() };
+                clients = new[] { state.DreamManager.GetConnectionFromMob(receiver) };
             } else if (receiver.IsSubtypeOf(DreamPath.Client)) {
-                clients = new[] { receiver };
+                clients = new[] { state.DreamManager.GetConnectionFromClient(receiver) };
             } else if (receiver == state.DreamManager.WorldInstance) {
-                clients = state.DreamManager.Clients;
+                clients = state.DreamManager.Connections;
             } else {
                 throw new Exception($"Invalid browse() recipient: expected mob, client, or world, got {receiver}");
             }
@@ -1490,8 +1490,8 @@ namespace OpenDreamRuntime.Procs {
                 throw new Exception($"Invalid browse() body: expected resource or string, got {body}");
             }
 
-            foreach (DreamObject client in clients) {
-                state.DreamManager.GetConnectionFromClient(client)?.Browse(browseValue, options);
+            foreach (DreamConnection client in clients) {
+                client?.Browse(browseValue, options);
             }
 
             return null;

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1491,7 +1491,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             foreach (DreamObject client in clients) {
-                state.DreamManager.GetConnectionFromClient(client)?.Browse(browseValue, options ?? "");
+                state.DreamManager.GetConnectionFromClient(client)?.Browse(browseValue, options);
             }
 
             return null;

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -56,5 +56,9 @@ namespace OpenDreamRuntime.Resources {
         private void CreateDirectory() {
             Directory.CreateDirectory(Path.GetDirectoryName(_filePath));
         }
+
+        public override string? ToString() {
+            return $"'{ResourcePath}'";
+        }
     }
 }

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -5,7 +5,7 @@ namespace OpenDreamRuntime.Resources {
     [Virtual]
     public class DreamResource {
         public string ResourcePath;
-        public byte[] ResourceData {
+        public byte[]? ResourceData {
             get {
                 if (_resourceData == null && Exists()) {
                     _resourceData = File.ReadAllBytes(_filePath);
@@ -16,7 +16,7 @@ namespace OpenDreamRuntime.Resources {
         }
 
         private string _filePath;
-        private byte[] _resourceData = null;
+        private byte[]? _resourceData = null;
 
         public DreamResource(string filePath, string resourcePath) {
             _filePath = filePath;
@@ -28,7 +28,7 @@ namespace OpenDreamRuntime.Resources {
         }
 
         public virtual string? ReadAsString() {
-            if (!File.Exists(_filePath)) return null;
+            if (ResourceData == null) return null;
 
             string resourceString = Encoding.ASCII.GetString(ResourceData);
 
@@ -42,7 +42,7 @@ namespace OpenDreamRuntime.Resources {
         }
 
         public virtual void Output(DreamValue value) {
-            if (value.TryGetValueAsString(out string text)) {
+            if (value.TryGetValueAsString(out string? text)) {
                 string filePath = Path.Combine(IoCManager.Resolve<DreamResourceManager>().RootPath, ResourcePath);
 
                 CreateDirectory();

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -34,7 +34,7 @@ namespace OpenDreamRuntime.Resources
         public DreamResource LoadResource(string resourcePath) {
             if (resourcePath == "") return new ConsoleOutputResource(); //An empty resource path is the console
 
-            if (!_resourceCache.TryGetValue(resourcePath, out DreamResource resource)) {
+            if (!_resourceCache.TryGetValue(resourcePath, out DreamResource? resource)) {
                 resource = new DreamResource(Path.Combine(RootPath, resourcePath), resourcePath);
                 _resourceCache.Add(resourcePath, resource);
             }
@@ -45,8 +45,7 @@ namespace OpenDreamRuntime.Resources
         public void RxRequestResource(MsgRequestResource pRequestResource) {
             DreamResource resource = LoadResource(pRequestResource.ResourcePath);
 
-            if (resource.ResourceData != null)
-            {
+            if (resource.ResourceData != null) {
                 var msg = new MsgResource() {
                     ResourcePath = resource.ResourcePath,
                     ResourceData = resource.ResourceData


### PR DESCRIPTION
- Make `world << browse(...)` send to all clients instead of erroring.
- Fix `browse('file')` without options causing an error. In the default skin (see #851) this would go to a default browser control, but in most skins it will probably do nothing.

Also:
- Fix tab characters being invisible in output controls by replacing them with 8 spaces. This isn't exactly like DM but it's better than them being invisible.
- Add `DreamResource.ToString` so it doesn't need to be special-cased in `DreamValue.ToString`.