### PR TITLE
prune formatting when outputting

### DIFF
--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using System.Web;
+using DMCompiler.Bytecode;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Procs.Native;
@@ -282,7 +283,11 @@ public sealed class DreamConnection {
             return;
         }
 
-        OutputControl(value.Stringify(), null);
+        // Prune any remaining formatting
+        var message = value.Stringify();
+        message = StringFormatEncoder.RemoveFormatting(message);
+
+        OutputControl(message, null);
     }
 
     public void OutputControl(string message, string? control) {

--- a/OpenDreamRuntime/Resources/ConsoleOutputResource.cs
+++ b/OpenDreamRuntime/Resources/ConsoleOutputResource.cs
@@ -1,3 +1,4 @@
+using DMCompiler.Bytecode;
 using OpenDreamRuntime.Procs.DebugAdapter;
 
 namespace OpenDreamRuntime.Resources;
@@ -19,6 +20,10 @@ sealed class ConsoleOutputResource : DreamResource {
     }
 
     public override void Output(DreamValue value) {
-        WriteConsole(LogLevel.Info, "world.log", value.Stringify());
+        // Prune any remaining formatting
+        var message = value.Stringify();
+        message = StringFormatEncoder.RemoveFormatting(message);
+
+        WriteConsole(LogLevel.Info, "world.log", message);
     }
 }

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using DMCompiler.Bytecode;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -77,6 +78,9 @@ public class DreamResource(int id, string? filePath, string? resourcePath) {
         } else if (!value.TryGetValueAsString(out text)) {
             throw new Exception($"Invalid output operation '{ResourcePath}' << {value}");
         }
+
+        // Prune any remaining formatting
+        text = StringFormatEncoder.RemoveFormatting(text);
 
         CreateDirectory();
         File.AppendAllText(ResourcePath, text + "\r\n");


### PR DESCRIPTION
Closes #1601

Test case:

```
	verb/test_improper()
		var/x1 = "\proper something (proper)"
		var/x2 = "\improper something (improper)"
		world.log << "\a [x1]"
		world.log << "\a [x2]"
		world.log << x1
		world.log << x2
```

BYOND:

```
something (proper)
a something (improper)
something (proper)
something (improper)
```

Before PR:

```
[INFO] world.log: something (proper)
[INFO] world.log: a something (improper)
[INFO] world.log: ０something (proper)
[INFO] world.log: １something (improper)
```

With PR:

```
[INFO] world.log: something (proper)
[INFO] world.log: a something (improper)
[INFO] world.log: something (proper)
[INFO] world.log: something (improper)
```
