### PR TITLE
Implement pre-516.1674 `Byond_LastError()`

### DIFF
--- a/OpenDreamRuntime/ByondApi/ByondApi.Functions.cs
+++ b/OpenDreamRuntime/ByondApi/ByondApi.Functions.cs
@@ -40,7 +40,22 @@ public static unsafe partial class ByondApi {
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte* Byond_LastError() {
-        return null;
+        try {
+            var utf8 = Encoding.UTF8.GetBytes(_lastError);
+            var buf = (byte*)_lastErrorPtr;
+            var copyLen = Math.Min(utf8.Length, LastErrorMaxLength - 1);
+
+            Marshal.Copy(utf8, 0, (nint)buf, utf8.Length);
+            buf[copyLen] = 0;
+
+            // This does return a string that could be overwritten later by another call to Byond_LastError()
+            // Don't know if BYOND does the same, but this was also made into a saner method in 516.1674 that we'll be updating this to later
+            // So whatever
+            return buf;
+        } catch (Exception e) {
+            SetLastError(e.Message); // Ironic. Maybe undesired?
+            return null;
+        }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
@@ -137,26 +152,26 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_ReadVar(CByondValue* loc, byte* varname, CByondValue* result) {
-        if (loc == null || varname == null || result == null) {
-            return 0;
-        }
+        if (loc == null || varname == null || result == null)
+            return SetLastError("loc, varname, or result argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 string? varName = Marshal.PtrToStringUTF8((nint)varname);
-                if (varName == null) {
-                    return 0;
-                }
+                if (varName == null)
+                    return SetLastError("varname argument was a null pointer");
 
                 DreamValue srcValue = ValueFromDreamApi(*loc);
-                if (!srcValue.TryGetValueAsDreamObject(out var srcObj)) return 0;
-                if (srcObj == null) return 0;
+                if (!srcValue.TryGetValueAsDreamObject(out var srcObj))
+                    return SetLastError("loc was not a DreamObject");
+                if (srcObj == null)
+                    return SetLastError("loc was null");
 
                 var srcVar = srcObj.GetVariable(varName);
                 var cSrcVar = ValueToByondApi(srcVar);
                 *result = cSrcVar;
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -175,24 +190,26 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_ReadVarByStrId(CByondValue* loc, uint varname, CByondValue* result) {
-        if (loc == null || result == null) {
-            return 0;
-        }
+        if (loc == null || result == null)
+            return SetLastError("loc or result argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 DreamValue varNameVal = _dreamManager!.RefIdToValue((int)varname);
-                if (!varNameVal.TryGetValueAsString(out var varName)) return 0;
+                if (!varNameVal.TryGetValueAsString(out var varName))
+                    return SetLastError("varname argument was not a reference to a string");
 
                 DreamValue srcValue = ValueFromDreamApi(*loc);
-                if (!srcValue.TryGetValueAsDreamObject(out var srcObj)) return 0;
-                if (srcObj == null) return 0;
+                if (!srcValue.TryGetValueAsDreamObject(out var srcObj))
+                    return SetLastError("loc argument was not a DreamObject");
+                if (srcObj == null)
+                    return SetLastError("loc argument was null");
 
                 var srcVar = srcObj.GetVariable(varName);
                 var cSrcVar = ValueToByondApi(srcVar);
                 *result = cSrcVar;
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -209,25 +226,25 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_WriteVar(CByondValue* loc, byte* varname, CByondValue* val) {
-        if (loc == null || varname == null || val == null) {
-            return 0;
-        }
+        if (loc == null || varname == null || val == null)
+            return SetLastError("loc, varname, or val argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 string? varName = Marshal.PtrToStringUTF8((nint)varname);
-                if (varName == null) {
-                    return 0;
-                }
+                if (varName == null)
+                    return SetLastError("varname was a null pointer");
 
                 DreamValue srcValue = ValueFromDreamApi(*val);
                 DreamValue dstValue = ValueFromDreamApi(*loc);
-                if (!dstValue.TryGetValueAsDreamObject(out var dstObj)) return 0;
-                if (dstObj == null) return 0;
+                if (!dstValue.TryGetValueAsDreamObject(out var dstObj))
+                    return SetLastError("loc argument was not a DreamObject");
+                if (dstObj == null)
+                    return SetLastError("loc argument was null");
 
                 dstObj.SetVariable(varName, srcValue);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -248,16 +265,19 @@ public static unsafe partial class ByondApi {
         return RunOnMainThread<byte>(() => {
             try {
                 DreamValue varNameVal = _dreamManager!.RefIdToValue((int)varname);
-                if (!varNameVal.TryGetValueAsString(out var varName)) return 0;
+                if (!varNameVal.TryGetValueAsString(out var varName))
+                    return SetLastError("varname argument was not a ref to a string");
 
                 DreamValue srcValue = ValueFromDreamApi(*val);
                 DreamValue dstValue = ValueFromDreamApi(*loc);
-                if (!dstValue.TryGetValueAsDreamObject(out var dstObj)) return 0;
-                if (dstObj == null) return 0;
+                if (!dstValue.TryGetValueAsDreamObject(out var dstObj))
+                    return SetLastError("loc argument was not a DreamObject");
+                if (dstObj == null)
+                    return SetLastError("loc argument was null");
 
                 dstObj.SetVariable(varName, srcValue);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -277,8 +297,8 @@ public static unsafe partial class ByondApi {
             DreamValue val = new DreamValue(newList);
             try {
                 *result = ValueToByondApi(val);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -295,9 +315,8 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_ReadList(CByondValue* loc, CByondValue* list, uint* len) {
-        if (len == null) {
-            return 0;
-        }
+        if (len == null)
+            return SetLastError("len argument was a null pointer");
 
         int providedBufLen = (int)*len;
 
@@ -305,14 +324,15 @@ public static unsafe partial class ByondApi {
             DreamValue srcValue = ValueFromDreamApi(*loc);
             if (!srcValue.TryGetValueAsDreamList(out var srcList)) {
                 *len = 0;
-                return 0;
+                return SetLastError("loc argument was not a list");
             }
 
             int length = srcList.GetLength();
             *len = (uint)length;
-            if (list == null || providedBufLen < length) {
-                return 0;
-            }
+            if (list == null)
+                return SetLastError("list argument was a null pointer");
+            if (providedBufLen < length)
+                return SetLastError($"provided buf length of {providedBufLen} was less than needed {length}");
 
             try {
                 int i = 0;
@@ -322,8 +342,8 @@ public static unsafe partial class ByondApi {
 
                     list[i++] = ValueToByondApi(value);
                 }
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -340,24 +360,22 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_WriteList(CByondValue* loc, CByondValue* list, uint len) {
-        if (list == null || loc == null) {
-            return 0;
-        }
+        if (list == null || loc == null)
+            return SetLastError("list or loc argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 DreamValue dstValue = ValueFromDreamApi(*loc);
-                if (!dstValue.TryGetValueAsDreamList(out DreamList? dstListValue)) {
-                    return 0;
-                }
+                if (!dstValue.TryGetValueAsDreamList(out DreamList? dstListValue))
+                    return SetLastError("loc argument was not a list");
 
                 dstListValue.Cut();
                 for (int i = 0; i < len; i++) {
                     DreamValue srcValue = ValueFromDreamApi(list[i]);
                     dstListValue.AddValue(srcValue);
                 }
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -374,9 +392,8 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_ReadListAssoc(CByondValue* loc, CByondValue* list, uint* len) {
-        if (len == null) {
-            return 0;
-        }
+        if (len == null)
+            return SetLastError("len argument was a null pointer");
 
         int providedBufLen = (int)*len;
 
@@ -384,15 +401,16 @@ public static unsafe partial class ByondApi {
             DreamValue srcValue = ValueFromDreamApi(*loc);
             if (!srcValue.TryGetValueAsDreamList(out var srcList)) {
                 *len = 0;
-                return 0;
+                return SetLastError("loc argument was not a list");
             }
 
             var srcDreamVals = srcList.GetAssociativeValues();
             int length = srcDreamVals.Count * 2;
             *len = (uint)length;
-            if (list == null || providedBufLen < length) {
-                return 0;
-            }
+            if (list == null)
+                return SetLastError("list argument was a null pointer");
+            if (providedBufLen < length)
+                return SetLastError($"provided buf length of {providedBufLen} was less than needed {length}");
 
             try {
                 int i = 0;
@@ -401,8 +419,8 @@ public static unsafe partial class ByondApi {
                     list[i + 1] = ValueToByondApi(entry.Value);
                     i += 2;
                 }
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -419,22 +437,20 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_ReadListIndex(CByondValue* loc, CByondValue* cIdx, CByondValue* result) {
-        if (loc == null || cIdx == null || result == null) {
-            return 0;
-        }
+        if (loc == null || cIdx == null || result == null)
+            return SetLastError("loc, cIdx, or result argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 DreamValue idx = ValueFromDreamApi(*cIdx);
                 DreamValue listValue = ValueFromDreamApi(*loc);
-                if (!listValue.TryGetValueAsDreamList(out var srcList)) {
-                    return 0;
-                }
+                if (!listValue.TryGetValueAsDreamList(out var srcList))
+                    return SetLastError("loc argument was not a list");
 
                 var val = srcList.GetValue(idx);
                 *result = ValueToByondApi(val);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -451,22 +467,20 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_WriteListIndex(CByondValue* loc, CByondValue* cIdx, CByondValue* cVal) {
-        if (loc == null || cIdx == null || cVal == null) {
-            return 0;
-        }
+        if (loc == null || cIdx == null || cVal == null)
+            return SetLastError("loc, cIdx, or cVal argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 DreamValue idx = ValueFromDreamApi(*cIdx);
                 DreamValue listValue = ValueFromDreamApi(*loc);
-                if (!listValue.TryGetValueAsDreamList(out var dstList)) {
-                    return 0;
-                }
+                if (!listValue.TryGetValueAsDreamList(out var dstList))
+                    return SetLastError("loc argument was not a list");
 
                 var val = ValueFromDreamApi(*cVal);
                 dstList.SetValue(idx, val, true);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -482,9 +496,8 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_ReadPointer(CByondValue* cPtr, CByondValue* result) {
-        if (cPtr == null || result == null) {
-            return 0;
-        }
+        if (cPtr == null || result == null)
+            return SetLastError("cPtr or result argument was a null pointer");
 
         throw new NotImplementedException();
     }
@@ -498,9 +511,8 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_WritePointer(CByondValue* cPtr, CByondValue* cVal) {
-        if (cPtr == null || cVal == null) {
-            return 0;
-        }
+        if (cPtr == null || cVal == null)
+            return SetLastError("cPtr or cVal argument was a null pointer");
 
         throw new NotImplementedException();
     }
@@ -535,23 +547,26 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_CallProc(CByondValue* cSrc, byte* cName, CByondValue* cArgs, uint arg_count, CByondValue* cResult) {
-        if (cSrc == null || cArgs == null || cResult == null) {
-            return 0;
-        }
+        if (cSrc == null || cArgs == null || cResult == null)
+            return SetLastError("cSrc, cArgs, or cResult argument was a null pointer");
 
-        return RunOnMainThread<byte>(() => {
+        return RunOnMainThread(() => {
             try {
                 string? str = Marshal.PtrToStringUTF8((nint)cName);
-                if (str == null) return 0;
+                if (str == null)
+                    return SetLastError("cName argument was a null pointer");
 
                 DreamValue src = ValueFromDreamApi(*cSrc);
-                if (!src.TryGetValueAsDreamObject(out var srcObj)) return 0;
-                if (srcObj == null) return 0;
-                if (!srcObj.TryGetProc(str, out var proc)) return 0;
+                if (!src.TryGetValueAsDreamObject(out var srcObj))
+                    return SetLastError("cSrc argument was not a DreamObject");
+                if (srcObj == null)
+                    return SetLastError("cSrc argument was null");
+                if (!srcObj.TryGetProc(str, out var proc))
+                    return SetLastError($"cSrc argument does not own a proc named \"{str}\"");
 
                 return CallProcShared(srcObj, proc, cArgs, arg_count, cResult);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
         });
     }
@@ -570,23 +585,26 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_CallProcByStrId(CByondValue* cSrc, uint name, CByondValue* cArgs, uint arg_count, CByondValue* cResult) {
-        if (cSrc == null || cArgs == null || cResult == null) {
-            return 0;
-        }
+        if (cSrc == null || cArgs == null || cResult == null)
+            return SetLastError("cSrc, cArgs, or cResult argument was a null pointer");
 
-        return RunOnMainThread<byte>(() => {
+        return RunOnMainThread(() => {
             try {
                 DreamValue procNameVal = _dreamManager!.RefIdToValue((int)name);
-                if (!procNameVal.TryGetValueAsString(out var procName)) return 0;
+                if (!procNameVal.TryGetValueAsString(out var procName))
+                    return SetLastError("name argument was not a ref to a string");
 
                 DreamValue src = ValueFromDreamApi(*cSrc);
-                if (!src.TryGetValueAsDreamObject(out var srcObj)) return 0;
-                if (srcObj == null) return 0;
-                if (!srcObj.TryGetProc(procName, out var proc)) return 0;
+                if (!src.TryGetValueAsDreamObject(out var srcObj))
+                    return SetLastError("cSrc argument was not a DreamObject");
+                if (srcObj == null)
+                    return SetLastError("cSrc argument was null");
+                if (!srcObj.TryGetProc(procName, out var proc))
+                    return SetLastError($"cSrc does not own a proc named \"{procName}\"");
 
                 return CallProcShared(srcObj, proc, cArgs, arg_count, cResult);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
         });
     }
@@ -603,19 +621,20 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_CallGlobalProc(byte* cName, CByondValue* cArgs, uint arg_count, CByondValue* cResult) {
-        if (cArgs == null || cResult == null) {
-            return 0;
-        }
+        if (cArgs == null || cResult == null)
+            return SetLastError("cArgs or cResult argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 string? str = Marshal.PtrToStringUTF8((nint)cName);
-                if (str == null) return 0;
-                if (!_dreamManager!.TryGetGlobalProc(str, out var proc)) return 0;
+                if (str == null)
+                    return SetLastError("cName argument was a null pointer");
+                if (!_dreamManager!.TryGetGlobalProc(str, out var proc))
+                    return SetLastError($"no global proc named \"{str}\"");
 
                 CallProcShared(null, proc, cArgs, arg_count, cResult);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -635,19 +654,20 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_CallGlobalProcByStrId(uint name, CByondValue* cArgs, uint arg_count, CByondValue* cResult) {
-        if (cArgs == null || cResult == null) {
-            return 0;
-        }
+        if (cArgs == null || cResult == null)
+            return SetLastError("cArgs or cResult argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
                 DreamValue procNameVal = _dreamManager!.RefIdToValue((int)name);
-                if (!procNameVal.TryGetValueAsString(out var procName)) return 0;
-                if (!_dreamManager.TryGetGlobalProc(procName, out var proc)) return 0;
+                if (!procNameVal.TryGetValueAsString(out var procName))
+                    return SetLastError("name argument was not a ref to a string");
+                if (!_dreamManager.TryGetGlobalProc(procName, out var proc))
+                    return SetLastError($"no global proc named \"{procName}\"");
 
                 CallProcShared(null, proc, cArgs, arg_count, cResult);
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -664,9 +684,8 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_ToString(CByondValue* src, byte* buf, uint* buflen) {
-        if (src == null || buflen == null) {
-            return 0;
-        }
+        if (src == null || buflen == null)
+            return SetLastError("src or buflen argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
@@ -677,15 +696,16 @@ public static unsafe partial class ByondApi {
                 int length = utf8.Length;
 
                 *buflen = (uint)length + 1;
-                if (buf == null || providedBufLen <= length) {
-                    return 0;
-                }
+                if (buf == null)
+                    return SetLastError("buf was a null pointer");
+                if (providedBufLen <= length)
+                    return SetLastError($"provided buf length of {providedBufLen} was less than needed {length}");
 
                 Marshal.Copy(utf8, 0, (nint)buf, length);
                 buf[length] = 0;
-            } catch (Exception) {
+            } catch (Exception e) {
                 *buflen = 0;
-                return 0;
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -703,9 +723,8 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_Block(CByondXYZ* corner1, CByondXYZ* corner2, CByondValue* cList, uint* len) {
-        if (corner1 == null || corner2 == null || cList == null || len == null) {
-            return 0;
-        }
+        if (corner1 == null || corner2 == null || cList == null || len == null)
+            return SetLastError("corner1, corner2, cList, or len argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             List<CByondValue> list = new();
@@ -717,13 +736,13 @@ public static unsafe partial class ByondApi {
                 foreach (var turf in turfs.EnumerateValues()) {
                     list.Add(ValueToByondApi(turf));
                 }
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             if (*len < list.Count) {
                 *len = (uint)list.Count;
-                return 0;
+                return SetLastError($"provided buf length of {*len} was less than needed {list.Count}");
             }
 
             *len = (uint)list.Count;
@@ -744,17 +763,16 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_Length(CByondValue* src, CByondValue* result) {
-        if (src == null || result == null) {
-            return 0;
-        }
+        if (src == null || result == null)
+            return SetLastError("src or result argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             DreamValue srcValue = ValueFromDreamApi(*src);
             try {
                 *result = ValueToByondApi(DreamProcNativeRoot._length(srcValue, true));
                 return 1;
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
         });
     }
@@ -808,9 +826,8 @@ public static unsafe partial class ByondApi {
     /** <see cref="DMOpcodeHandlers.CreateObject(DMProcState)"/> */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_New(CByondValue* cType, CByondValue* cArgs, uint arg_count, CByondValue* cResult) {
-        if (cType == null || cArgs == null || cResult == null) {
-            return 0;
-        }
+        if (cType == null || cArgs == null || cResult == null)
+            return SetLastError("cType, cArgs, or cResult argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
@@ -818,9 +835,9 @@ public static unsafe partial class ByondApi {
                 if (!typeVal.TryGetValueAsType(out var treeEntry)) {
                     if (typeVal.TryGetValueAsString(out var pathString)) {
                         if (!_objectTree!.TryGetTreeEntry(pathString, out treeEntry))
-                            return 0;
+                            return SetLastError($"{pathString} is not a valid type");
                     } else {
-                        return 0;
+                        return SetLastError("cType argument was not a ref to a valid type");
                     }
                 }
 
@@ -839,7 +856,7 @@ public static unsafe partial class ByondApi {
                     // So instead this will replace an existing turf's type and return that same turf
                     DreamValue loc = args.GetArgument(0);
                     if (!loc.TryGetValueAsDreamObject<DreamObjectTurf>(out var turf)) {
-                        return 0;
+                        return SetLastError($"Invalid turf loc {loc}");
                     }
 
                     _dreamMapManager!.SetTurf(turf, objectDef, args);
@@ -849,8 +866,8 @@ public static unsafe partial class ByondApi {
                 var newObject = _objectTree.CreateObject(treeEntry);
                 newObject.InitSpawn(args);
                 *cResult = ValueToByondApi(new DreamValue(newObject));
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -868,9 +885,8 @@ public static unsafe partial class ByondApi {
     /** <see cref="DMOpcodeHandlers.CreateObject(DMProcState)"/> */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_NewArglist(CByondValue* cType, CByondValue* cArglist, CByondValue* cResult) {
-        if (cType == null || cArglist == null || cResult == null) {
-            return 0;
-        }
+        if (cType == null || cArglist == null || cResult == null)
+            return SetLastError("cType, cArglist, or cResult argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             try {
@@ -878,16 +894,17 @@ public static unsafe partial class ByondApi {
                 if (!typeVal.TryGetValueAsType(out var treeEntry)) {
                     if (typeVal.TryGetValueAsString(out var pathString)) {
                         if (!_objectTree!.TryGetTreeEntry(pathString, out treeEntry))
-                            return 0;
+                            return SetLastError($"{pathString} is not a valid type");
                     } else {
-                        return 0;
+                        return SetLastError("cType argument was not a ref to a valid type");
                     }
                 }
 
                 var objectDef = treeEntry.ObjectDefinition;
 
                 var arglistVal = ValueFromDreamApi(*cArglist);
-                if (!arglistVal.TryGetValueAsIDreamList(out var arglist)) return 0;
+                if (!arglistVal.TryGetValueAsIDreamList(out var arglist))
+                    return SetLastError("cArglist argument was not a list");
 
                 // Copy the arglist's values to a new array to ensure no shenanigans
                 var argValues = arglist.CopyToArray();
@@ -899,7 +916,7 @@ public static unsafe partial class ByondApi {
                     // So instead this will replace an existing turf's type and return that same turf
                     DreamValue loc = args.GetArgument(0);
                     if (!loc.TryGetValueAsDreamObject<DreamObjectTurf>(out var turf)) {
-                        return 0;
+                        return SetLastError($"Invalid turf loc {loc}");
                     }
 
                     _dreamMapManager!.SetTurf(turf, objectDef, args);
@@ -909,8 +926,8 @@ public static unsafe partial class ByondApi {
                 var newObject = _objectTree.CreateObject(treeEntry);
                 newObject.InitSpawn(args);
                 *cResult = ValueToByondApi(new DreamValue(newObject));
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -926,7 +943,8 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_Refcount(CByondValue* src, uint* result) {
-        if (src == null || result == null) return 0;
+        if (src == null || result == null)
+            return SetLastError("src or result argument was a null pointer");
 
         return RunOnMainThread<byte>(() => {
             // TODO
@@ -948,20 +966,23 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_XYZ(CByondValue* src, CByondXYZ* xyz) {
-        if (src == null || xyz == null) return 0;
+        if (src == null || xyz == null)
+            return SetLastError("src or xyz argument was a null pointer");
+
         *xyz = new CByondXYZ();
 
         return RunOnMainThread<byte>(() => {
             try {
                 var srcVal = ValueFromDreamApi(*src);
-                if (!srcVal.TryGetValueAsDreamObject<DreamObjectAtom>(out var srcObj)) return 0;
+                if (!srcVal.TryGetValueAsDreamObject<DreamObjectAtom>(out var srcObj))
+                    return SetLastError("src argument was not an atom");
 
                 var (x, y, z) = _atomManager!.GetAtomPosition(srcObj);
                 xyz->x = (short)x;
                 xyz->y = (short)y;
                 xyz->z = (short)z;
-            } catch (Exception) {
-                return 0;
+            } catch (Exception e) {
+                return SetLastError(e.Message);
             }
 
             return 1;
@@ -977,7 +998,9 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_PixLoc(CByondValue* src, CByondPixLoc *pixLoc) {
-        if (src == null) return 0;
+        if (src == null)
+            return SetLastError("src argument was a null pointer");
+
         throw new NotImplementedException();
     }
 
@@ -991,7 +1014,9 @@ public static unsafe partial class ByondApi {
      */
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_BoundPixLoc(CByondValue* src, byte dir, CByondPixLoc* pixLoc) {
-        if (src == null) return 0;
+        if (src == null)
+            return SetLastError("src argument was a null pointer");
+
         throw new NotImplementedException();
     }
 
@@ -1043,7 +1068,7 @@ public static unsafe partial class ByondApi {
     // This only applies to ref types, not null/num/string which are always valid.
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
     private static byte Byond_TestRef(CByondValue* src) {
-        if (src == null) return 0;
+        if (src == null) return SetLastError("src argument was a null pointer");
         if (src->type == ByondValueType.Null) {
             return 1;
         }

--- a/OpenDreamRuntime/ByondApi/ByondApi.cs
+++ b/OpenDreamRuntime/ByondApi/ByondApi.cs
@@ -23,6 +23,7 @@ public static partial class ByondApi {
     /// A failed ByondApi call will set this string. It can be retrieved with <see cref="Byond_LastError"/>.
     /// </summary>
     private static string _lastError = string.Empty;
+    
     private static IntPtr _lastErrorPtr = IntPtr.Zero;
 
     public static void Initialize(DreamManager dreamManager, AtomManager atomManager, IDreamMapManager dreamMapManager, DreamObjectTree objectTree) {

--- a/OpenDreamRuntime/ByondApi/ByondApi.cs
+++ b/OpenDreamRuntime/ByondApi/ByondApi.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Objects;
@@ -8,6 +9,8 @@ using Robust.Shared.Utility;
 namespace OpenDreamRuntime.ByondApi;
 
 public static partial class ByondApi {
+    private const int LastErrorMaxLength = 128;
+
     private static DreamManager? _dreamManager;
     private static AtomManager? _atomManager;
     private static IDreamMapManager? _dreamMapManager;
@@ -15,6 +18,12 @@ public static partial class ByondApi {
 
     private static readonly ConcurrentQueue<Action> ThreadSyncQueue = new();
     private static int _mainThreadId;
+
+    /// <summary>
+    /// A failed ByondApi call will set this string. It can be retrieved with <see cref="Byond_LastError"/>.
+    /// </summary>
+    private static string _lastError = string.Empty;
+    private static IntPtr _lastErrorPtr = IntPtr.Zero;
 
     public static void Initialize(DreamManager dreamManager, AtomManager atomManager, IDreamMapManager dreamMapManager, DreamObjectTree objectTree) {
         DebugTools.Assert(_dreamManager is null or { IsShutDown: true });
@@ -27,7 +36,13 @@ public static partial class ByondApi {
         _mainThreadId = Environment.CurrentManagedThreadId;
         ThreadSyncQueue.Clear();
 
+        _lastErrorPtr = Marshal.AllocHGlobal(LastErrorMaxLength);
+
         InitTrampoline();
+    }
+
+    public static void Shutdown() {
+        Marshal.FreeHGlobal(_lastErrorPtr);
     }
 
     public static void ExecuteThreadSyncs() {
@@ -154,6 +169,14 @@ public static partial class ByondApi {
             default:
                 throw new ArgumentOutOfRangeException();
         }
+    }
+
+    /// <summary>
+    /// Helper method that sets <see cref="_lastError"/> and returns an error code (false)
+    /// </summary>
+    private static byte SetLastError(string lastError) {
+        _lastError = lastError;
+        return 0;
     }
 
     [SuppressMessage("Usage", "RA0004:Risk of deadlock from accessing Task<T>.Result")]

--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -84,6 +84,7 @@ namespace OpenDreamRuntime {
 
             _dreamManager.Shutdown();
             _debugManager.Shutdown();
+            ByondApi.ByondApi.Shutdown();
         }
 
         public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs) {


### PR DESCRIPTION
Implements `Byond_LastError()` so we can get more descriptive error messages when a ByondApi call fails.

Neither Paradise or /tg/ use a new enough BYOND version for the new `Byond_LastError()` to be relevant yet.