### PR TITLE
Fix some DMF issues

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -10,7 +10,7 @@ namespace OpenDreamClient.Interface.Controls;
 internal sealed class ControlChild(ControlDescriptor controlDescriptor, ControlWindow window) : InterfaceControl(controlDescriptor, window) {
     private ControlDescriptorChild ChildDescriptor => (ControlDescriptorChild)ElementDescriptor;
 
-    private Splitter _splitter;
+    private Splitter _splitter = default!;
 
     protected override Control CreateUIElement() {
         _splitter = new Splitter();

--- a/OpenDreamClient/Interface/Controls/UI/Splitter.cs
+++ b/OpenDreamClient/Interface/Controls/UI/Splitter.cs
@@ -29,8 +29,10 @@ public sealed class Splitter : Container {
                 RemoveChild(_left);
 
             _left = value;
-            if (_left != null)
+            if (_left != null) {
+                _left.Orphan();
                 AddChild(_left);
+            }
         }
     }
 
@@ -44,8 +46,10 @@ public sealed class Splitter : Container {
                 RemoveChild(_right);
 
             _right = value;
-            if (_right != null)
+            if (_right != null) {
+                _right.Orphan();
                 AddChild(_right);
+            }
         }
     }
 

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -349,7 +349,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             if (Windows.ContainsKey(windowId)) {
                 window = Windows[windowId];
             } else if (Menus.TryGetValue(windowId, out var menu)) {
-                if (menu.MenuElements.TryGetValue(elementId, out var menuElement))
+                if (menu.MenuElementsById.TryGetValue(elementId, out var menuElement))
                     return menuElement;
             } else if(MacroSets.TryGetValue(windowId, out var macroSet)) {
                 if (macroSet.Macros.TryGetValue(elementId, out var macroElement))
@@ -389,7 +389,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                 if (menu.Id.Value == elementId)
                     return menu;
 
-                if (menu.MenuElements.TryGetValue(elementId, out var menuElement))
+                if (menu.MenuElementsById.TryGetValue(elementId, out var menuElement))
                     return menuElement;
             }
 


### PR DESCRIPTION
* If a pane is used in multiple CHILDs, only the last CHILD gets to have it
* Implement INPUT's `no-command` and `command`
* Implement INPUT's `focus=true`
* Attempt to find menu categories by either id or name
* Remove '&' anywhere in menu texts, not just the beginning