### PR TITLE
Include AlphaToApply in icon drawing

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -471,7 +471,11 @@ internal sealed partial class DreamViewOverlay : Overlay {
         handle.UseShader(GetBlendAndColorShader(iconMetaData, ignoreColor: true));
 
         handle.SetTransform(CalculateDrawingMatrix(iconMetaData.TransformToApply, pixelPosition, frame.Size, renderTargetSize));
-        handle.DrawTextureRect(frame, Box2.FromDimensions(Vector2.Zero, frame.Size), iconMetaData.ColorToApply);
+
+        Color colorToApply = iconMetaData.ColorToApply;
+        colorToApply.A *= iconMetaData.AlphaToApply;
+
+        handle.DrawTextureRect(frame, Box2.FromDimensions(Vector2.Zero, frame.Size), colorToApply);
 
         if (iconMetaData.Particles is not null) {
             handle.UseShader(GetBlendAndColorShader(iconMetaData, ignoreColor: true));


### PR DESCRIPTION
I noticed Square Man wasn't becoming invisible when I was animating him and I noticed that `AlphaToApply` seems to get ignored when an icon is drawn. I'm a little unsure what is meant to be happening but it seems to be expected at some point prior to a certain `DrawTextureRect` call in `DreamViewOverlay` so I've put it there. Let me know if I'm way off base here.  