### PR TITLE
Fix nested object var blocks

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -214,6 +214,12 @@ namespace DMCompiler.Compiler.DM {
             Whitespace();
             CurrentPath = CurrentPath.Combine(path.Path);
 
+            //Object definition
+            if (Block() is { } block) {
+                Compiler.VerbosePrint($"Parsed object {CurrentPath}");
+                return new DMASTObjectDefinition(loc, CurrentPath, block);
+            }
+
             //Proc definition
             if (Check(TokenType.DM_LeftParenthesis)) {
                 Compiler.VerbosePrint($"Parsing proc {CurrentPath}()");
@@ -363,12 +369,6 @@ namespace DMCompiler.Compiler.DM {
                 RequireExpression(ref value);
 
                 return new DMASTObjectVarOverride(loc, CurrentPath, value);
-            }
-
-            //Object definition
-            if (Block() is { } block) {
-                Compiler.VerbosePrint($"Parsed object {CurrentPath}");
-                return new DMASTObjectDefinition(loc, CurrentPath, block);
             }
 
             //Empty object definition

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -412,5 +412,3 @@
 /world/New()
 	..()
 	world.log << "World loaded!"
-	var/particles/A = new()
-	A.width = null


### PR DESCRIPTION
Moves object blocks to be prioritized over object vars, which gets the recursive parsing working.

Alternative fix to #2178.