### PR TITLE
Fix `list.Find()` default `End`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -219,7 +219,7 @@ public class DreamList : DreamObject, IDreamList {
     }
 
     public virtual int FindValue(DreamValue value, int start = 1, int end = 0) {
-        if (end == 0 || end > _values.Count) end = _values.Count;
+        if (end == 0 || end > _values.Count) end = _values.Count + 1;
 
         for (int i = start; i < end; i++) {
             if (_values[i - 1].Equals(value)) return i;


### PR DESCRIPTION
The default `End` was off by one after #2436.