### PR TITLE
Make `macro` optional

### DIFF
--- a/OpenDreamClient/DreamClientSystem.cs
+++ b/OpenDreamClient/DreamClientSystem.cs
@@ -13,6 +13,6 @@ internal sealed class DreamClientSystem : EntitySystem {
     private void OnPlayerAttached(LocalPlayerAttachedEvent e) {
         // The active input context gets reset to "common" when a new player is attached
         // So we have to set it again
-        _interfaceManager.DefaultWindow?.Macro.SetActive();
+        _interfaceManager.DefaultWindow?.Macro?.SetActive();
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -20,7 +20,7 @@ public sealed class ControlWindow : InterfaceControl {
     public readonly List<InterfaceControl> ChildControls = new();
 
     public string Title => WindowDescriptor.Title.Value;
-    public InterfaceMacroSet Macro => _interfaceManager.MacroSets[WindowDescriptor.Macro.AsRaw()];
+    public InterfaceMacroSet? Macro => _interfaceManager.MacroSets.GetValueOrDefault(WindowDescriptor.Macro.AsRaw());
 
     private WindowDescriptor WindowDescriptor => (WindowDescriptor)ElementDescriptor;
 
@@ -54,7 +54,7 @@ public sealed class ControlWindow : InterfaceControl {
             UpdateWindowAttributes(_myWindow);
 
         if (WindowDescriptor.IsDefault.Value) {
-            Macro.SetActive();
+            Macro?.SetActive();
         }
     }
 


### PR DESCRIPTION
Resolves #1996 

I tested that this removes the exception by nuking the `macro` from testgame.

I did not test whether this fix requires move involved changes to the active macro set.