### PR TITLE
Anchor render sources at the bottom left instead of center

### DIFF
--- a/OpenDreamClient/Rendering/DreamPlane.cs
+++ b/OpenDreamClient/Rendering/DreamPlane.cs
@@ -54,7 +54,6 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
                 var positionOffset = -worldAABB.BottomLeft;
 
                 if (sprite.HasRenderSource && overlay.RenderSourceLookup.TryGetValue(sprite.RenderSource!, out var renderSourceTexture)) {
-                    positionOffset -= renderSourceTexture.Size / 2 / EyeManager.PixelsPerMeter;
                     sprite.TextureOverride = renderSourceTexture.Texture;
                 }
 


### PR DESCRIPTION
As per the BYOND v516.1648 changelog:
> Breaking change: Previously, render_source replaced an icon with the render_target by anchoring to the center of the icon. This was stupid, because it created the need for hacky workarounds and it produced a ton of annoying bugs, but it was also unintuitive. Now, when render_source replaces an icon it anchors to the lower left, just as if you were simply using a different icon. (Lummox JR)