### PR TITLE
Savefile test parity

### DIFF
--- a/Content.Tests/DMProject/Tests/Savefile/BasicReadAndWrite.dm
+++ b/Content.Tests/DMProject/Tests/Savefile/BasicReadAndWrite.dm
@@ -50,11 +50,17 @@
 	//Test dir
 	S.cd = "/"
 	var/dir = S.dir
-	ASSERT(dir ~= list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2"))
+	var/dir_compare = list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2") 
+	ASSERT(length(dir) == length(dir_compare))
+	for(var/d in dir)
+		ASSERT(d in dir_compare)
 
 	//test add
 	dir += "test/beep"
-	ASSERT(dir ~= list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2", "test"))
+	dir_compare = list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2", "test")
+	ASSERT(length(dir) == length(dir_compare))
+	for(var/d in dir)
+		ASSERT(d in dir_compare)
 	ASSERT(S["test"] == null)
 	S.cd = "test"
 	ASSERT(dir ~= list("beep"))
@@ -62,15 +68,24 @@
 	//test del
 	S.cd = "/"
 	dir -= "test"
-	ASSERT(dir ~= list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2"))
+	dir_compare = list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2")
+	ASSERT(length(dir) == length(dir_compare))
+	for(var/d in dir)
+		ASSERT(d in dir_compare)
 
 	//test rename and null
 	dir[1] = "CBA"
-	ASSERT(dir ~= list("CBA", "DEF", "notakey", "pathymcpathface", "pie", "pie2"))
-	ASSERT(S["CBA"] == null)
+	dir_compare = list("CBA", "DEF", "notakey", "pathymcpathface", "pie", "pie2")
+	ASSERT(length(dir) == length(dir_compare))
+	for(var/d in dir)
+		ASSERT(d in dir_compare)
+
+	ASSERT(S["CBA"] == 5)
 
 	fdel("savefile.sav")
 
+#ifdef OPENDREAM
+//we're only testing this in OD for now, BYOND reports an error but not a runtime when reading from a malformed save
 	file("badsavefile.sav") << "hey wait, this isn't json! oh well, better fail miserably and die"
 	
 	var/savefile/fail
@@ -80,3 +95,4 @@
 		ASSERT(isnull(fail))
 	ASSERT(fail == null)
 	fdel("badsavefile.sav")
+#endif

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -1645,7 +1645,7 @@ public sealed class SavefileDirList(DreamObjectDefinition listDef, DreamObjectSa
         if (index < 1 || index > backedSaveFile.CurrentDir.Count)
             throw new Exception($"Out of bounds index on savefile dir list: {index}");
 
-        backedSaveFile.RenameAndNullSavefileValue(backedSaveFile.CurrentDir.Keys.ElementAt(index - 1), valueStr);
+        backedSaveFile.RenameSavefileValue(backedSaveFile.CurrentDir.Keys.ElementAt(index - 1), valueStr);
     }
 
     public override void AddValue(DreamValue value) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -311,15 +311,10 @@ public sealed class DreamObjectSavefile : DreamObject {
         }
     }
 
-    public void RenameAndNullSavefileValue(string index, string newIndex) {
+    public void RenameSavefileValue(string index, string newIndex) {
         if (CurrentDir.TryGetValue(index, out var value)) {
             CurrentDir.Remove(index);
-            SfDreamDir newDir = new SfDreamDir();
-            foreach (var key in value.Keys) {
-                newDir[key] = value[key];
-            }
-
-            CurrentDir[newIndex] = newDir;
+            CurrentDir[newIndex] = value;
             SavefilesToFlush.Add(this);
         }
     }


### PR DESCRIPTION
We decided a while back we weren't gonna match behaviour on savefile dir order

also renaming elements doesn't null them, maybe it did in an old version, but it doesn't now.