### PR TITLE
add pixloc on atom

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -62,6 +62,7 @@
 	var/mouse_drop_zone = FALSE
 	var/render_target
 	var/vis_flags as opendream_unimplemented
+	var/pixloc/pixloc as opendream_unimplemented
 
 	proc/Click(location, control, params)
 	proc/DblClick(location, control, params)

--- a/DMCompiler/DMStandard/Types/PixLoc.dm
+++ b/DMCompiler/DMStandard/Types/PixLoc.dm
@@ -2,6 +2,12 @@
 	var/turf/loc as opendream_unimplemented
 	var/step_x as opendream_unimplemented
 	var/step_y as opendream_unimplemented
-	var/x as opendream_unimplemented
-	var/y as opendream_unimplemented
-	var/z as opendream_unimplemented
+	var/x as num|opendream_unimplemented
+	var/y as num|opendream_unimplemented
+	var/z as num|opendream_unimplemented
+
+	proc/New(x, y, z)
+		set opendream_unimplemented = TRUE
+
+/proc/pixloc(x, y, z)
+	return new /pixloc(x, y, z)


### PR DESCRIPTION
var exists there now https://www.byond.com/docs/ref/#/atom/var/pixloc

needed since kev uses pixloc for visual shenanigans on cit-rp (ci failing since var does not exist on atom)