### PR TITLE
Fix Tracy on TG

### DIFF
--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -146,48 +146,46 @@ public sealed class DreamObjectTree {
     /// (by calling the result of <see cref="DreamObject.InitProc(DreamThread, DreamObject?, DreamProcArguments)"/> or <see cref="DreamObject.InitSpawn(DreamProcArguments)"/>)
     /// </remarks>
     public DreamObject CreateObject(TreeEntry type) {
-        using (Profiler.BeginZone("new DreamObject")) {
-            if (type == List)
-                return CreateList();
-            if (type == Savefile)
-                return new DreamObjectSavefile(Savefile.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(DatabaseQuery))
-                return new DreamObjectDatabaseQuery(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Database))
-                return new DreamObjectDatabase(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Matrix))
-                return new DreamObjectMatrix(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Sound))
-                return new DreamObjectSound(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Regex))
-                return new DreamObjectRegex(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Image))
-                return new DreamObjectImage(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Icon))
-                return new DreamObjectIcon(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Filter))
-                return new DreamObjectFilter(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Mob))
-                return new DreamObjectMob(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Movable))
-                return new DreamObjectMovable(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Area))
-                return new DreamObjectArea(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Atom))
-                return new DreamObjectAtom(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Client))
-                throw new Exception("Cannot create objects of type /client");
-            if (type.ObjectDefinition.IsSubtypeOf(Turf))
-                throw new Exception("New turfs must be created by the map manager");
-            if (type.ObjectDefinition.IsSubtypeOf(Exception))
-                return new DreamObjectException(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Callee))
-                return new DreamObjectCallee(type.ObjectDefinition);
-            if (type.ObjectDefinition.IsSubtypeOf(Vector))
-                return new DreamObjectVector(type.ObjectDefinition);
+        if (type == List)
+            return CreateList();
+        if (type == Savefile)
+            return new DreamObjectSavefile(Savefile.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(DatabaseQuery))
+            return new DreamObjectDatabaseQuery(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Database))
+            return new DreamObjectDatabase(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Matrix))
+            return new DreamObjectMatrix(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Sound))
+            return new DreamObjectSound(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Regex))
+            return new DreamObjectRegex(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Image))
+            return new DreamObjectImage(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Icon))
+            return new DreamObjectIcon(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Filter))
+            return new DreamObjectFilter(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Mob))
+            return new DreamObjectMob(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Movable))
+            return new DreamObjectMovable(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Area))
+            return new DreamObjectArea(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Atom))
+            return new DreamObjectAtom(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Client))
+            throw new Exception("Cannot create objects of type /client");
+        if (type.ObjectDefinition.IsSubtypeOf(Turf))
+            throw new Exception("New turfs must be created by the map manager");
+        if (type.ObjectDefinition.IsSubtypeOf(Exception))
+            return new DreamObjectException(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Callee))
+            return new DreamObjectCallee(type.ObjectDefinition);
+        if (type.ObjectDefinition.IsSubtypeOf(Vector))
+            return new DreamObjectVector(type.ObjectDefinition);
 
-            return new DreamObject(type.ObjectDefinition);
-        }
+        return new DreamObject(type.ObjectDefinition);
     }
 
     public T CreateObject<T>(TreeEntry type) where T : DreamObject {


### PR DESCRIPTION
I thought when you did a new srcloc with a unique name it only counted as one because the actual source location was the same. That turns out to not be the case, so we were wasting a ton of the 32k limit on logging every type of DreamObject that was created, even though that information is preserved in the callstack.

Basically this just frees up some srclocs that were useless, enabling Tracy to run on TG codebases.