### PR TITLE
DreamList membership reverse lookup

### DIFF
--- a/Content.Tests/DMProject/Tests/List/ListIndexToKey.dm
+++ b/Content.Tests/DMProject/Tests/List/ListIndexToKey.dm
@@ -1,0 +1,6 @@
+﻿/proc/RunTest()
+	var/list/A = list("thing")
+	ASSERT(A[1] == "thing")
+	
+	A["thing"] = 6
+	ASSERT(A["thing"] == 6)

--- a/Content.Tests/DMProject/Tests/List/ListIndexToKey.dm
+++ b/Content.Tests/DMProject/Tests/List/ListIndexToKey.dm
@@ -4,3 +4,10 @@
 	
 	A["thing"] = 6
 	ASSERT(A["thing"] == 6)
+
+	var/list/L = list()
+	for(var/i in 1 to 5)
+		L.Add("[i]")
+		L["[i]"] = "item [i]"
+	ASSERT(length(L) == 5)
+	ASSERT(L["3"] == "item 3")

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -459,7 +459,7 @@ public struct DreamValue : IEquatable<DreamValue> {
                     _refValue = null;
                 if (other._refValue != null && Unsafe.As<DreamObject>(other._refValue).Deleted)
                     other._refValue = null;
-                break;
+                return _refValue == other._refValue;
             }
         }
 

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -459,7 +459,7 @@ public struct DreamValue : IEquatable<DreamValue> {
                     _refValue = null;
                 if (other._refValue != null && Unsafe.As<DreamObject>(other._refValue).Deleted)
                     other._refValue = null;
-                return _refValue == other._refValue;
+                break;
             }
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
@@ -119,4 +119,16 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
         return _values.ContainsKey(value);
     }
 
+    public override DreamValue OperatorAppend(DreamValue b) {
+        if (b.TryGetValueAsDreamList(out var bList)) {
+            foreach (var value in bList.EnumerateValues()) {
+                AddValue(value); // Always add the value
+            }
+        } else {
+            AddValue(b);
+        }
+
+        return new(this);
+    }
+
 }

