### PR TITLE
Support text box editing via setting text attribute

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlInput.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInput.cs
@@ -9,11 +9,6 @@ namespace OpenDreamClient.Interface.Controls;
 internal sealed class ControlInput(ControlDescriptor controlDescriptor, ControlWindow window) : InterfaceControl(controlDescriptor, window) {
     private LineEdit _textBox = default!;
 
-    // flag for if we are processing a submission and if any writes to the text attribute should override the textbox reset
-    private bool pendingSubmit = false;
-    // in the event of processing a submission, if a write to the text attribute did happen and we should indeed not reset
-    private bool textWasSetDuringSubmit = false;
-
     private ControlDescriptorInput InputDescriptor => (ControlDescriptorInput)ControlDescriptor;
 
     protected override Control CreateUIElement() {
@@ -27,7 +22,7 @@ internal sealed class ControlInput(ControlDescriptor controlDescriptor, ControlW
         if (InputDescriptor.NoCommand.Value)
             return;
 
-        pendingSubmit = true;
+        ResetText();
 
         var command = InputDescriptor.Command.Value;
         if (command.StartsWith('!')) {
@@ -35,14 +30,6 @@ internal sealed class ControlInput(ControlDescriptor controlDescriptor, ControlW
         } else {
             _interfaceManager.RunCommand(command + lineEditEventArgs.Text);
         }
-
-        if (textWasSetDuringSubmit) {
-            textWasSetDuringSubmit = false;
-        } else {
-            ResetText();
-        }
-
-        pendingSubmit = false;
     }
 
     protected override void UpdateElementDescriptor() {
@@ -69,9 +56,6 @@ internal sealed class ControlInput(ControlDescriptor controlDescriptor, ControlW
                     _textBox.GrabKeyboardFocus();
                 break;
             case "text":
-                if (pendingSubmit) {
-                    textWasSetDuringSubmit = true;
-                }
                 _textBox.Text = value;
                 break;
             default:


### PR DESCRIPTION
Adds the ability to set the text value of an input via winset.

**Test Setup**

1.  Starting with TestGame, add the following verb to mob:

```
	verb/set_text()
		set name = "Set Text"
		winset(src,"outputwindow.input","text=asdf")
```

2. Compile and start server
3. Click "Set Text" verb in Verbs tab (test case 1)
4. Clear input box of any content, then type `set-text` in input box and press enter (test case 2)
5. Clear input box of any content, then type `.winset "outputwindow.input.text="asdf""` in text box and press enter (test case 3)

**Test Results**

master OD:
The text box will be empty for all test cases

PR:
The text box will be set to `asdf` for all test cases
