### PR TITLE
Implement `caller`

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/caller.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/caller.dm
@@ -1,0 +1,16 @@
+/datum/meep/proc/bar()
+    ASSERT(caller.caller.caller.name == "ihateithere")
+
+/datum/proc/foo()
+    var/datum/meep/M = new
+    ASSERT(caller.name == "ihateithere")
+    M.bar()
+
+/proc/ihateithere()
+	var/datum/D = new
+	ASSERT(caller.name == "RunTest")
+	D.foo()
+
+/proc/RunTest()
+    ASSERT(caller.name == "New")
+    ihateithere()

--- a/Content.Tests/DMProject/Tests/Builtins/caller.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/caller.dm
@@ -12,5 +12,5 @@
 	D.foo()
 
 /proc/RunTest()
-    ASSERT(caller.name == "New")
+    // RunTest()'s caller is null due to how unit tests are invoked
     ihateithere()

--- a/DMCompiler/DMStandard/Types/Callee.dm
+++ b/DMCompiler/DMStandard/Types/Callee.dm
@@ -1,7 +1,7 @@
 ﻿/callee
 	var/proc
 	var/args
-	var/caller as /callee|null
+	var/callee/caller as /callee|null
 	
 	var/name as text|null
 	var/desc as text|null

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DMCompiler.DM;
 using OpenDreamRuntime.Objects;