--- a/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
@@ -122,7 +122,7 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
     public override DreamValue OperatorAppend(DreamValue b) {
         if (b.TryGetValueAsDreamList(out var bList)) {
             foreach (var value in bList.EnumerateValues()) {
-                AddValue(value); // Always add the value
+                AddValue(value);
             }
         } else {
             AddValue(b);

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -261,6 +261,8 @@ public class DreamList : DreamObject, IDreamList {
     public virtual int FindValue(DreamValue value, int start = 1, int end = 0) {
         if (end == 0 || end > _values.Count) end = _values.Count + 1;
 
+        if(!ContainsValue(value)) return 0;
+        
         for (int i = start; i < end; i++) {
             if (_values[i - 1].Equals(value)) return i;
         }

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -709,6 +709,16 @@ public sealed class ClientVerbsList : DreamList {
             yield return new(verb);
     }
 
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         throw new Exception("Cannot set the values of a verbs list");
     }
@@ -771,6 +781,16 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
 
             yield return new(verb);
         }
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -845,6 +865,16 @@ public sealed class DreamOverlaysList : DreamList {
         foreach (var overlay in GetOverlaysArray(appearance)) {
             yield return new(overlay.ToMutable());
         }
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public override void Cut(int start = 1, int end = 0) {
@@ -962,6 +992,16 @@ public sealed class DreamVisContentsList : DreamList {
     public override IEnumerable<DreamValue> EnumerateValues() {
         foreach (var visContent in _visContents)
             yield return new(visContent);
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public override void Cut(int start = 1, int end = 0) {
@@ -1121,6 +1161,16 @@ public sealed class DreamFilterList(DreamObjectDefinition listDef, DreamObject o
         }
     }
 
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         if (!value.TryGetValueAsDreamObject<DreamObjectFilter>(out var filterObject) && !value.IsNull)
             throw new Exception($"Cannot set value of filter list to {value}");
@@ -1269,6 +1319,16 @@ public sealed class ClientImagesList(
         return _imageObjects;
     }
 
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         throw new Exception("Cannot write to an index of a client images list");
     }
@@ -1332,6 +1392,16 @@ public sealed class WorldContentsList(DreamObjectDefinition listDef, AtomManager
         return AtomManager.EnumerateAtoms().Select(atom => new DreamValue(atom));
     }
 
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         throw new Exception("Cannot set the value of world contents list");
     }
@@ -1373,6 +1443,16 @@ public sealed class TurfContentsList(DreamObjectDefinition listDef, DreamObjectT
     public override IEnumerable<DreamValue> EnumerateValues() {
         foreach (var movable in Cell.Movables)
             yield return new(movable);
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1441,6 +1521,16 @@ public sealed class AreaContentsList(DreamObjectDefinition listDef, DreamObjectA
             foreach (var content in turf.Contents.EnumerateValues())
                 yield return content;
         }
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1592,6 +1682,16 @@ internal sealed class ProcArgsList(DreamObjectDefinition listDef, DMProcState st
     public override IEnumerable<DreamValue> EnumerateValues() {
         for (int i = 0; i < state.ArgumentCount; i++)
             yield return state.GetArguments()[i];
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        foreach (var containedVal in EnumerateValues()) {
+            if (value.Equals(containedVal)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -178,9 +178,10 @@ public class DreamList : DreamObject, IDreamList {
                 _values[keyInteger - 1] = value;
             }
         } else {
-            if (!ContainsValue(key)) _values.Add(key);
-
             _associativeValues ??= new Dictionary<DreamValue, DreamValue>(1);
+            if (!_associativeValues.ContainsKey(key)) {
+                _values.Add(key);
+            }
             _associativeValues[key] = value;
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -223,17 +223,15 @@ public class DreamList : DreamObject, IDreamList {
     }
 
     public virtual void RemoveValue(DreamValue value) {
-        int valueIndex = _values.LastIndexOf(value);
-
-        if (valueIndex != -1) {
-            if(_reverseLookup.ContainsKey(value)) {
-                var rLCount = _reverseLookup[value] -= 1;
-                if (rLCount <= 0) {
-                    _reverseLookup.Remove(value);
-                }
+        _associativeValues?.Remove(value);
+        if (_reverseLookup.ContainsKey(value)) {
+            var rLCount = _reverseLookup[value] -= 1;
+            if (rLCount <= 0) {
+                _reverseLookup.Remove(value);
             }
+            _reverseLookup[value] = rLCount;
 
-            _associativeValues?.Remove(value);
+            int valueIndex = _values.LastIndexOf(value);
             _values.RemoveAt(valueIndex);
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -21,7 +21,7 @@ public class DreamList : DreamObject, IDreamList {
     /// <summary>
     /// Looks up the key to find the index
     /// </summary>
-    private readonly Dictionary<DreamValue, int> reverseLookup = [];
+    private readonly Dictionary<DreamValue, int> _reverseLookup = [];
     private readonly List<DreamValue> _values;
     private Dictionary<DreamValue, DreamValue>? _associativeValues;
 
@@ -34,8 +34,8 @@ public class DreamList : DreamObject, IDreamList {
             _values = poppedValues;
             _values.EnsureCapacity(size);
             foreach (var value in poppedValues) {
-                if (!reverseLookup.TryAdd(value, 1)) {
-                    reverseLookup[value] += 1;
+                if (!_reverseLookup.TryAdd(value, 1)) {
+                    _reverseLookup[value] += 1;
                 }
             }
 
@@ -50,8 +50,8 @@ public class DreamList : DreamObject, IDreamList {
     public DreamList(DreamObjectDefinition listDef, List<DreamValue> values, Dictionary<DreamValue, DreamValue>? associativeValues) : base(listDef) {
         _values = values;
         foreach (var value in values) {
-            if (!reverseLookup.TryAdd(value, 1)) {
-                reverseLookup[value] += 1;
+            if (!_reverseLookup.TryAdd(value, 1)) {
+                _reverseLookup[value] += 1;
             }
         }
         _associativeValues = associativeValues;
@@ -191,20 +191,20 @@ public class DreamList : DreamObject, IDreamList {
             if (allowGrowth && keyInteger == index) {
                 _values.Add(value);
 
-                if (!reverseLookup.TryAdd(value, 1)) {
-                    reverseLookup[value] += 1;
+                if (!_reverseLookup.TryAdd(value, 1)) {
+                    _reverseLookup[value] += 1;
                 }
             } else {
                 _values[keyInteger - 1] = value;
 
-                if (!reverseLookup.TryAdd(value, 1)) {
-                    reverseLookup[value] += 1;
+                if (!_reverseLookup.TryAdd(value, 1)) {
+                    _reverseLookup[value] += 1;
                 }
 
             }
         } else {
-            if (!reverseLookup.TryAdd(key, 1)) {
-                reverseLookup[key] += 1;
+            if (!_reverseLookup.TryAdd(key, 1)) {
+                _reverseLookup[key] += 1;
             } else {
                 _values.Add(key);
             }
@@ -220,9 +220,9 @@ public class DreamList : DreamObject, IDreamList {
         int valueIndex = _values.LastIndexOf(value);
 
         if (valueIndex != -1) {
-            if(reverseLookup.TryGetValue(value, out int element)) {
+            if(_reverseLookup.TryGetValue(value, out int element)) {
                 if (element - 1 <= 0) {
-                    reverseLookup.Remove(value);
+                    _reverseLookup.Remove(value);
                 }
             }
 
@@ -235,8 +235,8 @@ public class DreamList : DreamObject, IDreamList {
 
     public virtual void AddValue(DreamValue value) {
         _values.Add(value); 
-        if (!reverseLookup.TryAdd(value, 1)) {
-            reverseLookup[value] += 1;
+        if (!_reverseLookup.TryAdd(value, 1)) {
+            _reverseLookup[value] += 1;
         }
 
         UpdateTracyContentsMemory();
@@ -244,7 +244,7 @@ public class DreamList : DreamObject, IDreamList {
 
     //Does not include associations
     public virtual bool ContainsValue(DreamValue value) {
-        if(reverseLookup.ContainsKey(value)) {
+        if(_reverseLookup.ContainsKey(value)) {
             return true;
         }
         for (int i = 0; i < _values.Count; i++) {
@@ -283,10 +283,10 @@ public class DreamList : DreamObject, IDreamList {
             var elements = _values.GetRange(index, len);
 
             foreach (var element in elements) {
-                var rlCache = reverseLookup[element] -= 1;
+                var rlCache = _reverseLookup[element] -= 1;
 
                 if (rlCache <= 0) {
-                    reverseLookup.Remove(element);
+                    _reverseLookup.Remove(element);
                 }
             }
 
@@ -298,8 +298,8 @@ public class DreamList : DreamObject, IDreamList {
 
     public void Insert(int index, DreamValue value) {
         _values.Insert(index - 1, value);
-        if (!reverseLookup.TryAdd(value, 1)) {
-            reverseLookup[value] += 1;
+        if (!_reverseLookup.TryAdd(value, 1)) {
+            _reverseLookup[value] += 1;
         }
         UpdateTracyContentsMemory();
     }

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -220,8 +220,9 @@ public class DreamList : DreamObject, IDreamList {
         int valueIndex = _values.LastIndexOf(value);
 
         if (valueIndex != -1) {
-            if(_reverseLookup.TryGetValue(value, out int element)) {
-                if (element - 1 <= 0) {
+            if(_reverseLookup.ContainsKey(value)) {
+                var rLCount = _reverseLookup[value] -= 1;
+                if (rLCount <= 0) {
                     _reverseLookup.Remove(value);
                 }
             }

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -195,6 +195,12 @@ public class DreamList : DreamObject, IDreamList {
                     _reverseLookup[value] += 1;
                 }
             } else {
+                var oldValue = _values[keyInteger - 1];
+                var rLCount = _reverseLookup[oldValue] -= 1;
+                if(rLCount <= 0) {
+                    _reverseLookup.Remove(oldValue);
+                }
+
                 _values[keyInteger - 1] = value;
 
                 if (!_reverseLookup.TryAdd(value, 1)) {

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -223,15 +223,17 @@ public class DreamList : DreamObject, IDreamList {
     }
 
     public virtual void RemoveValue(DreamValue value) {
-        _associativeValues?.Remove(value);
-        if (_reverseLookup.ContainsKey(value)) {
-            var rLCount = _reverseLookup[value] -= 1;
-            if (rLCount <= 0) {
-                _reverseLookup.Remove(value);
-            }
-            _reverseLookup[value] = rLCount;
+        int valueIndex = _values.LastIndexOf(value);
 
-            int valueIndex = _values.LastIndexOf(value);
+        if (valueIndex != -1) {
+            if (_reverseLookup.ContainsKey(value)) {
+                var rLCount = _reverseLookup[value] -= 1;
+                if (rLCount <= 0) {
+                    _reverseLookup.Remove(value);
+                }
+            }
+
+            _associativeValues?.Remove(value);
             _values.RemoveAt(valueIndex);
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -18,6 +18,10 @@ public class DreamList : DreamObject, IDreamList {
 
     public virtual bool IsAssociative => _associativeValues is { Count: > 0 };
 
+    /// <summary>
+    /// Looks up the key to find the index
+    /// </summary>
+    private readonly Dictionary<DreamValue, int> reverseLookup = [];
     private readonly List<DreamValue> _values;
     private Dictionary<DreamValue, DreamValue>? _associativeValues;
 
@@ -29,6 +33,12 @@ public class DreamList : DreamObject, IDreamList {
         if (size >= DreamManager.ListPoolThreshold && ListPool.TryPop(out var poppedValues)) {
             _values = poppedValues;
             _values.EnsureCapacity(size);
+            foreach (var value in poppedValues) {
+                if (!reverseLookup.TryAdd(value, 1)) {
+                    reverseLookup[value] += 1;
+                }
+            }
+
         } else {
             _values = new List<DreamValue>(size);
         }
@@ -39,6 +49,11 @@ public class DreamList : DreamObject, IDreamList {
     /// </summary>
     public DreamList(DreamObjectDefinition listDef, List<DreamValue> values, Dictionary<DreamValue, DreamValue>? associativeValues) : base(listDef) {
         _values = values;
+        foreach (var value in values) {
+            if (!reverseLookup.TryAdd(value, 1)) {
+                reverseLookup[value] += 1;
+            }
+        }
         _associativeValues = associativeValues;
 
         #if TOOLS
@@ -172,16 +187,29 @@ public class DreamList : DreamObject, IDreamList {
 
     public virtual void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         if (key.TryGetValueAsInteger(out int keyInteger)) {
-            if (allowGrowth && keyInteger == _values.Count + 1) {
+            var index = _values.Count + 1;
+            if (allowGrowth && keyInteger == index) {
                 _values.Add(value);
+
+                if (!reverseLookup.TryAdd(value, 1)) {
+                    reverseLookup[value] += 1;
+                }
             } else {
                 _values[keyInteger - 1] = value;
+
+                if (!reverseLookup.TryAdd(value, 1)) {
+                    reverseLookup[value] += 1;
+                }
+
             }
         } else {
-            _associativeValues ??= new Dictionary<DreamValue, DreamValue>(1);
-            if (!_associativeValues.ContainsKey(key)) {
+            if (!reverseLookup.TryAdd(key, 1)) {
+                reverseLookup[key] += 1;
+            } else {
                 _values.Add(key);
             }
+
+            _associativeValues ??= new Dictionary<DreamValue, DreamValue>(1);
             _associativeValues[key] = value;
         }
 
@@ -192,6 +220,12 @@ public class DreamList : DreamObject, IDreamList {
         int valueIndex = _values.LastIndexOf(value);
 
         if (valueIndex != -1) {
+            if(reverseLookup.TryGetValue(value, out int element)) {
+                if (element - 1 <= 0) {
+                    reverseLookup.Remove(value);
+                }
+            }
+
             _associativeValues?.Remove(value);
             _values.RemoveAt(valueIndex);
         }
@@ -200,12 +234,19 @@ public class DreamList : DreamObject, IDreamList {
     }
 
     public virtual void AddValue(DreamValue value) {
-        _values.Add(value);
+        _values.Add(value); 
+        if (!reverseLookup.TryAdd(value, 1)) {
+            reverseLookup[value] += 1;
+        }
+
         UpdateTracyContentsMemory();
     }
 
     //Does not include associations
     public virtual bool ContainsValue(DreamValue value) {
+        if(reverseLookup.ContainsKey(value)) {
+            return true;
+        }
         for (int i = 0; i < _values.Count; i++) {
             if (_values[i].Equals(value))
                 return true;
@@ -236,14 +277,30 @@ public class DreamList : DreamObject, IDreamList {
                 _associativeValues.Remove(_values[i - 1]);
         }
 
-        if (end > start)
-            _values.RemoveRange(start - 1, end - start);
+        if (end > start) {
+            var index = start - 1;
+            var len = end - start;
+            var elements = _values.GetRange(index, len);
+
+            foreach (var element in elements) {
+                var rlCache = reverseLookup[element] -= 1;
+
+                if (rlCache <= 0) {
+                    reverseLookup.Remove(element);
+                }
+            }
+
+            _values.RemoveRange(index, len);
+        }
 
         UpdateTracyContentsMemory();
     }
 
     public void Insert(int index, DreamValue value) {
         _values.Insert(index - 1, value);
+        if (!reverseLookup.TryAdd(value, 1)) {
+            reverseLookup[value] += 1;
+        }
         UpdateTracyContentsMemory();
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -209,9 +209,7 @@ public class DreamList : DreamObject, IDreamList {
 
             }
         } else {
-            if (!_reverseLookup.TryAdd(key, 1)) {
-                _reverseLookup[key] += 1;
-            } else {
+            if (_reverseLookup.TryAdd(key, 1)) {
                 _values.Add(key);
             }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -245,15 +245,7 @@ public class DreamList : DreamObject, IDreamList {
 
     //Does not include associations
     public virtual bool ContainsValue(DreamValue value) {
-        if(_reverseLookup.ContainsKey(value)) {
-            return true;
-        }
-        for (int i = 0; i < _values.Count; i++) {
-            if (_values[i].Equals(value))
-                return true;
-        }
-
-        return false;
+        return _reverseLookup.ContainsKey(value);
     }
 
     public virtual bool ContainsKey(DreamValue value) {


### PR DESCRIPTION
This PR expands on the work done by @redmoogle in #2418 in speeding up dreamlist `ContainsValue` by adding a reverse lookup for list membership checking.

It comes with a logic fix, some overriding of contains in child classes of `DreamList` which don't keep the lookup synchronized, and an alist fix to support `alist += 1` at runtime which was run into during testing. 

I agree with @wixoaGit  that a proper fix for #2367 will involve changing `Equals` and a new GC but I do notice that caching membership in this way substantially speeds up the `in` operator for code which makes frequent checks for list membership with `in`, exceeding the speed of byond's list implementation. So I wonder if it is worth including anyway.

I tested performance changes with the following verb. Alist was included as point of comparison, its performance should not be affected by changes. Although I did notice that a change was needed to support `alist += 1` and that is in this PR too. I can submit that as a separate PR if this one doesn't go anywhere but it was needed here for the comparison
```
	verb/test_alert()
		var/list/bigList1 = new()
		for (var/i in 1 to 50000)
			bigList1.Add(i*2)
		
		var/start1 = world.timeofday
		var/x = 0
		for (var/i in 1 to 100000)
			if (i in bigList1)
				x += 1
		world.log << world.timeofday - start1
		world.log << "[x] should be 50000"
		
		var/bigList2[0]
		for (var/i in 1 to 50000)
			var/datum/ind = new()
			bigList2[ind] = i*2
		
		var/start2 = world.timeofday
		x = 0
		for (var/i in 1 to 100000)
			if (i in bigList2)
				x += 1
		world.log << world.timeofday - start2
		world.log << "[x] should be 0"
		
		var/alist/bigList3 = new()
		for (var/i in 1 to 50000)
			bigList3 += i*2
		
		var/start3 = world.timeofday
		x = 0
		for (var/i in 1 to 100000)
			if (i in bigList3)
				x += 1
		world.log << world.timeofday - start3
		world.log << "[x] should be 50000"
```

Results Byond:
```
33
50000 should be 50000
42
0 should be 0
0
50000 should be 50000
```

Results OD before changes:
```
[INFO] world.log: 52
[INFO] world.log: 50000 should be 50000
[INFO] world.log: 37
[INFO] world.log: 0 should be 0
[INFO] world.log: 0
[INFO] world.log: 50000 should be 50000
```

Results OD after changes:
```
[INFO] world.log: 0
[INFO] world.log: 50000 should be 50000
[INFO] world.log: 0
[INFO] world.log: 0 should be 0
[INFO] world.log: 0
[INFO] world.log: 50000 should be 50000
```

This was a pretty "optimistic" test and doesn't really examine what overhead might be introduced by this PR so I'm curious if anyone can recommend a good way to test that.