### PR TITLE
Allow multiple definitions of DMF attributes

### DIFF
--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -972,17 +972,17 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     }
 
     private void OnWindowFocused(WindowFocusedEventArgs args) {
-        if(ClydeWindowIdToControl.TryGetValue(args.Window.Id, out var controlWindow)){
-            _sawmill.Debug($"window id {controlWindow.Id} was {(args.Focused ? "focused" : "defocused")}");
-            WindowDescriptor descriptor = (WindowDescriptor) controlWindow.ElementDescriptor;
+        if (ClydeWindowIdToControl.TryGetValue(args.Window.Id, out var controlWindow)) {
+            _sawmill.Verbose($"window id {controlWindow.Id} was {(args.Focused ? "focused" : "defocused")}");
+            WindowDescriptor descriptor = (WindowDescriptor)controlWindow.ElementDescriptor;
             descriptor.Focus = new DMFPropertyBool(args.Focused);
-            if(args.Focused && MacroSets.TryGetValue(descriptor.Macro.AsRaw(), out var windowMacroSet)){
-                _sawmill.Debug($"Activating macroset {descriptor.Macro}");
+            if (args.Focused && MacroSets.TryGetValue(descriptor.Macro.AsRaw(), out var windowMacroSet)) {
+                _sawmill.Verbose($"Activating macroset {descriptor.Macro}");
                 windowMacroSet.SetActive();
             }
+        } else {
+            _sawmill.Verbose($"window id was not found (probably a modal) but was {(args.Focused ? "focused" : "defocused")}");
         }
-        else
-            _sawmill.Debug($"window id was not found (probably a modal) but was {(args.Focused ? "focused" : "defocused")}");
     }
 
     private void LoadDescriptor(ElementDescriptor descriptor) {

--- a/OpenDreamShared/Interface/DMF/DMFParser.cs
+++ b/OpenDreamShared/Interface/DMF/DMFParser.cs
@@ -284,7 +284,7 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
             if (winset.Value == "none")
                 continue;
 
-            attributes.Add(winset.Attribute, winset.Value);
+            attributes[winset.Attribute] = winset.Value;
         }
 
         return attributes;


### PR DESCRIPTION
A DMF or winset with duplicate keys will use the last value. This fixes dark mode in Nebula, since their winsets define each attribute twice:
```dm
winset(src, "output", "background-color = none;background-color = [COLOR_DARKMODE_DARKBACKGROUND]")
winset(src, "output", "text-color = #000000;text-color = [COLOR_DARKMODE_TEXT]")
```

I also changed some of the more spammy console logs to be Verbose.