### PR TITLE
Better `DreamConnection.Session` disconnect handling

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -77,6 +77,8 @@ public sealed class DreamObjectClient : DreamObject {
                 value = new(long.Parse(hashStr, System.Globalization.NumberStyles.HexNumber).ToString()); // Converts from hex to decimal. Output is in analogous format to BYOND's.
                 return true;
             case "address":
+                // TODO: Session could be null if this is gotten from /mob/Logout() or /client/Del()
+                // BYOND's behavior there needs tested
                 value = new(Connection.Session!.Channel.RemoteEndPoint.Address.ToString());
                 return true;
             case "inactivity":

--- a/OpenDreamRuntime/Rendering/ServerClientImagesSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerClientImagesSystem.cs
@@ -9,8 +9,7 @@ public sealed class ServerClientImagesSystem : SharedClientImagesSystem {
     [Dependency] private readonly PvsOverrideSystem _pvsOverrideSystem = default!;
 
     public void AddImageObject(DreamConnection connection, DreamObjectImage imageObject) {
-        DreamObject? loc = imageObject.GetAttachedLoc();
-        if(loc == null)
+        if (connection.Session == null || imageObject.GetAttachedLoc() is not { } loc)
             return;
 
         EntityUid locEntity = EntityUid.Invalid;
@@ -25,13 +24,12 @@ public sealed class ServerClientImagesSystem : SharedClientImagesSystem {
         EntityUid imageObjectEntity = imageObject.Entity;
         NetEntity imageObjectNetEntity = GetNetEntity(imageObjectEntity);
         if (imageObjectEntity != EntityUid.Invalid)
-            _pvsOverrideSystem.AddSessionOverride(imageObjectEntity, connection.Session!);
-        RaiseNetworkEvent(new AddClientImageEvent(ent, turfCoords, imageObjectNetEntity), connection.Session!.Channel);
+            _pvsOverrideSystem.AddSessionOverride(imageObjectEntity, connection.Session);
+        RaiseNetworkEvent(new AddClientImageEvent(ent, turfCoords, imageObjectNetEntity), connection.Session.Channel);
     }
 
     public void RemoveImageObject(DreamConnection connection, DreamObjectImage imageObject) {
-        DreamObject? loc = imageObject.GetAttachedLoc();
-        if (loc == null)
+        if (connection.Session == null || imageObject.GetAttachedLoc() is not { } loc)
             return;
 
         EntityUid locEntity = EntityUid.Invalid;
@@ -45,8 +43,8 @@ public sealed class ServerClientImagesSystem : SharedClientImagesSystem {
         NetEntity ent = GetNetEntity(locEntity);
         EntityUid imageObjectEntity = imageObject.Entity;
         if (imageObjectEntity != EntityUid.Invalid)
-            _pvsOverrideSystem.RemoveSessionOverride(imageObjectEntity, connection.Session!);
+            _pvsOverrideSystem.RemoveSessionOverride(imageObjectEntity, connection.Session);
         NetEntity imageObjectNetEntity = GetNetEntity(imageObject.Entity);
-        RaiseNetworkEvent(new RemoveClientImageEvent(ent, turfCoords, imageObjectNetEntity), connection.Session!.Channel);
+        RaiseNetworkEvent(new RemoveClientImageEvent(ent, turfCoords, imageObjectNetEntity), connection.Session.Channel);
     }
 }

--- a/OpenDreamRuntime/Rendering/ServerScreenOverlaySystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerScreenOverlaySystem.cs
@@ -9,6 +9,9 @@ public sealed class ServerScreenOverlaySystem : SharedScreenOverlaySystem {
     [Dependency] private readonly PvsOverrideSystem _pvsOverride = default!;
 
     public void AddScreenObject(DreamConnection connection, DreamObjectMovable screenObject) {
+        if (connection.Session is null)
+            return;
+
         _pvsOverride.AddForceSend(screenObject.Entity, connection.Session);
 
         NetEntity ent = _entityManager.GetNetEntity(screenObject.Entity);
@@ -16,6 +19,9 @@ public sealed class ServerScreenOverlaySystem : SharedScreenOverlaySystem {
     }
 
     public void RemoveScreenObject(DreamConnection connection, DreamObjectMovable screenObject) {
+        if (connection.Session is null)
+            return;
+
         _pvsOverride.RemoveForceSend(screenObject.Entity, connection.Session);
 
         NetEntity ent = _entityManager.GetNetEntity(screenObject.Entity);

--- a/OpenDreamRuntime/ServerVerbSystem.cs
+++ b/OpenDreamRuntime/ServerVerbSystem.cs
@@ -112,6 +112,9 @@ public sealed class ServerVerbSystem : VerbSystem {
     /// </summary>
     /// <param name="client">The client to update</param>
     public void UpdateClientVerbs(DreamObjectClient client) {
+        if (client.Connection.Session == null)
+            return;
+
         var verbs = client.ClientVerbs.Verbs;
         var verbIds = new List<int>(verbs.Count);
 
@@ -121,7 +124,7 @@ public sealed class ServerVerbSystem : VerbSystem {
             verbIds.Add(verb.VerbId!.Value);
         }
 
-        RaiseNetworkEvent(new UpdateClientVerbsEvent(verbIds), client.Connection.Session!);
+        RaiseNetworkEvent(new UpdateClientVerbsEvent(verbIds), client.Connection.Session);
     }
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e) {
@@ -178,7 +181,7 @@ public sealed class ServerVerbSystem : VerbSystem {
 
     private void RunVerb(DreamProc verb, string name, DreamObject? src, DreamConnection usr, params DreamValue[] arguments) {
         using var _ = Profiler.BeginZone("DM Execution", color: (uint)Color.LightPink.ToArgb());
-        
+
         DreamThread.Run($"Execute {name} by {usr.Session!.Name}", async state => {
             await state.Call(verb, src, usr.Mob, arguments);
             return DreamValue.Null;


### PR DESCRIPTION
`Session` was still around during `/mob/Logout()` and `/client/Del()`. Any attempts to use it would throw an exception for using a disconnected channel. This fixes that.

Paradise was triggering this by modifying `/client.screen` from `/mob/Logout()`.