### PR TITLE
Allow `astype()` to infer a type from its first argument

### DIFF
--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -1144,11 +1144,16 @@ internal class DMExpressionBuilder(ExpressionContext ctx, DMExpressionBuilder.Sc
     private DMExpression BuildImplicitAsType(DMASTImplicitAsType asType, DreamPath? inferredPath) {
         var expr = BuildExpression(asType.Value, inferredPath);
 
-        if (inferredPath is null) {
+        // From the DM ref:
+        // 1. If astype() is on the right-hand side of an assignment operation, the left-hand side's var type is the implied type, just like with the new() operator.
+        // 2. Otherwise, the var type of the first argument is the implied type, just as it is in istype().
+        var inferredType = inferredPath ?? expr.Path;
+
+        if (inferredType is null) {
             return BadExpression(WarningCode.BadExpression, asType.Location, "Could not infer a type");
         }
 
-        return new AsTypeInferred(asType.Location, expr, inferredPath.Value);
+        return new AsTypeInferred(asType.Location, expr, inferredType.Value);
     }
 
     private DMExpression BuildImplicitIsType(DMASTImplicitIsType isType, DreamPath? inferredPath) {


### PR DESCRIPTION
From the DM ref:
> 1. If astype() is on the right-hand side of an assignment operation, the left-hand side's var type is the implied type, just like with the new() operator.
> 2. Otherwise, the var type of the first argument is the implied type, just as it is in istype().

The behavior of 2 is now implemented.

Fixes #2521