### PR TITLE
Compress the `MsgAllAppearances` packet

### DIFF
--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -1,8 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
 using Lidgren.Network;
 using OpenDreamShared.Dream;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace OpenDreamShared.Network.Messages;
 
@@ -13,19 +16,37 @@ public sealed class MsgAllAppearances(Dictionary<uint, ImmutableAppearance> allA
     public MsgAllAppearances() : this(new()) { }
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
-        var count = buffer.ReadInt32();
+        var compressedData = new MemoryStream(buffer.Data, buffer.PositionInBytes, buffer.LengthBytes - buffer.PositionInBytes);
+        using var decompressStream = new DeflateStream(compressedData, CompressionMode.Decompress);
+        var decompressedData = decompressStream.CopyToArray();
+        var decompressed = new NetBuffer {
+            Data = decompressedData,
+            LengthBytes = decompressedData.Length,
+            Position = 0
+        };
+
+        var count = decompressed.ReadInt32();
         AllAppearances = new(count);
 
         for (int i = 0; i < count; i++) {
-            var appearance = new ImmutableAppearance(buffer, serializer);
+            var appearance = new ImmutableAppearance(decompressed, serializer);
             AllAppearances.Add(appearance.MustGetId(), appearance);
         }
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
-        buffer.Write(AllAppearances.Count);
+        var beforeCompress = new NetBuffer();
+        beforeCompress.Write(AllAppearances.Count);
         foreach (var pair in AllAppearances) {
-            pair.Value.WriteToBuffer(buffer,serializer);
+            pair.Value.WriteToBuffer(beforeCompress, serializer);
         }
+
+        var compressBound = ZStd.CompressBound(beforeCompress.LengthBytes);
+        var compressedData = new MemoryStream(compressBound);
+        using var compressStream = new DeflateStream(compressedData, CompressionMode.Compress);
+
+        compressStream.Write(beforeCompress.Data, 0, beforeCompress.LengthBytes);
+        compressStream.Flush();
+        buffer.Write(compressedData.GetBuffer(), 0, (int)compressedData.Position);
     }
 }


### PR DESCRIPTION
Compressing the MsgAllAppearances packet sent by the Paradise test server brought the size from 8.8MiB to 1.9MiB. This should greatly reduce the time it takes to join a server.