### PR TITLE
Resources without a path stringify to an empty string

### DIFF
--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -423,7 +423,7 @@ public struct DreamValue : IEquatable<DreamValue> {
 
             case DreamValueType.DreamResource:
                 var rsc = MustGetValueAsDreamResource();
-                return rsc.ResourcePath ?? rsc.Id.ToString();
+                return rsc.ResourcePath ?? string.Empty;
             case DreamValueType.DreamType:
                 return MustGetValueAsType().Path;
             case DreamValueType.DreamProc:


### PR DESCRIPTION
/tg/ depends on this behavior in [`/proc/icon_metadata()`](https://github.com/tgstation/tgstation/blob/65fb93b4b3fcccbed13bd6a0987a7185f3ced7f0/code/__HELPERS/icons.dm#L1181)