### PR TITLE
Fallback to `world.turf` when a DMM is missing a turf

### DIFF
--- a/DMCompiler/Compiler/DMM/DMMParser.cs
+++ b/DMCompiler/Compiler/DMM/DMMParser.cs
@@ -104,6 +104,9 @@ internal sealed class DMMParser(DMCompiler compiler, DMLexer lexer, int zOffset)
                 }
             }
 
+            if (cellDefinition.Turf == null)
+                Compiler.ForcedWarning(currentToken.Location, $"Cell definition \"{cellDefinition.Name}\" is missing a turf");
+
             Consume(TokenType.DM_RightParenthesis, "Expected ')'");
             return cellDefinition;
         }

--- a/DMCompiler/Json/DreamMapJson.cs
+++ b/DMCompiler/Json/DreamMapJson.cs
@@ -12,7 +12,7 @@ public sealed class DreamMapJson {
 
 public sealed class CellDefinitionJson(string name) {
     public string Name { get; set; } = name;
-    public MapObjectJson Turf { get; set; }
+    public MapObjectJson? Turf { get; set; }
     public MapObjectJson? Area { get; set; }
     public List<MapObjectJson> Objects { get; set; } = new();
 }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -319,8 +319,6 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
 
         LoadInterfaceFromSource(interfaceText);
         _netManager.ClientSendMessage(new MsgAckLoadInterface());
-        if (_entitySystemManager.TryGetEntitySystem(out ClientVerbSystem? verbSystem))
-            DefaultInfo?.RefreshVerbs(verbSystem);
     }
 
     private void RxUpdateClientInfo(MsgUpdateClientInfo msg) {

--- a/OpenDreamRuntime/Map/DreamMapManager.cs
+++ b/OpenDreamRuntime/Map/DreamMapManager.cs
@@ -36,7 +36,7 @@ public sealed partial class DreamMapManager : IDreamMapManager {
 
     // Set in Initialize
     private MapObjectJson _defaultArea = default!;
-    private TreeEntry _defaultTurf = default!;
+    private MapObjectJson _defaultTurf = default!;
 
     private List<DreamMapJson>? _jsonMaps = new();
 
@@ -47,30 +47,23 @@ public sealed partial class DreamMapManager : IDreamMapManager {
         DreamObjectDefinition worldDefinition = _objectTree.World.ObjectDefinition;
 
         // Default area
-        if (worldDefinition.Variables["area"].TryGetValueAsType(out var area)) {
-            if(!area.ObjectDefinition.IsSubtypeOf(_objectTree.Area)) throw new Exception("bad area");
-
-            _defaultArea = new MapObjectJson(area.Id);
-        } else if (worldDefinition.Variables["area"].IsNull ||
-                   worldDefinition.Variables["area"].TryGetValueAsInteger(out var areaInt) && areaInt == 0) {
-            //TODO: Properly handle disabling default area
-            _defaultArea = new MapObjectJson(_objectTree.Area.Id);
-        } else {
+        var defaultArea = worldDefinition.Variables["area"];
+        if (!defaultArea.TryGetValueAsType(out var defaultAreaValue) &&
+            defaultArea.TryGetValueAsFloatCoerceNull(out var areaInt) && areaInt == 0) //TODO: Properly handle disabling default area
+            defaultAreaValue = _objectTree.Area;
+        if(defaultAreaValue?.ObjectDefinition.IsSubtypeOf(_objectTree.Area) is not true)
             throw new Exception("bad area");
-        }
 
         //Default turf
-        if (worldDefinition.Variables["turf"].TryGetValueAsType(out var turf)) {
-            if (!turf.ObjectDefinition.IsSubtypeOf(_objectTree.Turf))
-                throw new Exception("bad turf");
-            _defaultTurf = turf;
-        } else if (worldDefinition.Variables["turf"].IsNull ||
-                   worldDefinition.Variables["turf"].TryGetValueAsInteger(out var turfInt) && turfInt == 0) {
-            //TODO: Properly handle disabling default turf
-            _defaultTurf = _objectTree.Turf;
-        } else {
+        var defaultTurf = worldDefinition.Variables["turf"];
+        if (!defaultTurf.TryGetValueAsType(out var defaultTurfValue) &&
+            defaultTurf.TryGetValueAsFloatCoerceNull(out var turfInt) && turfInt == 0) //TODO: Properly handle disabling default turf
+            defaultTurfValue = _objectTree.Turf;
+        if(defaultTurfValue?.ObjectDefinition.IsSubtypeOf(_objectTree.Turf) is not true)
             throw new Exception("bad turf");
-        }
+
+        _defaultArea = new MapObjectJson(defaultAreaValue.Id);
+        _defaultTurf = new MapObjectJson(defaultTurfValue.Id);
     }
 
     public void UpdateTiles() {
@@ -291,11 +284,12 @@ public sealed partial class DreamMapManager : IDreamMapManager {
                             continue;
                         }
 
-                        var defaultTurf = new DreamObjectTurf(_defaultTurf.ObjectDefinition, x, y, existingLevel.Z);
+                        var defaultTurfDef = _objectTree.GetTreeEntry(_defaultTurf.Type).ObjectDefinition;
+                        var defaultTurf = new DreamObjectTurf(defaultTurfDef, x, y, existingLevel.Z);
                         var cell = new Cell(DefaultArea, defaultTurf);
                         defaultTurf.Cell = cell;
                         existingLevel.Cells[x - 1, y - 1] = cell;
-                        SetTurf(new Vector2i(x, y), existingLevel.Z, _defaultTurf.ObjectDefinition, new());
+                        SetTurf(new Vector2i(x, y), existingLevel.Z, defaultTurfDef, new());
                     }
                 }
             }
@@ -328,19 +322,21 @@ public sealed partial class DreamMapManager : IDreamMapManager {
 
     public void SetZLevels(int levels) {
         if (levels > Levels) {
+            var defaultTurfDef = _objectTree.GetTreeEntry(_defaultTurf.Type).ObjectDefinition;
+
             for (int z = Levels + 1; z <= levels; z++) {
                 MapId mapId = new(z);
                 _mapSystem.CreateMap(mapId);
 
                 var grid = _mapManager.CreateGridEntity(mapId);
-                Level level = new Level(z, grid, _defaultTurf.ObjectDefinition, DefaultArea, Size);
+                Level level = new Level(z, grid, defaultTurfDef, DefaultArea, Size);
                 _levels.Add(level);
 
                 for (int x = 1; x <= Size.X; x++) {
                     for (int y = 1; y <= Size.Y; y++) {
                         Vector2i pos = (x, y);
 
-                        SetTurf(pos, z, _defaultTurf.ObjectDefinition, new());
+                        SetTurf(pos, z, defaultTurfDef, new());
                     }
                 }
             }
@@ -372,7 +368,7 @@ public sealed partial class DreamMapManager : IDreamMapManager {
             Vector2i pos = (block.X + blockX - 1, block.Y + block.Height - blockY);
 
             _levels[block.Z - 1].Cells[pos.X - 1, pos.Y - 1].Area = area;
-            SetTurf(pos, block.Z, CreateMapObjectDefinition(cellDefinition.Turf), new());
+            SetTurf(pos, block.Z, CreateMapObjectDefinition(cellDefinition.Turf ?? _defaultTurf), new());
 
             blockX++;
             if (blockX > block.Width) {


### PR DESCRIPTION
Use `world.turf` when the DMM is missing a turf in a spot. Also provide a compiler warning for it.

I also removed an unnecessary `RefreshVerbs()` call on the client that was always throwing an exception because the entity system wasn't ready yet.