### PR TITLE
Remove most of `Robust.Shared` as a `DMCompiler` dependency

### DIFF
--- a/DMCompiler/DMCompiler.csproj
+++ b/DMCompiler/DMCompiler.csproj
@@ -13,7 +13,9 @@
     <DMStandard Include="DMStandard\**" />
   </ItemGroup>
 
-  <Import Project="..\RobustToolbox\Imports\Shared.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\RobustToolbox\Robust.Shared.Maths\Robust.Shared.Maths.csproj" />
+  </ItemGroup>
 
   <Target Name="CopyDMStandard" AfterTargets="AfterBuild">
     <Copy SourceFiles="@(DMStandard)" DestinationFiles="@(DMStandard->'$(OutDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')" />


### PR DESCRIPTION
DMCompiler only uses `Robust.Shared.Maths.Color` so there's no need to import the entirety of `Robust.Shared`.

This cut the clean build time from 30 seconds to 7 seconds on my laptop.
22 seconds to 8 seconds in CI.