### PR TITLE
Set the name of implicit menus

### DIFF
--- a/OpenDreamClient/Interface/InterfaceMenu.cs
+++ b/OpenDreamClient/Interface/InterfaceMenu.cs
@@ -49,7 +49,8 @@ public sealed class InterfaceMenu : InterfaceElement {
                 !MenuElementsByName.TryGetValue(elementDescriptor.Category.Value, out parentMenu)) {
                 //if category is set but the parent element doesn't exist, create it
                 var parentMenuDescriptor = new MenuElementDescriptor {
-                    Id = elementDescriptor.Category
+                    Id = elementDescriptor.Category,
+                    Name = elementDescriptor.Category
                 };
 
                 parentMenu = new(parentMenuDescriptor, this);

--- a/OpenDreamShared/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamShared/Interface/Descriptors/InterfaceDescriptor.cs
@@ -42,7 +42,10 @@ public partial class ElementDescriptor {
         init => _id = value;
     }
 
-    public DMFPropertyString Name => new(_name.Value);
+    public DMFPropertyString Name {
+        get => new(_name.Value);
+        init => _name = value;
+    }
 
     public DMFPropertyString Type {
         get => _type;


### PR DESCRIPTION
Menus implicitly created by other menu buttons weren't having their name set.

Fixes #2404