+using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamShared.Dream;
@@ -142,6 +143,9 @@ namespace OpenDreamRuntime {
 
         public abstract DreamProc? Proc { get; }
 
+        protected DreamObjectCallee? Callee { get; set; }
+        protected DreamObjectCallee? Caller { get; set; }
+
         protected void Initialize(DreamThread thread, bool waitFor) {
             Thread = thread;
             WaitFor = waitFor;
@@ -223,6 +227,10 @@ namespace OpenDreamRuntime {
 
         public DreamValue Resume() {
             return ReentrantResume(null, out _);
+        }
+
+        public ProcState PeekStack(int index = 0) {
+            return index == 0 ? _stack.Peek() : _stack.ElementAt(index);
         }
 
         /// <summary>

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -238,7 +238,8 @@ namespace OpenDreamRuntime {
             return ReentrantResume(null, out _);
         }
 
-        public ProcState PeekStack(int index = 0) {
+        public ProcState? PeekStack(int index = 0) {
+            if (_stack.Count == 0) return null;
             return index == 0 ? _stack.Peek() : _stack.ElementAt(index);
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
@@ -65,11 +65,11 @@ public sealed class DreamObjectCallee : DreamObject {
     /// </summary>
     private void SetCaller() {
         if (ProcState is null || _caller is not null) return;
+        if (ProcState.Thread.PeekStack(1) is not DMProcState dmProcState) return;
 
         var caller = ObjectTree.CreateObject<DreamObjectCallee>(ObjectTree.Callee);
-        var peekStack = ProcState.Thread.PeekStack(1);
-        caller.ProcState = (DMProcState)peekStack;
-        caller.ProcStateId = peekStack.Id;
+        caller.ProcState = dmProcState;
+        caller.ProcStateId = dmProcState.Id;
         _caller = caller;
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
@@ -4,7 +4,7 @@ using OpenDreamRuntime.Procs;
 namespace OpenDreamRuntime.Objects.Types;
 
 public sealed class DreamObjectCallee : DreamObject {
-    public DMProcState? ProcState;
+    public ProcState? ProcState;
     public long ProcStateId; // Used to ensure the proc state hasn't been reused for another proc
     private DreamObjectCallee? _caller; // Caching caller prevents issues with returning incorrect info when the proc ends or calls another proc
 
@@ -19,7 +19,7 @@ public sealed class DreamObjectCallee : DreamObject {
 
         switch (varName) {
             case "proc":
-                value = new(ProcState.Proc);
+                value = ProcState.Proc != null ? new(ProcState.Proc) : DreamValue.Null;
                 return true;
             case "args":
                 value = new(new ProcArgsList(ObjectTree.List.ObjectDefinition, ProcState));
@@ -29,19 +29,23 @@ public sealed class DreamObjectCallee : DreamObject {
                 value = new DreamValue(_caller);
                 return true;
             case "name":
-                value = new(ProcState.Proc.VerbName);
+                value = ProcState.Proc?.VerbName != null ? new(ProcState.Proc.VerbName) : DreamValue.Null;
                 return true;
             case "desc":
-                value = ProcState.Proc.VerbDesc != null ? new(ProcState.Proc.VerbDesc) : DreamValue.Null;
+                value = ProcState.Proc?.VerbDesc != null ? new(ProcState.Proc.VerbDesc) : DreamValue.Null;
                 return true;
             case "category":
-                value = ProcState.Proc.VerbCategory != null ? new(ProcState.Proc.VerbCategory) : DreamValue.Null;
+                value = ProcState.Proc?.VerbCategory != null ? new(ProcState.Proc.VerbCategory) : DreamValue.Null;
                 return true;
             case "file":
-                value = new(ProcState.Proc.GetSourceAtOffset(0).Source);
+                value = ProcState.Proc is DMProc procFile
+                    ? new DreamValue(procFile.GetSourceAtOffset(0).Source)
+                    : DreamValue.Null;
                 return true;
             case "line":
-                value = new(ProcState.Proc.GetSourceAtOffset(0).Line);
+                value = ProcState.Proc is DMProc procLine
+                    ? new DreamValue(procLine.GetSourceAtOffset(0).Line)
+                    : DreamValue.Null;
                 return true;
             case "src":
                 value = new(ProcState.Instance);

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -834,16 +834,25 @@ public sealed class DMProcState : ProcState {
             case DMReference.Type.Args: return new(new ProcArgsList(Proc.ObjectTree.List.ObjectDefinition, this));
             case DMReference.Type.World: return new(DreamManager.WorldInstance);
             case DMReference.Type.Callee: {
-                // TODO: BYOND seems to reuse the same object. At least, callee == callee
+                // BYOND seems to reuse the same object. At least, callee == callee
+                if (Callee is not null) return new DreamValue(Callee);
                 var callee = Proc.ObjectTree.CreateObject<DreamObjectCallee>(Proc.ObjectTree.Callee);
 
                 callee.ProcState = this;
                 callee.ProcStateId = Id;
+                Callee = callee;
                 return new(callee);
             }
             case DMReference.Type.Caller: {
-                // TODO
-                return DreamValue.Null;
+                // Note that the ref says that caller still returns a "/callee" object, just with the caller's info
+                if (Caller is not null) return new DreamValue(Caller);
+                var caller = Proc.ObjectTree.CreateObject<DreamObjectCallee>(Proc.ObjectTree.Callee);
+
+                var threadPeek = Thread.PeekStack();
+                caller.ProcState = (DMProcState)threadPeek;
+                caller.ProcStateId = threadPeek.Id;
+                Caller = caller;
+                return new(caller);
             }
             case DMReference.Type.Field: {
                 DreamValue owner = peek ? Peek() : Pop();

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -846,11 +846,11 @@ public sealed class DMProcState : ProcState {
             case DMReference.Type.Caller: {
                 // Note that the ref says that caller still returns a "/callee" object, just with the caller's info
                 if (Caller is not null) return new DreamValue(Caller);
-                var caller = Proc.ObjectTree.CreateObject<DreamObjectCallee>(Proc.ObjectTree.Callee);
+                if (Thread.PeekStack() is not DMProcState dmProcState) return DreamValue.Null;
 
-                var threadPeek = Thread.PeekStack();
-                caller.ProcState = (DMProcState)threadPeek;
-                caller.ProcStateId = threadPeek.Id;
+                var caller = Proc.ObjectTree.CreateObject<DreamObjectCallee>(Proc.ObjectTree.Callee);
+                caller.ProcState = dmProcState;
+                caller.ProcStateId = dmProcState.Id;
                 Caller = caller;
                 return new(caller);
             }


### PR DESCRIPTION
https://github.com/OpenDreamProject/OpenDream/issues/2203

This is admittedly a bit awful but the alternative is every single proccall storing its `ProcState` on the called proc even when nobody utilizes or cares about `caller`.