### PR TITLE
Optimize `locate(/type) in world`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -1105,20 +1105,14 @@ public sealed class ClientImagesList : DreamList {
 
 // world.contents list
 // Operates on a list of all atoms
-public sealed class WorldContentsList : DreamList {
-    private readonly AtomManager _atomManager;
-
-    public WorldContentsList(DreamObjectDefinition listDef, AtomManager atomManager) : base(listDef, 0) {
-        _atomManager = atomManager;
-    }
-
+public sealed class WorldContentsList(DreamObjectDefinition listDef, AtomManager atomManager) : DreamList(listDef, 0) {
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
             throw new Exception($"Invalid index into world contents list: {key}");
-        if (index < 1 || index > _atomManager.AtomCount)
+        if (index < 1 || index > atomManager.AtomCount)
             throw new Exception($"Out of bounds index on world contents list: {index}");
 
-        var element = _atomManager.EnumerateAtoms().ElementAt(index - 1); // Ouch
+        var element = atomManager.EnumerateAtoms().ElementAt(index - 1); // Ouch
         return new DreamValue(element);
     }
 
@@ -1139,7 +1133,7 @@ public sealed class WorldContentsList : DreamList {
     }
 
     public override int GetLength() {
-        return _atomManager.AtomCount;
+        return atomManager.AtomCount;
     }
 }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2087,7 +2087,7 @@ namespace OpenDreamRuntime.Procs {
             DreamValue value = state.Pop();
 
             // Enumerate atoms rather than creating a list of every /atom using WorldContentsList.GetValues()
-            if (container is DreamObjectWorld) {
+            if (container is DreamObjectWorld && value.Type != DreamValue.DreamValueType.String) {
                 // "locate(value) in world" only works on type paths. Other values return null.
                 if (value.TryGetValueAsType(out var searchingType)) {
                     var result = state.Proc.AtomManager.EnumerateAtoms(searchingType).FirstOrDefault();


### PR DESCRIPTION
vgstation was allocating over 6GB every few seconds while loading the map. This was because `locate(/type) in world` was creating a new list containing every atom in the world every time it was executed. I made a special path in the Locate opcode to handle `world`, and use `AtomManager.EnumerateAtoms()` instead.

On my machine this brought mapload time from ~10 minutes down to less than 1.