### PR TITLE
Create `DreamRefManager`

### DIFF
--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -203,7 +203,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                 browser.SetFileSource(null);
             }
         } else if (pBrowse.HtmlSource != null) {
-            var htmlFileName = $"browse{_random.Next()}"; // TODO: Possible collisions and explicit file names
+            var htmlFileName = $"browse_{pBrowse.Window}_{_random.Next()}"; // TODO: Possible collisions and explicit file names
             ControlBrowser? outputBrowser = referencedElement as ControlBrowser;
 
             if (outputBrowser == null) {

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -14,22 +14,30 @@ using Dependency = Robust.Shared.IoC.DependencyAttribute;
 namespace OpenDreamRuntime;
 
 public sealed class AtomManager {
-    public int AtomCount { get; private set; }
+    public int AtomCount {
+        get {
+            ReadOnlySpan<RefType> atomTypes = [
+                RefType.DreamObjectArea,
+                RefType.DreamObjectTurf,
+                RefType.DreamObjectMovable,
+                RefType.DreamObjectMob
+            ];
+
+            int count = 0;
+            foreach (var atomType in atomTypes) {
+                count += _refManager.GetCountOf(atomType);
+            }
+
+            return count;
+        }
+    }
 
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
     [Dependency] private readonly DreamObjectTree _objectTree = default!;
     [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
     [Dependency] private readonly DreamResourceManager _resourceManager = default!;
-
-    private readonly List<DreamObjectMob?> _mobs = new();
-    private readonly List<DreamObjectMovable?> _movables = new();
-    private readonly List<DreamObjectArea?> _areas = new();
-    private readonly List<DreamObjectTurf?> _turfs = new();
-    private int _nextEmptyMobSlot;
-    private int _nextEmptyMovableSlot;
-    private int _nextEmptyAreaSlot;
-    private int _nextEmptyTurfSlot;
+    [Dependency] private readonly DreamRefManager _refManager = default!;
 
     private readonly Dictionary<EntityUid, DreamObjectMovable> _entityToAtom = new();
     private readonly Dictionary<DreamObjectDefinition, MutableAppearance> _definitionAppearanceCache = new();
@@ -37,33 +45,28 @@ public sealed class AtomManager {
 
     private ServerAppearanceSystem? AppearanceSystem {
         get {
-            if(_appearanceSystem is null)
-                _entitySystemManager.TryGetEntitySystem(out _appearanceSystem);
-            return _appearanceSystem;
+            if(field is null)
+                _entitySystemManager.TryGetEntitySystem(out field);
+            return field;
         }
     }
 
     private DMISpriteSystem? DMISpriteSystem {
         get {
-            if(_dmiSpriteSystem is null)
-                _entitySystemManager.TryGetEntitySystem(out _dmiSpriteSystem);
-            return _dmiSpriteSystem;
+            if(field is null)
+                _entitySystemManager.TryGetEntitySystem(out field);
+            return field;
         }
     }
 
     private ServerVerbSystem? VerbSystem {
         get {
-            if(_verbSystem is null)
-                _entitySystemManager.TryGetEntitySystem(out _verbSystem);
-            return _verbSystem;
+            if(field is null)
+                _entitySystemManager.TryGetEntitySystem(out field);
+            return field;
         }
     }
 
-    private ServerAppearanceSystem? _appearanceSystem;
-    private ServerVerbSystem? _verbSystem;
-    private DMISpriteSystem? _dmiSpriteSystem;
-
-    // ReSharper disable ForCanBeConvertedToForeach (the collections could be added to)
     public IEnumerable<DreamObjectAtom> EnumerateAtoms(TreeEntry? filterType = null) {
         // Order of world.contents:
         //  Mobs + Other Movables + Areas + Turfs
@@ -72,144 +75,31 @@ public sealed class AtomManager {
             filterType = null;
 
         if (filterType?.IsSubtypeOf(_objectTree.Mob) != false) {
-            for (int i = 0; i < _mobs.Count; i++) {
-                var mob = _mobs[i];
-
-                if (mob != null && (filterType == null || mob.IsSubtypeOf(filterType)))
-                    yield return mob;
+            foreach (var mob in _refManager.EnumerateType(RefType.DreamObjectMob)) {
+                if (filterType == null || mob.IsSubtypeOf(filterType))
+                    yield return (DreamObjectMob)mob;
             }
         }
 
         if (filterType?.IsSubtypeOf(_objectTree.Movable) != false) {
-            for (int i = 0; i < _movables.Count; i++) {
-                var movable = _movables[i];
-                if (movable != null && (filterType == null || movable.IsSubtypeOf(filterType)))
-                    yield return movable;
+            foreach (var movable in _refManager.EnumerateType(RefType.DreamObjectMovable)) {
+                if (filterType == null || movable.IsSubtypeOf(filterType))
+                    yield return (DreamObjectMovable)movable;
             }
         }
 
         if (filterType?.IsSubtypeOf(_objectTree.Area) != false) {
-            for (int i = 0; i < _areas.Count; i++) {
-                var area = _areas[i];
-                if (area != null && (filterType == null || area.IsSubtypeOf(filterType)))
-                    yield return area;
+            foreach (var area in _refManager.EnumerateType(RefType.DreamObjectArea)) {
+                if (filterType == null || area.IsSubtypeOf(filterType))
+                    yield return (DreamObjectArea)area;
             }
         }
 
         if (filterType?.IsSubtypeOf(_objectTree.Turf) != false) {
-            for (int i = 0; i < _turfs.Count; i++) {
-                var turf = _turfs[i];
-                if (turf != null && (filterType == null || turf.IsSubtypeOf(filterType)))
-                    yield return turf;
+            foreach (var turf in _refManager.EnumerateType(RefType.DreamObjectTurf)) {
+                if (filterType == null || turf.IsSubtypeOf(filterType))
+                    yield return (DreamObjectTurf)turf;
             }
-        }
-    }
-    // ReSharper restore ForCanBeConvertedToForeach
-
-    public void AddAtom(DreamObjectAtom atom) {
-        AtomCount++;
-
-        switch (atom) {
-            case DreamObjectArea area: {
-                var nextSlot = _nextEmptyAreaSlot++;
-                if (nextSlot >= _areas.Count) {
-                    _areas.Add(area);
-                    return;
-                }
-
-                _areas[nextSlot] = area;
-                for (; _nextEmptyAreaSlot < _areas.Count; _nextEmptyAreaSlot++) {
-                    if (_areas[_nextEmptyAreaSlot] == null)
-                        break;
-                }
-
-                break;
-            }
-            case DreamObjectTurf turf: {
-                var nextSlot = _nextEmptyTurfSlot++;
-                if (nextSlot >= _turfs.Count) {
-                    _turfs.Add(turf);
-                    return;
-                }
-
-                _turfs[nextSlot] = turf;
-                for (; _nextEmptyTurfSlot < _turfs.Count; _nextEmptyTurfSlot++) {
-                    if (_turfs[_nextEmptyTurfSlot] == null)
-                        break;
-                }
-
-                break;
-            }
-            case DreamObjectMob mob: {
-                var nextSlot = _nextEmptyMobSlot++;
-                if (nextSlot >= _mobs.Count) {
-                    _mobs.Add(mob);
-                    return;
-                }
-
-                _mobs[nextSlot] = mob;
-                for (; _nextEmptyMobSlot < _mobs.Count; _nextEmptyMobSlot++) {
-                    if (_mobs[_nextEmptyMobSlot] == null)
-                        break;
-                }
-
-                break;
-            }
-            case DreamObjectMovable movable: {
-                var nextSlot = _nextEmptyMovableSlot++;
-                if (nextSlot >= _movables.Count) {
-                    _movables.Add(movable);
-                    return;
-                }
-
-                _movables[nextSlot] = movable;
-                for (; _nextEmptyMovableSlot < _movables.Count; _nextEmptyMovableSlot++) {
-                    if (_movables[_nextEmptyMovableSlot] == null)
-                        break;
-                }
-
-                break;
-            }
-        }
-    }
-
-    public void RemoveAtom(DreamObjectAtom atom) {
-        AtomCount--;
-
-        int index;
-        switch (atom) {
-            case DreamObjectArea area:
-                index = _areas.IndexOf(area);
-                if (index == -1)
-                    return;
-
-                _nextEmptyAreaSlot = Math.Min(_nextEmptyAreaSlot, index);
-                _areas[index] = null;
-                break;
-            case DreamObjectTurf turf:
-                index = _turfs.IndexOf(turf);
-                if (index == -1)
-                    return;
-
-                _nextEmptyTurfSlot = Math.Min(_nextEmptyTurfSlot, index);
-                _turfs[index] = null;
-                break;
-            case DreamObjectMob mob:
-                index = _mobs.IndexOf(mob);
-                if (index == -1)
-                    return;
-
-                _nextEmptyMobSlot = Math.Min(_nextEmptyMobSlot, index);
-                _mobs[index] = null;
-                break;
-            case DreamObjectMovable movable:
-                index = _movables.IndexOf(movable);
-                if (index == -1)
-                    return;
-
-                _nextEmptyMovableSlot = Math.Min(_nextEmptyMovableSlot, index);
-                _movables[index] = null;
-                break;
         }
     }
 
@@ -565,7 +455,7 @@ public sealed class AtomManager {
                 var lays = varName == "overlays" ? appearance.Overlays : appearance.Underlays;
                 var list = _objectTree.CreateList(lays.Length);
 
-                if (_appearanceSystem != null) {
+                if (AppearanceSystem != null) {
                     foreach (var lay in lays) {
                         list.AddValue(new(lay.ToMutable()));
                     }

--- a/OpenDreamRuntime/ByondApi/ByondApi.Functions.cs
+++ b/OpenDreamRuntime/ByondApi/ByondApi.Functions.cs
@@ -110,7 +110,7 @@ public static unsafe partial class ByondApi {
         }
 
         return RunOnMainThread(() => {
-            var strId = _dreamManager!.FindString(str);
+            var strId = _refManager!.FindStringId(str);
             if (strId != null) {
                 return strId.Value;
             }
@@ -137,7 +137,7 @@ public static unsafe partial class ByondApi {
         }
 
         return RunOnMainThread(() => {
-            var strIdx = _dreamManager!.FindOrAddString(str);
+            var strIdx = _refManager!.GetRef(str);
             return strIdx;
         });
     }
@@ -195,7 +195,7 @@ public static unsafe partial class ByondApi {
 
         return RunOnMainThread<byte>(() => {
             try {
-                DreamValue varNameVal = _dreamManager!.RefToValue(RefType.String, (int)varname);
+                DreamValue varNameVal = _refManager!.LocateRef((uint)RefType.String | varname);
                 if (!varNameVal.TryGetValueAsString(out var varName))
                     return SetLastError("varname argument was an invalid string ID");
 
@@ -264,7 +264,7 @@ public static unsafe partial class ByondApi {
     private static byte Byond_WriteVarByStrId(CByondValue* loc, uint varname, CByondValue* val) {
         return RunOnMainThread<byte>(() => {
             try {
-                DreamValue varNameVal = _dreamManager!.RefToValue(RefType.String, (int)varname);
+                DreamValue varNameVal = _refManager!.LocateRef((uint)RefType.String | varname);
                 if (!varNameVal.TryGetValueAsString(out var varName))
                     return SetLastError("varname argument was an invalid string ID");
 
@@ -590,7 +590,7 @@ public static unsafe partial class ByondApi {
 
         return RunOnMainThread(() => {
             try {
-                DreamValue procNameVal = _dreamManager!.RefToValue(RefType.String, (int)name);
+                DreamValue procNameVal = _refManager!.LocateRef((uint)RefType.String | name);
                 if (!procNameVal.TryGetValueAsString(out var procName))
                     return SetLastError("name argument was an invalid string ID");
 
@@ -659,10 +659,10 @@ public static unsafe partial class ByondApi {
 
         return RunOnMainThread<byte>(() => {
             try {
-                DreamValue procNameVal = _dreamManager!.RefToValue(RefType.String, (int)name);
+                DreamValue procNameVal = _refManager!.LocateRef((uint)RefType.String | name);
                 if (!procNameVal.TryGetValueAsString(out var procName))
                     return SetLastError("name argument was an invalid string ID");
-                if (!_dreamManager.TryGetGlobalProc(procName, out var proc))
+                if (!_dreamManager!.TryGetGlobalProc(procName, out var proc))
                     return SetLastError($"no global proc named \"{procName}\"");
 
                 CallProcShared(null, proc, cArgs, arg_count, cResult);

--- a/OpenDreamRuntime/ByondApi/ByondApi.cs
+++ b/OpenDreamRuntime/ByondApi/ByondApi.cs
@@ -12,6 +12,7 @@ public static partial class ByondApi {
     private const int LastErrorMaxLength = 128;
 
     private static DreamManager? _dreamManager;
+    private static DreamRefManager? _refManager;
     private static AtomManager? _atomManager;
     private static IDreamMapManager? _dreamMapManager;
     private static DreamObjectTree? _objectTree;
@@ -26,10 +27,11 @@ public static partial class ByondApi {
 
     private static IntPtr _lastErrorPtr = IntPtr.Zero;
 
-    public static void Initialize(DreamManager dreamManager, AtomManager atomManager, IDreamMapManager dreamMapManager, DreamObjectTree objectTree) {
+    public static void Initialize(DreamManager dreamManager, DreamRefManager dreamRefManager, AtomManager atomManager, IDreamMapManager dreamMapManager, DreamObjectTree objectTree) {
         DebugTools.Assert(_dreamManager is null or { IsShutDown: true });
 
         _dreamManager = dreamManager;
+        _refManager = dreamRefManager;
         _atomManager = atomManager;
         _dreamMapManager = dreamMapManager;
         _objectTree = objectTree;
@@ -90,32 +92,7 @@ public static partial class ByondApi {
             case ByondValueType.Appearance:
             case ByondValueType.World:
             case ByondValueType.Proc:
-                var refType = ctype switch {
-                    ByondValueType.Turf => RefType.DreamObjectTurf,
-                    ByondValueType.Obj => RefType.DreamObject,
-                    ByondValueType.Mob => RefType.DreamObjectMob,
-                    ByondValueType.Area => RefType.DreamObjectArea,
-                    ByondValueType.Client => RefType.DreamObjectClient,
-                    ByondValueType.Image => RefType.DreamObjectImage,
-                    ByondValueType.List => RefType.DreamObjectList,
-                    ByondValueType.Datum => RefType.DreamObjectDatum,
-                    ByondValueType.World => RefType.DreamObjectDatum,
-                    ByondValueType.String => RefType.String,
-                    ByondValueType.Resource => RefType.DreamResource,
-                    ByondValueType.Appearance => RefType.DreamAppearance,
-                    ByondValueType.Proc => RefType.Proc,
-
-                    ByondValueType.ObjTypePath or
-                    ByondValueType.MobTypePath or
-                    ByondValueType.TurfTypePath or
-                    ByondValueType.DatumTypePath or
-                    ByondValueType.AreaTypePath => RefType.DreamType,
-
-                    _ => throw new Exception($"Invalid reference type for type {ctype.ToString()}")
-                };
-
-                int refId = (int)cdata.@ref;
-                return _dreamManager!.RefToValue(refType, refId);
+                return _refManager!.LocateRef(cdata.@ref);
         }
     }
 
@@ -135,57 +112,26 @@ public static partial class ByondApi {
             case DreamValue.DreamValueType.DreamType:
             case DreamValue.DreamValueType.Appearance:
             case DreamValue.DreamValueType.DreamProc:
-                var refId = _dreamManager!.GetRefId(value, out var refType);
-                ByondValueType type;
-                ByondValueData data = new ByondValueData { @ref = refId };
-
-                switch (refType) {
-                    default:
-                        throw new Exception($"Invalid reference type for type {refType}");
-                    case RefType.Null:
-                        type = ByondValueType.Null;
-                        break;
-                    case RefType.DreamObjectTurf:
-                        type = ByondValueType.Turf;
-                        break;
-                    case RefType.DreamObject:
-                        type = ByondValueType.Obj;
-                        break;
-                    case RefType.DreamObjectMob:
-                        type = ByondValueType.Mob;
-                        break;
-                    case RefType.DreamObjectArea:
-                        type = ByondValueType.Area;
-                        break;
-                    case RefType.DreamObjectClient:
-                        type = ByondValueType.Client;
-                        break;
-                    case RefType.DreamObjectImage:
-                        type = ByondValueType.Image;
-                        break;
-                    case RefType.DreamObjectList:
-                        type = ByondValueType.List;
-                        break;
-                    case RefType.DreamObjectDatum:
-                        type = ByondValueType.Datum;
-                        break;
-                    case RefType.String:
-                        type = ByondValueType.String;
-                        break;
-                    case RefType.DreamResource:
-                        type = ByondValueType.Resource;
-                        break;
-                    case RefType.DreamType:
-                        // just assume objtypepath for now?
-                        type = ByondValueType.ObjTypePath;
-                        break;
-                    case RefType.DreamAppearance:
-                        type = ByondValueType.Appearance;
-                        break;
-                    case RefType.Proc:
-                        type = ByondValueType.Proc;
-                        break;
-                }
+                var @ref = _refManager!.GetRef(value);
+                var refType = (RefType)(@ref & DreamRefManager.RefTypeMask);
+                var data = new ByondValueData { @ref = @ref };
+                var type = refType switch {
+                    RefType.Null => ByondValueType.Null,
+                    RefType.DreamObjectTurf => ByondValueType.Turf,
+                    RefType.DreamObjectMovable => ByondValueType.Obj,
+                    RefType.DreamObjectMob => ByondValueType.Mob,
+                    RefType.DreamObjectArea => ByondValueType.Area,
+                    RefType.DreamObjectClient => ByondValueType.Client,
+                    RefType.DreamObjectImage => ByondValueType.Image,
+                    RefType.DreamObjectList => ByondValueType.List,
+                    RefType.DreamObjectDatum => ByondValueType.Datum,
+                    RefType.String => ByondValueType.String,
+                    RefType.DreamResource => ByondValueType.Resource,
+                    RefType.DreamType => ByondValueType.ObjTypePath, // just assume objtypepath for now?
+                    RefType.DreamAppearance => ByondValueType.Appearance,
+                    RefType.Proc => ByondValueType.Proc,
+                    _ => throw new Exception($"Invalid reference type for type {refType}")
+                };
 
                 return new CByondValue {
                     data = data,

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -16,6 +16,7 @@ namespace OpenDreamRuntime;
 
 public sealed class DreamConnection {
     [Dependency] private readonly DreamManager _dreamManager = default!;
+    [Dependency] private readonly DreamRefManager _refManager = default!;
     [Dependency] private readonly DreamObjectTree _objectTree = default!;
     [Dependency] private readonly DreamResourceManager _resourceManager = default!;
     [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
@@ -233,7 +234,7 @@ public sealed class DreamConnection {
         DreamValue src = DreamValue.Null;
 
         if (srcRefValue.TryGetValueAsString(out var srcRef)) {
-            src = _dreamManager.LocateRef(srcRef);
+            src = _refManager.LocateRef(srcRef);
         }
 
         Client?.SpawnProc("Topic", usr: Mob, new(pTopic.Query), new(hrefList), src);

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
-using System.Threading;
 using DMCompiler.Bytecode;
 using DMCompiler.Json;
 using DMCompiler.Compiler;
@@ -11,9 +9,7 @@ using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.Native;
-using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
-using OpenDreamRuntime.Util;
 using OpenDreamShared;
 using OpenDreamShared.Dream;
 using Robust.Server;
@@ -33,14 +29,11 @@ public sealed partial class DreamManager {
     // Global state that may not really (really really) belong here
     public DreamValue[] Globals { get; set; } = Array.Empty<DreamValue>();
     public List<string> GlobalNames { get; private set; } = new();
-    public ConcurrentDictionary<int, WeakDreamRef> ReferenceIDsToDreamObject { get; } = new();
     public HashSet<DreamObject> Clients { get; } = new();
 
-    // I solemnly swear this benefits from being a linked list (constant remove times without relying on object hash) --kaylie
-    public LinkedList<WeakDreamRef> Datums { get; } = new();
     public readonly ConcurrentBag<DreamObject> DelQueue = new();
+    public readonly HashSet<uint> RefDeleteQueue = new();
     public Random Random { get; set; } = new();
-    public Dictionary<string, List<DreamObject>> Tags { get; } = new();
     public DreamProc ImageConstructor, ImageFactoryProc;
     public int ListPoolThreshold, ListPoolSize;
     public Dictionary<WarningCode, ErrorLevel> OptionalErrors { get; private set; } = new();
@@ -55,9 +48,9 @@ public sealed partial class DreamManager {
     public long CurrentTickStart { get; private set; }
 
     private ISawmill _sawmill = default!;
-    private int _dreamObjectRefIdCounter;
 
     [Dependency] private readonly AtomManager _atomManager = default!;
+    [Dependency] private readonly DreamRefManager _refManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
     [Dependency] private readonly ProcScheduler _procScheduler = default!;
@@ -66,16 +59,13 @@ public sealed partial class DreamManager {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly DreamObjectTree _objectTree = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
-    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-
-    private ServerAppearanceSystem? _appearanceSystem;
 
     //TODO This arg is awful and temporary until RT supports cvar overrides in unit tests
     public void PreInitialize(string? jsonPath) {
         _sawmill = Logger.GetSawmill("opendream");
         ListPoolThreshold = _config.GetCVar(OpenDreamCVars.ListPoolThreshold);
         ListPoolSize = _config.GetCVar(OpenDreamCVars.ListPoolSize);
-        ByondApi.ByondApi.Initialize(this, _atomManager, _dreamMapManager, _objectTree);
+        ByondApi.ByondApi.Initialize(this, _refManager, _atomManager, _dreamMapManager, _objectTree);
 
         InitializeConnectionManager();
         _dreamResourceManager.PreInitialize();
@@ -140,12 +130,6 @@ public sealed partial class DreamManager {
         }
 
         Profiler.EmitFrameMark();
-    }
-
-    public void ProcessDelQueue() {
-        while (DelQueue.TryTake(out var obj)) {
-            obj.Delete();
-        }
     }
 
     public bool TryGetGlobalProc(string name, [NotNullWhen(true)] out DreamProc? proc) {
@@ -214,209 +198,6 @@ public sealed partial class DreamManager {
         }
     }
 
-    public uint FindOrAddString(string str) {
-        var idx = FindString(str);
-        if (idx == null) {
-            _objectTree.Strings.Add(str);
-            idx = (uint)(_objectTree.Strings.Count - 1);
-        }
-
-        return (uint)idx;
-    }
-
-    public uint? FindString(string str) {
-        int idx = _objectTree.Strings.IndexOf(str);
-
-        if (idx < 0) {
-            return null;
-        }
-
-        return (uint)idx;
-    }
-
-    public string CreateRef(DreamValue value) {
-        var refId = GetRefId(value, out var refType);
-
-        // refType combines with the highest byte. This could produce an invalid ref, but that's BYOND behavior too.
-        var combined = (uint)refType | refId;
-        return $"[0x{combined:x}]";
-    }
-
-    public uint GetRefId(DreamValue value, out RefType refType) {
-        int idx;
-
-        if (value.TryGetValueAsDreamObject(out var refObject)) {
-            if (refObject == null) {
-                refType = RefType.Null;
-                idx = 0;
-            } else {
-                if (refObject.Deleted) {
-                    // i dont believe this will **ever** be called, but just to be sure, funky errors /might/ appear in the future if someone does a fucky wucky and calls this on a deleted object.
-                    throw new Exception("Cannot create reference ID for an object that is deleted");
-                }
-
-                switch (refObject) {
-                    case DreamObjectTurf: refType = RefType.DreamObjectTurf; break;
-                    case DreamObjectMob: refType = RefType.DreamObjectMob; break;
-                    case DreamObjectArea: refType = RefType.DreamObjectArea; break;
-                    case DreamObjectClient: refType = RefType.DreamObjectArea; break;
-                    case DreamObjectImage: refType = RefType.DreamObjectImage; break;
-                    case DreamObjectFilter: refType = RefType.DreamObjectFilter; break;
-                    default: {
-                        refType = RefType.DreamObjectDatum;
-                        if (refObject.IsSubtypeOf(_objectTree.Obj))
-                            refType = RefType.DreamObject;
-                        else if (refObject.GetType() == typeof(DreamList))
-                            refType = RefType.DreamObjectList;
-                        break;
-                    }
-                }
-
-                if (refObject.RefId is not { } id) {
-                    idx = Interlocked.Increment(ref _dreamObjectRefIdCounter);
-                    refObject.RefId = idx;
-
-                    // SAFETY: Infallible! idx is always unique and add can only fail if this is not the case.
-                    ReferenceIDsToDreamObject.TryAdd(idx, new WeakDreamRef(refObject));
-                } else {
-                    idx = id;
-                }
-            }
-        } else if (value.TryGetValueAsString(out var refStr)) {
-            refType = RefType.String;
-            idx = _objectTree.Strings.IndexOf(refStr);
-
-            if (idx == -1) {
-                _objectTree.Strings.Add(refStr);
-                idx = _objectTree.Strings.Count - 1;
-            }
-        } else if (value.TryGetValueAsType(out var type)) {
-            refType = RefType.DreamType;
-            idx = type.Id;
-        } else if (value.TryGetValueAsAppearance(out var appearance)) {
-            refType = RefType.DreamAppearance;
-            _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
-            idx = (int)_appearanceSystem.AddAppearance(appearance).MustGetId();
-        } else if (value.TryGetValueAsDreamResource(out var refRsc)) {
-            refType = RefType.DreamResource;
-            idx = refRsc.Id;
-        } else if (value.TryGetValueAsProc(out var proc)) {
-            refType = RefType.Proc;
-            idx = proc.Id;
-        } else if (value.TryGetValueAsFloat(out var floatValue)) {
-            refType = RefType.Number;
-
-            // Yes, this combines with the refType and produces an invalid ref.
-            // This is BYOND behavior (as of writing at least, on 516.1661).
-            idx = BitConverter.SingleToInt32Bits(floatValue);
-        } else {
-            throw new NotImplementedException($"Ref for {value} is unimplemented");
-        }
-
-        return (uint)idx;
-    }
-
-    /// <summary>
-    /// Iterates the list of datums
-    /// </summary>
-    /// <returns>Datum enumerator</returns>
-    /// <remarks>As it's a convenient time, this will collect any dead datum refs as it finds them.</remarks>
-    public IEnumerable<DreamObject> IterateDatums() {
-        // This isn't a common operation so we'll use this time to also do some pruning.
-        var node = Datums.First;
-
-        while (node is not null) {
-            var next = node.Next;
-            var val = node.Value.Target;
-            if (val is null)
-                Datums.Remove(node);
-            else
-                yield return val;
-            node = next;
-        }
-    }
-
-    public DreamValue RefToValue(int rawRef) {
-        // The first one/two digits give the type, the last 6 give the index
-        var refType = (RefType)(rawRef & 0xFF000000);
-        var refId = (rawRef & 0x00FFFFFF); // The ref minus its ref type prefix
-
-        return RefToValue(refType, refId);
-    }
-
-    public DreamValue RefToValue(RefType refType, int refId) {
-        switch (refType) {
-            case RefType.Null:
-                return DreamValue.Null;
-            case RefType.DreamObjectArea:
-            case RefType.DreamObjectClient:
-            case RefType.DreamObjectDatum:
-            case RefType.DreamObjectImage:
-            case RefType.DreamObjectFilter:
-            case RefType.DreamObjectList:
-            case RefType.DreamObjectMob:
-            case RefType.DreamObjectTurf:
-            case RefType.DreamObject:
-                if (ReferenceIDsToDreamObject.TryGetValue(refId, out var weakRef) && weakRef.Target is { } dreamObject)
-                    return new(dreamObject);
-
-                return DreamValue.Null;
-            case RefType.String:
-                return _objectTree.Strings.Count > refId
-                    ? new DreamValue(_objectTree.Strings[refId])
-                    : DreamValue.Null;
-            case RefType.DreamType:
-                return _objectTree.Types.Length > refId
-                    ? new DreamValue(_objectTree.Types[refId])
-                    : DreamValue.Null;
-            case RefType.DreamResourceIcon: // Alias of DreamResource for now. TODO: Does this *only* contain icon resources?
-            case RefType.DreamResource:
-                if (!_dreamResourceManager.TryLoadResource(refId, out var resource))
-                    return DreamValue.Null;
-
-                return new DreamValue(resource);
-            case RefType.DreamAppearance:
-                _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
-                return _appearanceSystem.TryGetAppearanceById((uint)refId, out ImmutableAppearance? appearance)
-                    ? new DreamValue(appearance.ToMutable())
-                    : DreamValue.Null;
-            case RefType.Proc:
-                return _objectTree.Procs.Count > refId
-                    ? new DreamValue(_objectTree.Procs[refId])
-                    : DreamValue.Null;
-            case RefType.Number: // For the oh so few numbers this works with (most numbers clobber the ref type)
-                return new(BitConverter.Int32BitsToSingle(refId));
-            default:
-                throw new Exception($"Invalid reference type for ref [0x{refId:x}]");
-        }
-    }
-
-    public DreamValue LocateRef(string refString) {
-        bool canBePointer = false;
-
-        if (refString.StartsWith('[') && refString.EndsWith(']')) {
-            // Strip the surrounding []
-            refString = refString.Substring(1, refString.Length - 2);
-
-            // This ref could possibly be a "pointer" (the hex number made up of an id and an index)
-            canBePointer = refString.StartsWith("0x");
-        }
-
-        if (canBePointer && int.TryParse(refString.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out var refId)) {
-            return RefToValue(refId);
-        }
-
-        // Search for an object with this ref as its tag
-        // Note that surrounding [] are stripped out at this point, this is intentional
-        // Doing locate("[abc]") is the same as locate("abc")
-        if (Tags.TryGetValue(refString, out var tagList)) {
-            return new DreamValue(tagList.First());
-        }
-
-        // Nothing found
-        return DreamValue.Null;
-    }
-
     public DreamObject? GetFromClientReference(DreamConnection connection, ClientObjectReference reference) {
         switch (reference.Type) {
             case ClientObjectReference.RefType.Client:
@@ -473,24 +254,18 @@ public sealed partial class DreamManager {
             throw exception;
         }
     }
-}
 
-public enum RefType : uint {
-    Null = 0x0,
-    DreamObjectTurf = 0x1000000,
-    DreamObject = 0x2000000,
-    DreamObjectMob = 0x3000000,
-    DreamObjectArea = 0x4000000,
-    DreamObjectClient = 0x5000000,
-    DreamResourceIcon = 0xC000000,
-    DreamObjectImage = 0xD000000,
-    DreamObjectList = 0xF000000,
-    DreamObjectDatum = 0x21000000,
-    String = 0x6000000,
-    DreamType = 0x9000000, //in byond type is from 0x8 to 0xb, but fuck that
-    DreamResource = 0x27000000, //Equivalent to file
-    DreamAppearance = 0x3A000000,
-    Proc = 0x26000000,
-    Number = 0x2A000000,
-    DreamObjectFilter = 0x53000000
+    private void ProcessDelQueue() {
+        lock (RefDeleteQueue) {
+            foreach (var refId in RefDeleteQueue) {
+                _refManager.DeleteRef(refId);
+            }
+
+            RefDeleteQueue.Clear();
+        }
+
+        while (DelQueue.TryTake(out var obj)) {
+            obj.Delete();
+        }
+    }
 }

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -155,6 +155,9 @@ public sealed partial class DreamManager {
         var resources = json.Resources ?? Array.Empty<string>();
         _dreamResourceManager.Initialize(rootPath, resources, json.Interface);
 
+        DelQueue.Clear();
+        RefDeleteQueue.Clear();
+        _refManager.Initialize();
         _objectTree.LoadJson(json);
         DreamProcNative.SetupNativeProcs(_objectTree);
         ImageConstructor = _objectTree.Image.ObjectDefinition.GetProc("New");

--- a/OpenDreamRuntime/Input/MouseInputSystem.cs
+++ b/OpenDreamRuntime/Input/MouseInputSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using OpenDreamRuntime.Map;
+using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Input;
@@ -10,6 +11,7 @@ namespace OpenDreamRuntime.Input;
 internal sealed class MouseInputSystem : SharedMouseInputSystem {
     [Dependency] private readonly AtomManager _atomManager = default!;
     [Dependency] private readonly DreamManager _dreamManager = default!;
+    [Dependency] private readonly DreamRefManager _refManager = default!;
     [Dependency] private readonly IDreamMapManager _mapManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -68,7 +70,7 @@ internal sealed class MouseInputSystem : SharedMouseInputSystem {
     }
 
     private void OnStatClicked(StatClickedEvent e, EntitySessionEventArgs sessionEvent) {
-        if (!_dreamManager.LocateRef(e.AtomRef).TryGetValueAsDreamObject<DreamObjectAtom>(out var dreamObject))
+        if (!_refManager.LocateRef(e.AtomRef).TryGetValueAsDreamObject<DreamObjectAtom>(out var dreamObject))
             return;
 
         HandleAtomClick(e, dreamObject, sessionEvent);

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -15,554 +15,554 @@ using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
 
-namespace OpenDreamRuntime.Objects {
-    [Virtual]
-    public class DreamObject {
-        public DreamObjectDefinition ObjectDefinition;
+namespace OpenDreamRuntime.Objects;
 
-        [Access(typeof(DreamObject))]
-        public bool Deleted;
+[Virtual]
+public class DreamObject {
+    public DreamObjectDefinition ObjectDefinition;
 
-        [Access(typeof(DreamManager), typeof(DreamObject))]
-        public int? RefId;
+    [Access(typeof(DreamObject))]
+    public bool Deleted;
 
-        public virtual bool ShouldCallNew => true;
+    [Access(typeof(DreamManager), typeof(DreamObject))]
+    public int? RefId;
 
-        // Shortcuts to IoC dependencies & entity systems
-        protected DreamManager DreamManager => ObjectDefinition.DreamManager;
-        protected DreamObjectTree ObjectTree => ObjectDefinition.ObjectTree;
-        protected AtomManager AtomManager => ObjectDefinition.AtomManager;
-        protected IDreamMapManager DreamMapManager => ObjectDefinition.DreamMapManager;
-        protected IMapManager MapManager => ObjectDefinition.MapManager;
-        protected DreamResourceManager DreamResourceManager => ObjectDefinition.DreamResourceManager;
-        protected WalkManager WalkManager => ObjectDefinition.WalkManager;
-        protected IEntityManager EntityManager => ObjectDefinition.EntityManager;
-        protected IPlayerManager PlayerManager => ObjectDefinition.PlayerManager;
-        protected ISerializationManager SerializationManager => ObjectDefinition.SerializationManager;
-        protected ServerAppearanceSystem? AppearanceSystem => ObjectDefinition.AppearanceSystem;
-        protected TransformSystem? TransformSystem => ObjectDefinition.TransformSystem;
-        protected PvsOverrideSystem? PvsOverrideSystem => ObjectDefinition.PvsOverrideSystem;
-        protected MetaDataSystem? MetaDataSystem => ObjectDefinition.MetaDataSystem;
-        protected ServerVerbSystem? VerbSystem => ObjectDefinition.VerbSystem;
-        protected ServerDreamParticlesSystem? ParticlesSystem => ObjectDefinition.ParticlesSystem;
+    public virtual bool ShouldCallNew => true;
 
-        protected Dictionary<string, DreamValue>? Variables;
+    // Shortcuts to IoC dependencies & entity systems
+    protected DreamManager DreamManager => ObjectDefinition.DreamManager;
+    protected DreamObjectTree ObjectTree => ObjectDefinition.ObjectTree;
+    protected AtomManager AtomManager => ObjectDefinition.AtomManager;
+    protected IDreamMapManager DreamMapManager => ObjectDefinition.DreamMapManager;
+    protected IMapManager MapManager => ObjectDefinition.MapManager;
+    protected DreamResourceManager DreamResourceManager => ObjectDefinition.DreamResourceManager;
+    protected WalkManager WalkManager => ObjectDefinition.WalkManager;
+    protected IEntityManager EntityManager => ObjectDefinition.EntityManager;
+    protected IPlayerManager PlayerManager => ObjectDefinition.PlayerManager;
+    protected ISerializationManager SerializationManager => ObjectDefinition.SerializationManager;
+    protected ServerAppearanceSystem? AppearanceSystem => ObjectDefinition.AppearanceSystem;
+    protected TransformSystem? TransformSystem => ObjectDefinition.TransformSystem;
+    protected PvsOverrideSystem? PvsOverrideSystem => ObjectDefinition.PvsOverrideSystem;
+    protected MetaDataSystem? MetaDataSystem => ObjectDefinition.MetaDataSystem;
+    protected ServerVerbSystem? VerbSystem => ObjectDefinition.VerbSystem;
+    protected ServerDreamParticlesSystem? ParticlesSystem => ObjectDefinition.ParticlesSystem;
 
-        #if TOOLS
+    protected Dictionary<string, DreamValue>? Variables;
+
+#if TOOLS
         protected ProfilerMemory? TracyMemoryId;
-        #endif
+#endif
 
-        //handle to the list of vars on this object so that it's only created once and refs to object.vars are consistent
-        private DreamListVars? _varsList;
+    //handle to the list of vars on this object so that it's only created once and refs to object.vars are consistent
+    private DreamListVars? _varsList;
 
-        private string? Tag {
-            get => _tag;
-            set {
-                // Even if we're setting it to the same string we still need to remove it
-                if (!string.IsNullOrEmpty(_tag)) {
-                    var list = ObjectDefinition.DreamManager.Tags[_tag];
+    private string? Tag {
+        get => _tag;
+        set {
+            // Even if we're setting it to the same string we still need to remove it
+            if (!string.IsNullOrEmpty(_tag)) {
+                var list = ObjectDefinition.DreamManager.Tags[_tag];
 
-                    if (list.Count > 1) {
-                        list.Remove(this);
-                    } else {
-                        ObjectDefinition.DreamManager.Tags.Remove(_tag);
-                    }
+                if (list.Count > 1) {
+                    list.Remove(this);
+                } else {
+                    ObjectDefinition.DreamManager.Tags.Remove(_tag);
                 }
+            }
 
-                _tag = value;
+            _tag = value;
 
-                // Now we add it (if it's a string)
-                if (!string.IsNullOrEmpty(_tag)) {
-                    if (ObjectDefinition.DreamManager.Tags.TryGetValue(_tag, out var list)) {
-                        list.Add(this);
-                    } else {
-                        var newList = new List<DreamObject> {
-                            this
-                        };
+            // Now we add it (if it's a string)
+            if (!string.IsNullOrEmpty(_tag)) {
+                if (ObjectDefinition.DreamManager.Tags.TryGetValue(_tag, out var list)) {
+                    list.Add(this);
+                } else {
+                    var newList = new List<DreamObject> {
+                        this
+                    };
 
-                        ObjectDefinition.DreamManager.Tags.Add(_tag, newList);
-                    }
+                    ObjectDefinition.DreamManager.Tags.Add(_tag, newList);
                 }
             }
         }
-        private string? _tag;
+    }
+    private string? _tag;
 
-        public DreamObject(DreamObjectDefinition objectDefinition) {
-            ObjectDefinition = objectDefinition;
+    public DreamObject(DreamObjectDefinition objectDefinition) {
+        ObjectDefinition = objectDefinition;
 
-            // Atoms are in world.contents
-            if (this is not DreamObjectAtom && IsSubtypeOf(ObjectTree.Datum)) {
-                ObjectDefinition.DreamManager.Datums.AddLast(new WeakDreamRef(this));
-            }
+        // Atoms are in world.contents
+        if (this is not DreamObjectAtom && IsSubtypeOf(ObjectTree.Datum)) {
+            ObjectDefinition.DreamManager.Datums.AddLast(new WeakDreamRef(this));
+        }
 
-            #if TOOLS
+#if TOOLS
              //if it's not null, subclasses have done their own allocation
             TracyMemoryId ??= Profiler.BeginMemoryZone((ulong)(Unsafe.SizeOf<DreamObject>() + ObjectDefinition.Variables.Count * Unsafe.SizeOf<DreamValue>() ), "/datum");
-            #endif
-        }
+#endif
+    }
 
-        public virtual void Initialize(DreamProcArguments args) {
-            // For subtypes to implement
-        }
+    public virtual void Initialize(DreamProcArguments args) {
+        // For subtypes to implement
+    }
 
-        protected virtual void HandleDeletion(bool possiblyThreaded) {
-            // Atoms are in world.contents
-            // Datum removal used to live here, but datums are now tracked weakly.
+    protected virtual void HandleDeletion(bool possiblyThreaded) {
+        // Atoms are in world.contents
+        // Datum removal used to live here, but datums are now tracked weakly.
 
-            if (RefId is not null)
-                DreamManager.ReferenceIDsToDreamObject.Remove(RefId.Value, out _);
+        if (RefId is not null)
+            DreamManager.ReferenceIDsToDreamObject.Remove(RefId.Value, out _);
 
-            Tag = null;
-            Deleted = true;
-            //we release all relevant information, making this a very tiny object
-            Variables = null;
-            _varsList?.Delete(possiblyThreaded);
-            _varsList = null;
+        Tag = null;
+        Deleted = true;
+        //we release all relevant information, making this a very tiny object
+        Variables = null;
+        _varsList?.Delete(possiblyThreaded);
+        _varsList = null;
 
-            ObjectDefinition = null!;
+        ObjectDefinition = null!;
 
-            #if TOOLS
+#if TOOLS
             TracyMemoryId?.ReleaseMemory();
-            #endif
-        }
+#endif
+    }
 
-        /// <summary>
-        ///     Enters the current dream object into a global del queue that is guaranteed to run on the DM thread.
-        ///     Use if your deletion handler must be on the DM thread.
-        /// </summary>
-        protected void EnterIntoDelQueue() {
-            DreamManager.DelQueue.Add(this);
-        }
+    /// <summary>
+    ///     Enters the current dream object into a global del queue that is guaranteed to run on the DM thread.
+    ///     Use if your deletion handler must be on the DM thread.
+    /// </summary>
+    protected void EnterIntoDelQueue() {
+        DreamManager.DelQueue.Add(this);
+    }
 
-        /// <summary>
-        ///     Del() the object, cleaning up its variables and refs to minimize size until the .NET GC collects it.
-        /// </summary>
-        /// <param name="possiblyThreaded">If true, Delete() will be defensive and assume it may have been called from another thread by .NET</param>
-        public void Delete(bool possiblyThreaded = false) {
-            if (Deleted)
-                return;
+    /// <summary>
+    ///     Del() the object, cleaning up its variables and refs to minimize size until the .NET GC collects it.
+    /// </summary>
+    /// <param name="possiblyThreaded">If true, Delete() will be defensive and assume it may have been called from another thread by .NET</param>
+    public void Delete(bool possiblyThreaded = false) {
+        if (Deleted)
+            return;
 
-            if (TryGetProc("Del", out var delProc)) {
-                // SAFETY: See associated comment in Datum.dm. This relies on the invariant that this proc is in a
-                //         thread-safe subset of DM (if such a thing exists) or empty. Currently, it is empty.
-                var datumBaseProc = delProc is DMProc {Bytecode.Length: 0};
-                if (possiblyThreaded && !datumBaseProc) {
-                    EnterIntoDelQueue();
-                    return; //Whoops, cannot thread.
-                } else if (!datumBaseProc) {
-                    DreamThread.Run(delProc, this, null);
-                }
-            }
-
-            HandleDeletion(possiblyThreaded);
-        }
-
-        ~DreamObject() {
-            // Softdel, possibly.
-            Delete(true);
-        }
-
-        public bool IsSubtypeOf(TreeEntry ancestor) {
-            if(Deleted) //null deref protection, deleted objects don't have ObjectDefinition anymore
-                return false;
-            return ObjectDefinition.IsSubtypeOf(ancestor);
-        }
-
-        #region Variables
-        public virtual bool IsSaved(string name) {
-            return ObjectDefinition.Variables.ContainsKey(name)
-                && !ObjectDefinition.GlobalVariables.ContainsKey(name)
-                && !(ObjectDefinition.ConstVariables is not null && ObjectDefinition.ConstVariables.Contains(name))
-                && !(ObjectDefinition.TmpVariables is not null && ObjectDefinition.TmpVariables.Contains(name));
-        }
-
-        public bool HasVariable(string name) {
-            DebugTools.Assert(!Deleted, "Cannot call HasVariable() on a deleted object");
-
-            return ObjectDefinition.HasVariable(name);
-        }
-
-        public DreamValue GetVariable(string name) {
-            DebugTools.Assert(!Deleted, "Cannot call GetVariable() on a deleted object");
-
-            if (TryGetVariable(name, out DreamValue variableValue)) {
-                return variableValue;
-            } else {
-                throw new KeyNotFoundException($"Variable {name} doesn't exist");
+        if (TryGetProc("Del", out var delProc)) {
+            // SAFETY: See associated comment in Datum.dm. This relies on the invariant that this proc is in a
+            //         thread-safe subset of DM (if such a thing exists) or empty. Currently, it is empty.
+            var datumBaseProc = delProc is DMProc {Bytecode.Length: 0};
+            if (possiblyThreaded && !datumBaseProc) {
+                EnterIntoDelQueue();
+                return; //Whoops, cannot thread.
+            } else if (!datumBaseProc) {
+                DreamThread.Run(delProc, this, null);
             }
         }
 
-        public IEnumerable<string> GetVariableNames() {
-            DebugTools.Assert(!Deleted, "Cannot call GetVariableNames() on a deleted object");
+        HandleDeletion(possiblyThreaded);
+    }
 
-            return ObjectDefinition.Variables.Keys;
+    ~DreamObject() {
+        // Softdel, possibly.
+        Delete(true);
+    }
+
+    public bool IsSubtypeOf(TreeEntry ancestor) {
+        if(Deleted) //null deref protection, deleted objects don't have ObjectDefinition anymore
+            return false;
+        return ObjectDefinition.IsSubtypeOf(ancestor);
+    }
+
+    #region Variables
+    public virtual bool IsSaved(string name) {
+        return ObjectDefinition.Variables.ContainsKey(name)
+               && !ObjectDefinition.GlobalVariables.ContainsKey(name)
+               && !(ObjectDefinition.ConstVariables is not null && ObjectDefinition.ConstVariables.Contains(name))
+               && !(ObjectDefinition.TmpVariables is not null && ObjectDefinition.TmpVariables.Contains(name));
+    }
+
+    public bool HasVariable(string name) {
+        DebugTools.Assert(!Deleted, "Cannot call HasVariable() on a deleted object");
+
+        return ObjectDefinition.HasVariable(name);
+    }
+
+    public DreamValue GetVariable(string name) {
+        DebugTools.Assert(!Deleted, "Cannot call GetVariable() on a deleted object");
+
+        if (TryGetVariable(name, out DreamValue variableValue)) {
+            return variableValue;
+        } else {
+            throw new KeyNotFoundException($"Variable {name} doesn't exist");
         }
+    }
 
-        protected virtual bool TryGetVar(string varName, out DreamValue value) {
-            switch (varName) {
-                case "type":
-                    value = new(ObjectDefinition.TreeEntry);
-                    return true;
-                case "parent_type":
-                    if (ObjectDefinition.Parent != null)
-                        value = new(ObjectDefinition.Parent.TreeEntry);
-                    else
-                        value = DreamValue.Null;
+    public IEnumerable<string> GetVariableNames() {
+        DebugTools.Assert(!Deleted, "Cannot call GetVariableNames() on a deleted object");
 
-                    return true;
-                case "vars":
-                    _varsList ??= new DreamListVars(ObjectTree.List.ObjectDefinition, this);
-                    value = new(_varsList);
-                    return true;
-                case "tag":
-                    value = (Tag != null) ? new(Tag) : DreamValue.Null;
-                    return true;
-                default:
-                    return (Variables?.TryGetValue(varName, out value) is true) ||
-                     (ObjectDefinition.Variables.TryGetValue(varName, out value)) ||
-                        (ObjectDefinition.GlobalVariables.TryGetValue(varName, out var globalIndex)) && ObjectDefinition.DreamManager.Globals.TryGetValue(globalIndex, out value);
-            }
-        }
+        return ObjectDefinition.Variables.Keys;
+    }
 
-        protected virtual void SetVar(string varName, DreamValue value) {
-            switch (varName) {
-                case "type":
-                case "parent_type":
-                case "vars":
-                    throw new Exception($"Cannot set var \"{varName}\"");
-                case "tag":
-                    value.TryGetValueAsString(out var newTag);
-
-                    Tag = newTag;
-                    break;
-                default:
-                    if (ObjectDefinition.ConstVariables is not null && ObjectDefinition.ConstVariables.Contains(varName))
-                        throw new Exception($"Cannot set const var \"{varName}\" on {ObjectDefinition.Type}");
-                    if (!ObjectDefinition.Variables.ContainsKey(varName))
-                        throw new Exception($"Cannot set var \"{varName}\" on {ObjectDefinition.Type}");
-
-                    SetVariableValue(varName, value);
-                    break;
-            }
-        }
-
-        public bool TryGetVariable(string name, out DreamValue variableValue) {
-            DebugTools.Assert(!Deleted, "Cannot call TryGetVariable() on a deleted object");
-
-            return TryGetVar(name, out variableValue);
-        }
-
-        /// <summary>
-        /// Handles setting a variable, and special behavior by calling OnVariableSet()
-        /// </summary>
-        public void SetVariable(string name, DreamValue value) {
-            DebugTools.Assert(!Deleted, "Cannot call SetVariable() on a deleted object");
-
-            SetVar(name, value);
-        }
-
-        /// <summary>
-        /// Directly sets a variable's value, bypassing any special behavior
-        /// </summary>
-        /// <returns>The OLD variable value</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetVariableValue(string name, DreamValue value) {
-            DebugTools.Assert(!Deleted, "Cannot call SetVariableValue() on a deleted object");
-
-            Variables ??= new(4);
-            Variables[name] = value;
-        }
-        #endregion Variables
-
-        #region Proc Helpers
-        public DreamProc GetProc(string procName) {
-            DebugTools.Assert(!Deleted, "Cannot call GetProc() on a deleted object");
-
-            return ObjectDefinition.GetProc(procName);
-        }
-
-        public bool TryGetProc(string procName, [NotNullWhen(true)] out DreamProc? proc) {
-            DebugTools.Assert(!Deleted, "Cannot call TryGetProc() on a deleted object");
-
-            return ObjectDefinition.TryGetProc(procName, out proc);
-        }
-
-        public void InitSpawn(DreamProcArguments creationArguments) {
-            if (ObjectDefinition.NoConstructors) {
-                // Skip thread spinup.
-                Initialize(creationArguments);
-                return;
-            }
-
-            var thread = new DreamThread("new " + ObjectDefinition.Type);
-            var procState = InitProc(thread, null, creationArguments);
-
-            thread.PushProcState(procState);
-            thread.Resume();
-        }
-
-        public ProcState InitProc(DreamThread thread, DreamObject? usr, DreamProcArguments arguments) {
-            DebugTools.Assert(!Deleted, "Cannot call InitProc() on a deleted object");
-
-            if (!InitDreamObjectState.Pool.TryPop(out var state)) {
-                state = new InitDreamObjectState(ObjectDefinition.DreamManager, ObjectDefinition.ObjectTree);
-            }
-
-            state.Initialize(thread, this, usr, arguments);
-            return state;
-        }
-
-        public DreamValue SpawnProc(string procName, DreamObject? usr = null, params DreamValue[] arguments) {
-            DebugTools.Assert(!Deleted, "Cannot call SpawnProc() on a deleted object");
-
-            var proc = GetProc(procName);
-            return DreamThread.Run(proc, this, usr, arguments);
-        }
-        #endregion Proc Helpers
-
-        #region Name Helpers
-        // This could probably be placed elsewhere. Not sure where tho
-        /// <returns>true if \proper noun formatting should be used, false if \improper</returns>
-        public static bool StringIsProper(string str) {
-            if (str.Length == 0)
+    protected virtual bool TryGetVar(string varName, out DreamValue value) {
+        switch (varName) {
+            case "type":
+                value = new(ObjectDefinition.TreeEntry);
                 return true;
-            if (StringFormatEncoder.Decode(str[0], out var properMaybe)) {
-                switch (properMaybe) {
-                    case StringFormatEncoder.FormatSuffix.Proper:
-                        return true;
-                    case StringFormatEncoder.FormatSuffix.Improper:
-                        return false;
-                }
-            }
+            case "parent_type":
+                if (ObjectDefinition.Parent != null)
+                    value = new(ObjectDefinition.Parent.TreeEntry);
+                else
+                    value = DreamValue.Null;
 
-            if (char.IsWhiteSpace(
-                    str[0])) // NOTE: This might result in slightly different behaviour (since C# may be more unicode-friendly about what "whitespace" means)
                 return true;
-            return char.IsUpper(str[0]);
+            case "vars":
+                _varsList ??= new DreamListVars(ObjectTree.List.ObjectDefinition, this);
+                value = new(_varsList);
+                return true;
+            case "tag":
+                value = (Tag != null) ? new(Tag) : DreamValue.Null;
+                return true;
+            default:
+                return (Variables?.TryGetValue(varName, out value) is true) ||
+                       (ObjectDefinition.Variables.TryGetValue(varName, out value)) ||
+                       (ObjectDefinition.GlobalVariables.TryGetValue(varName, out var globalIndex)) && ObjectDefinition.DreamManager.Globals.TryGetValue(globalIndex, out value);
+        }
+    }
+
+    protected virtual void SetVar(string varName, DreamValue value) {
+        switch (varName) {
+            case "type":
+            case "parent_type":
+            case "vars":
+                throw new Exception($"Cannot set var \"{varName}\"");
+            case "tag":
+                value.TryGetValueAsString(out var newTag);
+
+                Tag = newTag;
+                break;
+            default:
+                if (ObjectDefinition.ConstVariables is not null && ObjectDefinition.ConstVariables.Contains(varName))
+                    throw new Exception($"Cannot set const var \"{varName}\" on {ObjectDefinition.Type}");
+                if (!ObjectDefinition.Variables.ContainsKey(varName))
+                    throw new Exception($"Cannot set var \"{varName}\" on {ObjectDefinition.Type}");
+
+                SetVariableValue(varName, value);
+                break;
+        }
+    }
+
+    public bool TryGetVariable(string name, out DreamValue variableValue) {
+        DebugTools.Assert(!Deleted, "Cannot call TryGetVariable() on a deleted object");
+
+        return TryGetVar(name, out variableValue);
+    }
+
+    /// <summary>
+    /// Handles setting a variable, and special behavior by calling OnVariableSet()
+    /// </summary>
+    public void SetVariable(string name, DreamValue value) {
+        DebugTools.Assert(!Deleted, "Cannot call SetVariable() on a deleted object");
+
+        SetVar(name, value);
+    }
+
+    /// <summary>
+    /// Directly sets a variable's value, bypassing any special behavior
+    /// </summary>
+    /// <returns>The OLD variable value</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetVariableValue(string name, DreamValue value) {
+        DebugTools.Assert(!Deleted, "Cannot call SetVariableValue() on a deleted object");
+
+        Variables ??= new(4);
+        Variables[name] = value;
+    }
+    #endregion Variables
+
+    #region Proc Helpers
+    public DreamProc GetProc(string procName) {
+        DebugTools.Assert(!Deleted, "Cannot call GetProc() on a deleted object");
+
+        return ObjectDefinition.GetProc(procName);
+    }
+
+    public bool TryGetProc(string procName, [NotNullWhen(true)] out DreamProc? proc) {
+        DebugTools.Assert(!Deleted, "Cannot call TryGetProc() on a deleted object");
+
+        return ObjectDefinition.TryGetProc(procName, out proc);
+    }
+
+    public void InitSpawn(DreamProcArguments creationArguments) {
+        if (ObjectDefinition.NoConstructors) {
+            // Skip thread spinup.
+            Initialize(creationArguments);
+            return;
         }
 
-        public static bool StringStartsWithVowel(string str) {
-            if (str.Length == 0)
-                return false;
-            char start = char.ToLower(str[0], CultureInfo.InvariantCulture);
-            switch (start) {
-                case 'a':
-                case 'e':
-                case 'i':
-                case 'o':
-                case 'u':
+        var thread = new DreamThread("new " + ObjectDefinition.Type);
+        var procState = InitProc(thread, null, creationArguments);
+
+        thread.PushProcState(procState);
+        thread.Resume();
+    }
+
+    public ProcState InitProc(DreamThread thread, DreamObject? usr, DreamProcArguments arguments) {
+        DebugTools.Assert(!Deleted, "Cannot call InitProc() on a deleted object");
+
+        if (!InitDreamObjectState.Pool.TryPop(out var state)) {
+            state = new InitDreamObjectState(ObjectDefinition.DreamManager, ObjectDefinition.ObjectTree);
+        }
+
+        state.Initialize(thread, this, usr, arguments);
+        return state;
+    }
+
+    public DreamValue SpawnProc(string procName, DreamObject? usr = null, params DreamValue[] arguments) {
+        DebugTools.Assert(!Deleted, "Cannot call SpawnProc() on a deleted object");
+
+        var proc = GetProc(procName);
+        return DreamThread.Run(proc, this, usr, arguments);
+    }
+    #endregion Proc Helpers
+
+    #region Name Helpers
+    // This could probably be placed elsewhere. Not sure where tho
+    /// <returns>true if \proper noun formatting should be used, false if \improper</returns>
+    public static bool StringIsProper(string str) {
+        if (str.Length == 0)
+            return true;
+        if (StringFormatEncoder.Decode(str[0], out var properMaybe)) {
+            switch (properMaybe) {
+                case StringFormatEncoder.FormatSuffix.Proper:
                     return true;
-                default:
+                case StringFormatEncoder.FormatSuffix.Improper:
                     return false;
             }
         }
 
-        /// <summary>
-        /// Get the display name of this object, WITH ALL FORMATTING EVALUATED OR REMOVED!
-        /// </summary>
-        public virtual string GetDisplayName(StringFormatEncoder.FormatSuffix? suffix = null) {
-            // /client is a little special and will return its key var
-            // TODO: Maybe this should be an override to GetDisplayName()?
-            if (this is DreamObjectClient client)
-                return client.Connection.Key;
+        if (char.IsWhiteSpace(
+                str[0])) // NOTE: This might result in slightly different behaviour (since C# may be more unicode-friendly about what "whitespace" means)
+            return true;
+        return char.IsUpper(str[0]);
+    }
 
-            var name = GetRawName();
-            bool isProper = StringIsProper(name);
-            name = StringFormatEncoder.RemoveFormatting(name); // TODO: Care about other formatting macros for obj names beyond \proper & \improper
-            if(!isProper) {
-                return name;
-            }
-
-            switch(suffix) {
-                case StringFormatEncoder.FormatSuffix.UpperDefiniteArticle:
-                    return isProper ? name : $"The {name}";
-                case StringFormatEncoder.FormatSuffix.LowerDefiniteArticle:
-                    return isProper ? name : $"the {name}";
-                default:
-                    return name;
-            }
+    public static bool StringStartsWithVowel(string str) {
+        if (str.Length == 0)
+            return false;
+        char start = char.ToLower(str[0], CultureInfo.InvariantCulture);
+        switch (start) {
+            case 'a':
+            case 'e':
+            case 'i':
+            case 'o':
+            case 'u':
+                return true;
+            default:
+                return false;
         }
+    }
 
-        /// <summary>
-        /// Similar to <see cref="GetDisplayName"/> except it just returns the name as plaintext, with formatting removed. No article or anything.
-        /// </summary>
-        public string GetNameUnformatted() {
-            return StringFormatEncoder.RemoveFormatting(GetRawName());
-        }
+    /// <summary>
+    /// Get the display name of this object, WITH ALL FORMATTING EVALUATED OR REMOVED!
+    /// </summary>
+    public virtual string GetDisplayName(StringFormatEncoder.FormatSuffix? suffix = null) {
+        // /client is a little special and will return its key var
+        // TODO: Maybe this should be an override to GetDisplayName()?
+        if (this is DreamObjectClient client)
+            return client.Connection.Key;
 
-        /// <summary>
-        /// Returns the name of this object with no formatting evaluated
-        /// </summary>
-        public string GetRawName() {
-            string name = ObjectDefinition.Type;
-
-            if (this is DreamObjectAtom) {
-                if (AtomManager.TryGetAppearance(this, out var appearance))
-                    name = appearance.Name;
-            } else if (TryGetVariable("name", out DreamValue nameVar) && nameVar.TryGetValueAsString(out var nameVarStr)) {
-                name = nameVarStr;
-            }
-
+        var name = GetRawName();
+        bool isProper = StringIsProper(name);
+        name = StringFormatEncoder.RemoveFormatting(name); // TODO: Care about other formatting macros for obj names beyond \proper & \improper
+        if(!isProper) {
             return name;
         }
-        #endregion Name Helpers
 
-        #region Operators
-        // +
-        public virtual DreamValue OperatorAdd(DreamValue b, DMProcState state) {
-            if (TryExecuteOperatorOverload(state, "operator+", new DreamProcArguments(b), out var result))
-                return result;
+        switch(suffix) {
+            case StringFormatEncoder.FormatSuffix.UpperDefiniteArticle:
+                return isProper ? name : $"The {name}";
+            case StringFormatEncoder.FormatSuffix.LowerDefiniteArticle:
+                return isProper ? name : $"the {name}";
+            default:
+                return name;
+        }
+    }
 
-            throw new InvalidOperationException($"Addition cannot be done between {this} and {b}");
+    /// <summary>
+    /// Similar to <see cref="GetDisplayName"/> except it just returns the name as plaintext, with formatting removed. No article or anything.
+    /// </summary>
+    public string GetNameUnformatted() {
+        return StringFormatEncoder.RemoveFormatting(GetRawName());
+    }
+
+    /// <summary>
+    /// Returns the name of this object with no formatting evaluated
+    /// </summary>
+    public string GetRawName() {
+        string name = ObjectDefinition.Type;
+
+        if (this is DreamObjectAtom) {
+            if (AtomManager.TryGetAppearance(this, out var appearance))
+                name = appearance.Name;
+        } else if (TryGetVariable("name", out DreamValue nameVar) && nameVar.TryGetValueAsString(out var nameVarStr)) {
+            name = nameVarStr;
         }
 
-        // -
-        public virtual DreamValue OperatorSubtract(DreamValue b, DMProcState state) {
-            if (TryExecuteOperatorOverload(state, "operator-", new DreamProcArguments(b), out var result))
-                return result;
+        return name;
+    }
+    #endregion Name Helpers
 
-            throw new InvalidOperationException($"Subtraction cannot be done between {this} and {b}");
+    #region Operators
+    // +
+    public virtual DreamValue OperatorAdd(DreamValue b, DMProcState state) {
+        if (TryExecuteOperatorOverload(state, "operator+", new DreamProcArguments(b), out var result))
+            return result;
+
+        throw new InvalidOperationException($"Addition cannot be done between {this} and {b}");
+    }
+
+    // -
+    public virtual DreamValue OperatorSubtract(DreamValue b, DMProcState state) {
+        if (TryExecuteOperatorOverload(state, "operator-", new DreamProcArguments(b), out var result))
+            return result;
+
+        throw new InvalidOperationException($"Subtraction cannot be done between {this} and {b}");
+    }
+
+    // *
+    public virtual DreamValue OperatorMultiply(DreamValue b, DMProcState state) {
+        if (TryExecuteOperatorOverload(state, "operator*", new DreamProcArguments(b), out var result))
+            return result;
+
+        throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
+    }
+
+    // *=
+    public virtual DreamValue OperatorMultiplyRef(DreamValue b, DMProcState state) {
+        var args = new DreamProcArguments(b);
+        if (TryExecuteOperatorOverload(state, "operator*=", args, out var result))
+            return result;
+
+        if (TryExecuteOperatorOverload(state, "operator*", args, out result))
+            return result;
+
+        throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
+    }
+
+    // /
+    public virtual DreamValue OperatorDivide(DreamValue b, DMProcState state) {
+        if (TryExecuteOperatorOverload(state, "operator/", new DreamProcArguments(b), out var result))
+            return result;
+
+        throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
+    }
+
+    // /=
+    public virtual DreamValue OperatorDivideRef(DreamValue b, DMProcState state) {
+        var args = new DreamProcArguments(b);
+        if (TryExecuteOperatorOverload(state, "operator/=", args, out var result))
+            return result;
+
+        if (TryExecuteOperatorOverload(state, "operator/", args, out result))
+            return result;
+
+        throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
+    }
+
+    // |
+    public virtual DreamValue OperatorOr(DreamValue b, DMProcState state) {
+        if (TryExecuteOperatorOverload(state, "operator|", new DreamProcArguments(b), out var result))
+            return result;
+
+        throw new InvalidOperationException($"Cannot or {this} and {b}");
+    }
+
+    // +=
+    public virtual DreamValue OperatorAppend(DreamValue b) {
+        throw new InvalidOperationException($"Cannot append {b} to {this}");
+    }
+
+    // -=
+    public virtual DreamValue OperatorRemove(DreamValue b) {
+        throw new InvalidOperationException($"Cannot remove {b} from {this}");
+    }
+
+    // |=
+    public virtual DreamValue OperatorCombine(DreamValue b) {
+        throw new InvalidOperationException($"Cannot combine {this} and {b}");
+    }
+
+    // &=
+    public virtual DreamValue OperatorMask(DreamValue b) {
+        throw new InvalidOperationException($"Cannot mask {this} and {b}");
+    }
+
+    // ~=
+    public virtual DreamValue OperatorEquivalent(DreamValue b) {
+        if (!b.TryGetValueAsDreamObject(out var bObject))
+            return DreamValue.False;
+
+        return Equals(bObject) ? DreamValue.True : DreamValue.False;
+    }
+
+    // << statement
+    public virtual void OperatorOutput(DreamValue b) {
+        throw new InvalidOperationException($"Cannot output {b} to {this}");
+    }
+
+    // []
+    public virtual DreamValue OperatorIndex(DreamValue index, DMProcState state) {
+        if (TryExecuteOperatorOverload(state, "operator[]", new DreamProcArguments(index), out var result))
+            return result;
+
+        throw new InvalidOperationException($"Cannot index {this} with {index}");
+    }
+
+    // []=
+    public virtual void OperatorIndexAssign(DreamValue index, DMProcState state, DreamValue value) {
+        if (TryExecuteOperatorOverload(state, "operator[]=", new DreamProcArguments(index, value), out _))
+            return;
+
+        throw new InvalidOperationException($"Cannot assign {value} to index {index} of {this}");
+    }
+    #endregion Operators
+
+    private bool TryExecuteOperatorOverload(
+        DMProcState parentState,
+        string operatorName,
+        DreamProcArguments arguments,
+        out DreamValue procResult) {
+        if (!TryGetProc(operatorName, out var proc)) {
+            procResult = default;
+            return false;
         }
 
-        // *
-        public virtual DreamValue OperatorMultiply(DreamValue b, DMProcState state) {
-            if (TryExecuteOperatorOverload(state, "operator*", new DreamProcArguments(b), out var result))
-                return result;
+        var thread = parentState.Thread;
+        var operatorProcState = proc.CreateState(thread, this, parentState.Usr, arguments);
+        operatorProcState.WaitFor = false;
+        thread.PushProcState(operatorProcState);
+        procResult = thread.ReentrantResume(parentState, out var resultStatus);
 
-            throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
+        switch (resultStatus) {
+            case ProcStatus.Cancelled:
+                // Throw DMError so parent .Resume() call also cancels cleanly.
+                throw new DMError("Re-entrant proc cancelled");
+            case ProcStatus.Returned:
+                // Normal behavior, proc finished executing.
+                return true;
+            default:
+                // This means Deferred, most likely. Which shouldn't be possible,
+                // as the proc state is WaitFor = false.
+                throw new Exception($"Unexpected proc result from re-entrant operator: {resultStatus}");
+        }
+    }
+
+    public override string ToString() {
+        if (Deleted) {
+            return "<deleted>";
         }
 
-        // *=
-        public virtual DreamValue OperatorMultiplyRef(DreamValue b, DMProcState state) {
-            var args = new DreamProcArguments(b);
-            if (TryExecuteOperatorOverload(state, "operator*=", args, out var result))
-                return result;
-
-            if (TryExecuteOperatorOverload(state, "operator*", args, out result))
-                return result;
-
-            throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
+        string name = GetNameUnformatted();
+        if (!string.IsNullOrEmpty(name)) {
+            return $"{ObjectDefinition.Type}{{name=\"{name}\"}}";
         }
 
-        // /
-        public virtual DreamValue OperatorDivide(DreamValue b, DMProcState state) {
-            if (TryExecuteOperatorOverload(state, "operator/", new DreamProcArguments(b), out var result))
-                return result;
-
-            throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
-        }
-
-        // /=
-        public virtual DreamValue OperatorDivideRef(DreamValue b, DMProcState state) {
-            var args = new DreamProcArguments(b);
-            if (TryExecuteOperatorOverload(state, "operator/=", args, out var result))
-                return result;
-
-            if (TryExecuteOperatorOverload(state, "operator/", args, out result))
-                return result;
-
-            throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
-        }
-
-        // |
-        public virtual DreamValue OperatorOr(DreamValue b, DMProcState state) {
-            if (TryExecuteOperatorOverload(state, "operator|", new DreamProcArguments(b), out var result))
-                return result;
-
-            throw new InvalidOperationException($"Cannot or {this} and {b}");
-        }
-
-        // +=
-        public virtual DreamValue OperatorAppend(DreamValue b) {
-            throw new InvalidOperationException($"Cannot append {b} to {this}");
-        }
-
-        // -=
-        public virtual DreamValue OperatorRemove(DreamValue b) {
-            throw new InvalidOperationException($"Cannot remove {b} from {this}");
-        }
-
-        // |=
-        public virtual DreamValue OperatorCombine(DreamValue b) {
-            throw new InvalidOperationException($"Cannot combine {this} and {b}");
-        }
-
-        // &=
-        public virtual DreamValue OperatorMask(DreamValue b) {
-            throw new InvalidOperationException($"Cannot mask {this} and {b}");
-        }
-
-        // ~=
-        public virtual DreamValue OperatorEquivalent(DreamValue b) {
-            if (!b.TryGetValueAsDreamObject(out var bObject))
-                return DreamValue.False;
-
-            return Equals(bObject) ? DreamValue.True : DreamValue.False;
-        }
-
-        // << statement
-        public virtual void OperatorOutput(DreamValue b) {
-            throw new InvalidOperationException($"Cannot output {b} to {this}");
-        }
-
-        // []
-        public virtual DreamValue OperatorIndex(DreamValue index, DMProcState state) {
-            if (TryExecuteOperatorOverload(state, "operator[]", new DreamProcArguments(index), out var result))
-                return result;
-
-            throw new InvalidOperationException($"Cannot index {this} with {index}");
-        }
-
-        // []=
-        public virtual void OperatorIndexAssign(DreamValue index, DMProcState state, DreamValue value) {
-            if (TryExecuteOperatorOverload(state, "operator[]=", new DreamProcArguments(index, value), out _))
-                return;
-
-            throw new InvalidOperationException($"Cannot assign {value} to index {index} of {this}");
-        }
-        #endregion Operators
-
-        private bool TryExecuteOperatorOverload(
-            DMProcState parentState,
-            string operatorName,
-            DreamProcArguments arguments,
-            out DreamValue procResult) {
-            if (!TryGetProc(operatorName, out var proc)) {
-                procResult = default;
-                return false;
-            }
-
-            var thread = parentState.Thread;
-            var operatorProcState = proc.CreateState(thread, this, parentState.Usr, arguments);
-            operatorProcState.WaitFor = false;
-            thread.PushProcState(operatorProcState);
-            procResult = thread.ReentrantResume(parentState, out var resultStatus);
-
-            switch (resultStatus) {
-                case ProcStatus.Cancelled:
-                    // Throw DMError so parent .Resume() call also cancels cleanly.
-                    throw new DMError("Re-entrant proc cancelled");
-                case ProcStatus.Returned:
-                    // Normal behavior, proc finished executing.
-                    return true;
-                default:
-                    // This means Deferred, most likely. Which shouldn't be possible,
-                    // as the proc state is WaitFor = false.
-                    throw new Exception($"Unexpected proc result from re-entrant operator: {resultStatus}");
-            }
-        }
-
-        public override string ToString() {
-            if (Deleted) {
-                return "<deleted>";
-            }
-
-            string name = GetNameUnformatted();
-            if (!string.IsNullOrEmpty(name)) {
-                return $"{ObjectDefinition.Type}{{name=\"{name}\"}}";
-            }
-
-            return ObjectDefinition.Type;
-        }
+        return ObjectDefinition.Type;
     }
 }

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -167,6 +167,7 @@ public class DreamObject {
     }
 
     #region Variables
+
     public virtual bool IsSaved(string name) {
         return ObjectDefinition.Variables.ContainsKey(name)
                && !ObjectDefinition.GlobalVariables.ContainsKey(name)
@@ -270,9 +271,11 @@ public class DreamObject {
         Variables ??= new(4);
         Variables[name] = value;
     }
+
     #endregion Variables
 
     #region Proc Helpers
+
     public DreamProc GetProc(string procName) {
         DebugTools.Assert(!Deleted, "Cannot call GetProc() on a deleted object");
 
@@ -316,9 +319,11 @@ public class DreamObject {
         var proc = GetProc(procName);
         return DreamThread.Run(proc, this, usr, arguments);
     }
+
     #endregion Proc Helpers
 
     #region Name Helpers
+
     // This could probably be placed elsewhere. Not sure where tho
     /// <returns>true if \proper noun formatting should be used, false if \improper</returns>
     public static bool StringIsProper(string str) {
@@ -403,9 +408,11 @@ public class DreamObject {
 
         return name;
     }
+
     #endregion Name Helpers
 
     #region Operators
+
     // +
     public virtual DreamValue OperatorAdd(DreamValue b, DMProcState state) {
         if (TryExecuteOperatorOverload(state, "operator+", new DreamProcArguments(b), out var result))
@@ -518,6 +525,7 @@ public class DreamObject {
 
         throw new InvalidOperationException($"Cannot assign {value} to index {index} of {this}");
     }
+
     #endregion Operators
 
     private bool TryExecuteOperatorOverload(

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -7,10 +7,8 @@ using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
-using OpenDreamRuntime.Util;
 using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
-using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
@@ -24,13 +22,13 @@ public class DreamObject {
     [Access(typeof(DreamObject))]
     public bool Deleted;
 
-    [Access(typeof(DreamManager), typeof(DreamObject))]
-    public int? RefId;
+    public readonly uint RefId;
 
     public virtual bool ShouldCallNew => true;
 
     // Shortcuts to IoC dependencies & entity systems
     protected DreamManager DreamManager => ObjectDefinition.DreamManager;
+    protected DreamRefManager DreamRefManager => ObjectDefinition.DreamRefManager;
     protected DreamObjectTree ObjectTree => ObjectDefinition.ObjectTree;
     protected AtomManager AtomManager => ObjectDefinition.AtomManager;
     protected IDreamMapManager DreamMapManager => ObjectDefinition.DreamMapManager;
@@ -38,7 +36,6 @@ public class DreamObject {
     protected DreamResourceManager DreamResourceManager => ObjectDefinition.DreamResourceManager;
     protected WalkManager WalkManager => ObjectDefinition.WalkManager;
     protected IEntityManager EntityManager => ObjectDefinition.EntityManager;
-    protected IPlayerManager PlayerManager => ObjectDefinition.PlayerManager;
     protected ISerializationManager SerializationManager => ObjectDefinition.SerializationManager;
     protected ServerAppearanceSystem? AppearanceSystem => ObjectDefinition.AppearanceSystem;
     protected TransformSystem? TransformSystem => ObjectDefinition.TransformSystem;
@@ -50,55 +47,50 @@ public class DreamObject {
     protected Dictionary<string, DreamValue>? Variables;
 
 #if TOOLS
-        protected ProfilerMemory? TracyMemoryId;
+    protected ProfilerMemory? TracyMemoryId;
 #endif
 
     //handle to the list of vars on this object so that it's only created once and refs to object.vars are consistent
     private DreamListVars? _varsList;
 
     private string? Tag {
-        get => _tag;
+        get;
         set {
             // Even if we're setting it to the same string we still need to remove it
-            if (!string.IsNullOrEmpty(_tag)) {
-                var list = ObjectDefinition.DreamManager.Tags[_tag];
+            if (!string.IsNullOrEmpty(field)) {
+                var list = DreamRefManager.Tags[field];
 
                 if (list.Count > 1) {
                     list.Remove(this);
                 } else {
-                    ObjectDefinition.DreamManager.Tags.Remove(_tag);
+                    DreamRefManager.Tags.Remove(field);
                 }
             }
 
-            _tag = value;
+            field = value;
 
             // Now we add it (if it's a string)
-            if (!string.IsNullOrEmpty(_tag)) {
-                if (ObjectDefinition.DreamManager.Tags.TryGetValue(_tag, out var list)) {
+            if (!string.IsNullOrEmpty(field)) {
+                if (DreamRefManager.Tags.TryGetValue(field, out var list)) {
                     list.Add(this);
                 } else {
                     var newList = new List<DreamObject> {
                         this
                     };
 
-                    ObjectDefinition.DreamManager.Tags.Add(_tag, newList);
+                    DreamRefManager.Tags.Add(field, newList);
                 }
             }
         }
     }
-    private string? _tag;
 
     public DreamObject(DreamObjectDefinition objectDefinition) {
         ObjectDefinition = objectDefinition;
-
-        // Atoms are in world.contents
-        if (this is not DreamObjectAtom && IsSubtypeOf(ObjectTree.Datum)) {
-            ObjectDefinition.DreamManager.Datums.AddLast(new WeakDreamRef(this));
-        }
+        RefId = DreamRefManager.GetRef(this);
 
 #if TOOLS
-             //if it's not null, subclasses have done their own allocation
-            TracyMemoryId ??= Profiler.BeginMemoryZone((ulong)(Unsafe.SizeOf<DreamObject>() + ObjectDefinition.Variables.Count * Unsafe.SizeOf<DreamValue>() ), "/datum");
+         //if it's not null, subclasses have done their own allocation
+        TracyMemoryId ??= Profiler.BeginMemoryZone((ulong)(Unsafe.SizeOf<DreamObject>() + ObjectDefinition.Variables.Count * Unsafe.SizeOf<DreamValue>() ), "/datum");
 #endif
     }
 
@@ -107,15 +99,20 @@ public class DreamObject {
     }
 
     protected virtual void HandleDeletion(bool possiblyThreaded) {
-        // Atoms are in world.contents
-        // Datum removal used to live here, but datums are now tracked weakly.
+        if (possiblyThreaded) {
+            // DeleteRef is not thread-safe, so pawn this off to the server thread
+            lock (DreamManager.RefDeleteQueue) {
+                DreamManager.RefDeleteQueue.Add(RefId);
+            }
+        } else {
+            // Remove the locate()-able reference to this object
+            // Freeing up the slot for later reuse
+            DreamRefManager.DeleteRef(RefId);
+        }
 
-        if (RefId is not null)
-            DreamManager.ReferenceIDsToDreamObject.Remove(RefId.Value, out _);
-
+        //we release all relevant information, making this a very tiny object
         Tag = null;
         Deleted = true;
-        //we release all relevant information, making this a very tiny object
         Variables = null;
         _varsList?.Delete(possiblyThreaded);
         _varsList = null;
@@ -123,7 +120,7 @@ public class DreamObject {
         ObjectDefinition = null!;
 
 #if TOOLS
-            TracyMemoryId?.ReleaseMemory();
+        TracyMemoryId?.ReleaseMemory();
 #endif
     }
 

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -16,6 +16,7 @@ public sealed class DreamObjectDefinition {
     // IoC dependencies & entity systems for DreamObjects to use
     // TODO: Wow, remove this
     public readonly DreamManager DreamManager;
+    public readonly DreamRefManager DreamRefManager;
     public readonly DreamObjectTree ObjectTree;
     public readonly AtomManager AtomManager;
     public readonly IDreamMapManager DreamMapManager;
@@ -23,7 +24,6 @@ public sealed class DreamObjectDefinition {
     public readonly DreamResourceManager DreamResourceManager;
     public readonly WalkManager WalkManager;
     public readonly IEntityManager EntityManager;
-    public readonly IPlayerManager PlayerManager;
     public readonly ISerializationManager SerializationManager;
     public readonly ServerAppearanceSystem? AppearanceSystem;
     public readonly TransformSystem? TransformSystem;
@@ -61,6 +61,7 @@ public sealed class DreamObjectDefinition {
 
     public DreamObjectDefinition(DreamObjectDefinition copyFrom) {
         DreamManager = copyFrom.DreamManager;
+        DreamRefManager = copyFrom.DreamRefManager;
         ObjectTree = copyFrom.ObjectTree;
         AtomManager = copyFrom.AtomManager;
         DreamMapManager = copyFrom.DreamMapManager;
@@ -68,7 +69,6 @@ public sealed class DreamObjectDefinition {
         DreamResourceManager = copyFrom.DreamResourceManager;
         WalkManager = copyFrom.WalkManager;
         EntityManager = copyFrom.EntityManager;
-        PlayerManager = copyFrom.PlayerManager;
         SerializationManager = copyFrom.SerializationManager;
         AppearanceSystem = copyFrom.AppearanceSystem;
         TransformSystem = copyFrom.TransformSystem;
@@ -90,8 +90,9 @@ public sealed class DreamObjectDefinition {
             Verbs = new Dictionary<string, int>(copyFrom.Verbs);
     }
 
-    public DreamObjectDefinition(DreamManager dreamManager, DreamObjectTree objectTree, AtomManager atomManager, IDreamMapManager dreamMapManager, IMapManager mapManager, DreamResourceManager dreamResourceManager, WalkManager walkManager, IEntityManager entityManager, IPlayerManager playerManager, ISerializationManager serializationManager, ServerAppearanceSystem? appearanceSystem, TransformSystem? transformSystem, PvsOverrideSystem? pvsOverrideSystem, MetaDataSystem? metaDataSystem, ServerVerbSystem? verbSystem, ServerDreamParticlesSystem? particlesSystem, TreeEntry? treeEntry) {
+    public DreamObjectDefinition(DreamManager dreamManager, DreamRefManager dreamRefManager, DreamObjectTree objectTree, AtomManager atomManager, IDreamMapManager dreamMapManager, IMapManager mapManager, DreamResourceManager dreamResourceManager, WalkManager walkManager, IEntityManager entityManager, ISerializationManager serializationManager, ServerAppearanceSystem? appearanceSystem, TransformSystem? transformSystem, PvsOverrideSystem? pvsOverrideSystem, MetaDataSystem? metaDataSystem, ServerVerbSystem? verbSystem, ServerDreamParticlesSystem? particlesSystem, TreeEntry? treeEntry) {
         DreamManager = dreamManager;
+        DreamRefManager = dreamRefManager;
         ObjectTree = objectTree;
         AtomManager = atomManager;
         DreamMapManager = dreamMapManager;
@@ -99,7 +100,6 @@ public sealed class DreamObjectDefinition {
         DreamResourceManager = dreamResourceManager;
         WalkManager = walkManager;
         EntityManager = entityManager;
-        PlayerManager = playerManager;
         SerializationManager = serializationManager;
         AppearanceSystem = appearanceSystem;
         TransformSystem = transformSystem;

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -11,7 +11,6 @@ using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
-using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Exceptions;
@@ -59,6 +58,7 @@ public sealed class DreamObjectTree {
 
     [Dependency] private readonly AtomManager _atomManager = default!;
     [Dependency] private readonly DreamManager _dreamManager = default!;
+    [Dependency] private readonly DreamRefManager _refManager = default!;
     [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IDreamDebugManager _dreamDebugManager = default!;
@@ -66,7 +66,6 @@ public sealed class DreamObjectTree {
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly DreamResourceManager _dreamResourceManager = default!;
     [Dependency] private readonly WalkManager _walkManager = default!;
-    [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly ISerializationManager _serializationManager = default!;
     [Dependency] private readonly ProcScheduler _procScheduler = default!;
     private ServerAppearanceSystem? _appearanceSystem;
@@ -93,7 +92,7 @@ public sealed class DreamObjectTree {
         Strings = json.Strings;
 
         if (json.GlobalInitProc is { } initProcDef) {
-            GlobalInitProc = new DMProc(0, Root, initProcDef, "<global init>", _dreamManager, _atomManager, _dreamMapManager, _dreamDebugManager, _dreamResourceManager, this, _procScheduler, _verbSystem);
+            GlobalInitProc = new DMProc(0, Root, initProcDef, "<global init>", _dreamManager, _refManager, _atomManager, _dreamMapManager, _dreamDebugManager, _dreamResourceManager, this, _procScheduler, _verbSystem);
         } else {
             GlobalInitProc = null;
         }
@@ -372,7 +371,7 @@ public sealed class DreamObjectTree {
         foreach (TreeEntry type in GetAllDescendants(Root)) {
             int typeId = type.Id;
             DreamTypeJson jsonType = types[typeId];
-            var definition = new DreamObjectDefinition(_dreamManager, this, _atomManager, _dreamMapManager, _mapManager, _dreamResourceManager, _walkManager, _entityManager, _playerManager, _serializationManager, _appearanceSystem, _transformSystem, _pvsOverrideSystem, _metaDataSystem, _verbSystem, _particlesSystem, type);
+            var definition = new DreamObjectDefinition(_dreamManager, _refManager, this, _atomManager, _dreamMapManager, _mapManager, _dreamResourceManager, _walkManager, _entityManager, _serializationManager, _appearanceSystem, _transformSystem, _pvsOverrideSystem, _metaDataSystem, _verbSystem, _particlesSystem, type);
 
             type.ObjectDefinition = definition;
             type.TreeIndex = treeIndex++;
@@ -465,7 +464,7 @@ public sealed class DreamObjectTree {
 
     public DreamProc LoadProcJson(int id, ProcDefinitionJson procDefinition) {
         TreeEntry owningType = Types[procDefinition.OwningTypeId];
-        return new DMProc(id, owningType, procDefinition, null, _dreamManager,
+        return new DMProc(id, owningType, procDefinition, null, _dreamManager, _refManager,
             _atomManager, _dreamMapManager, _dreamDebugManager, _dreamResourceManager, this, _procScheduler, _verbSystem);
     }
 
@@ -496,7 +495,7 @@ public sealed class DreamObjectTree {
 
     internal NativeProc CreateNativeProc(TreeEntry owningType, NativeProc.HandlerFn func) {
         var (name, defaultArgumentValues, argumentNames) = NativeProc.GetNativeInfo(func);
-        var proc = new NativeProc(Procs.Count, owningType, name, argumentNames, defaultArgumentValues, func, _dreamManager, _atomManager, _dreamMapManager, _dreamResourceManager, _walkManager, this);
+        var proc = new NativeProc(Procs.Count, owningType, name, argumentNames, defaultArgumentValues, func, _dreamManager, _refManager, _atomManager, _dreamMapManager, _dreamResourceManager, _walkManager, this);
 
         Procs.Add(proc);
         return proc;
@@ -512,7 +511,7 @@ public sealed class DreamObjectTree {
 
     internal void SetGlobalNativeProc(NativeProc.HandlerFn func) {
         var (name, defaultArgumentValues, argumentNames) = NativeProc.GetNativeInfo(func);
-        var proc = new NativeProc(_globalProcIds[name], Root, name, argumentNames, defaultArgumentValues, func, _dreamManager, _atomManager, _dreamMapManager, _dreamResourceManager, _walkManager, this);
+        var proc = new NativeProc(_globalProcIds[name], Root, name, argumentNames, defaultArgumentValues, func, _dreamManager, _refManager, _atomManager, _dreamMapManager, _dreamResourceManager, _walkManager, this);
 
         Procs[proc.Id] = proc;
     }

--- a/OpenDreamRuntime/Objects/DreamRefManager.cs
+++ b/OpenDreamRuntime/Objects/DreamRefManager.cs
@@ -1,0 +1,390 @@
+using System.Diagnostics;
+using OpenDreamRuntime.Objects.Types;
+using OpenDreamRuntime.Rendering;
+using OpenDreamRuntime.Resources;
+
+namespace OpenDreamRuntime.Objects;
+
+/// <summary>
+/// A centralized place for all your ref() and locate() needs
+/// Holds collections of every alive DreamObject
+/// </summary>
+// TODO: This could probably be expanded to hold buckets for non-DreamObject values as well (strings, appearances, etc)
+public sealed class DreamRefManager {
+    public const uint RefTypeMask = 0xFF000000;
+    public const uint RefIdMask = 0x00FFFFFF;
+
+    public Dictionary<string, List<DreamObject>> Tags { get; } = new();
+
+    [Dependency] private readonly DreamObjectTree _objectTree = default!;
+    [Dependency] private readonly DreamResourceManager _resourceManager = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+    private ServerAppearanceSystem? _appearanceSystem;
+
+    private readonly Dictionary<RefType, Bucket> _buckets = new();
+
+    /// <summary>
+    /// Holds all DreamObjects of a certain <see cref="RefType"/>
+    /// Attempts to performantly allow deletion & reuse of slots
+    /// </summary>
+    private sealed class Bucket {
+        /// The amount of alive values in this bucket
+        public int FilledCount { get; private set; }
+
+        private readonly List<WeakReference<DreamObject>?> _values = new();
+        private int _earliestEmptySlot;
+
+        public int Add(DreamObject value) {
+            FilledCount++;
+
+            var refId = _earliestEmptySlot++;
+            if (refId >= _values.Count) {
+                _values.Add(new(value));
+                return refId;
+            }
+
+            _values[refId] = new(value);
+
+            // Find the next null value to update _earliestEmptySlot
+            for (; _earliestEmptySlot < _values.Count; _earliestEmptySlot++) {
+                if (_values[_earliestEmptySlot]?.TryGetTarget(out _) is true)
+                    continue;
+
+                _values[_earliestEmptySlot] = null;
+                break;
+            }
+
+            return refId;
+        }
+
+        public DreamObject? Get(int refId) {
+            var weakRef = _values[refId];
+            DreamObject? value = null;
+
+            weakRef?.TryGetTarget(out value);
+            return value;
+        }
+
+        public void Remove(int refId) {
+            if (_values[refId] != null)
+                FilledCount--;
+
+            _values[refId] = null;
+            _earliestEmptySlot = Math.Min(_earliestEmptySlot, refId);
+        }
+
+        public IEnumerable<DreamObject> Enumerate() {
+            // This cannot ever be a foreach!
+            // world.contents allows modification during enumeration
+            for (var i = 0; i < _values.Count; i++) {
+                var weakRef = _values[i];
+                if (weakRef is null)
+                    continue;
+
+                if (weakRef.TryGetTarget(out var value)) {
+                    yield return value;
+                } else {
+                    // This isn't a common operation so we'll use this time to also do some pruning.
+                    FilledCount--;
+                    _values[i] = null;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get the number representation of a DreamValue's ref()<br/>
+    /// Use with <see cref="LocateRef(uint)"/> to later get the DreamValue again
+    /// </summary>
+    /// <remarks>
+    /// This is a weak reference, so deleted objects may have their ref reused by something else
+    /// </remarks>
+    /// <param name="value">The DreamValue to get the ref of</param>
+    public uint GetRef(DreamValue value) {
+        if (value.TryGetValueAsDreamObject(out var refObject))
+            return GetRef(refObject);
+        if (value.TryGetValueAsString(out var refStr))
+            return GetRef(refStr);
+        if (value.TryGetValueAsType(out var type))
+            return (uint)RefType.DreamType | (uint)type.Id;
+        if (value.TryGetValueAsDreamResource(out var refRsc))
+            return (uint)RefType.DreamResource | (uint)refRsc.Id;
+        if (value.TryGetValueAsProc(out var proc))
+            return (uint)RefType.Proc | (uint)proc.Id;
+
+        if (value.TryGetValueAsAppearance(out var appearance)) {
+            _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
+            var appearanceId = _appearanceSystem.AddAppearance(appearance).MustGetId();
+
+            return (uint)RefType.DreamAppearance | appearanceId;
+        }
+
+        // Yes, this combines with the refType and produces an invalid ref.
+        // This is BYOND behavior (as of writing at least, on 516.1661).
+        if (value.TryGetValueAsFloat(out var floatValue))
+            return (uint)RefType.Number | BitConverter.SingleToUInt32Bits(floatValue);
+
+        throw new NotImplementedException($"Ref for {value} is unimplemented");
+    }
+
+    /// <summary>
+    /// Get the number representation of a DreamObject's ref()
+    /// </summary>
+    /// <remarks>
+    /// This is a weak reference, so deleted objects may have their ref reused by something else
+    /// </remarks>
+    /// <param name="dreamObject">The DreamObject to get the ref of</param>
+    public uint GetRef(DreamObject? dreamObject) {
+        if (dreamObject == null)
+            return (uint)RefType.Null;
+
+        if (dreamObject.Deleted) {
+            // i dont believe this will **ever** be called, but just to be sure, funky errors /might/ appear in the future if someone does a fucky wucky and calls this on a deleted object.
+            throw new Exception("Cannot create reference ID for an object that is deleted");
+        }
+
+        // This DreamObject's RefId hasn't been initialized yet
+        // Presumably this method is being called in order to initialize it
+        if (dreamObject.RefId == default) {
+            return dreamObject switch {
+                DreamObjectTurf turf => CreateRef(RefType.DreamObjectTurf, turf),
+                DreamObjectMob mob => CreateRef(RefType.DreamObjectMob, mob),
+                DreamObjectArea area => CreateRef(RefType.DreamObjectArea, area),
+                DreamObjectClient client => CreateRef(RefType.DreamObjectArea, client),
+                DreamObjectImage image => CreateRef(RefType.DreamObjectImage, image),
+                DreamObjectFilter filter => CreateRef(RefType.DreamObjectFilter, filter),
+                DreamObjectMovable => CreateRef(RefType.DreamObjectMovable, dreamObject),
+                DreamList list when list.GetType() == typeof(DreamList) => CreateRef(RefType.DreamObjectList, list),
+                _ => CreateRef(RefType.DreamObjectDatum, dreamObject)
+            };
+        }
+
+        return dreamObject.RefId;
+    }
+
+    /// <summary>
+    /// Get the number representation of a string's ref()
+    /// </summary>
+    /// <param name="value">The string to get the ref of</param>
+    public uint GetRef(string value) {
+        return (uint)RefType.String | FindOrAddString(value);
+    }
+
+    /// <summary>
+    /// Get the string representation of a DreamValue's ref()<br/>
+    /// Use with <see cref="LocateRef(string)"/> to later get the DreamValue again
+    /// </summary>
+    /// <returns>The ref in [0xaabbccdd] format</returns>
+    /// <remarks>
+    /// This is a weak reference, so deleted objects may have their ref reused by something else
+    /// </remarks>
+    /// <param name="value">The DreamValue to get the ref of</param>
+    public string GetRefString(DreamValue value) {
+        var @ref = GetRef(value);
+
+        return $"[0x{@ref:x}]";
+    }
+
+    /// <summary>
+    /// Gets the DreamValue referred to by a ref
+    /// </summary>
+    /// <remarks>
+    /// May not return the same object that was passed to <see cref="GetRef(DreamValue)"/> if it was deleted and its ID reused
+    /// </remarks>
+    /// <param name="ref">The number representation of a ref</param>
+    public DreamValue LocateRef(uint @ref) {
+        var refType = (RefType)(@ref & RefTypeMask);
+        var refId = @ref & RefIdMask;
+
+        switch (refType) {
+            case RefType.Null:
+                Debug.Assert(refId == 0);
+                return DreamValue.Null;
+
+            case RefType.DreamObjectArea:
+            case RefType.DreamObjectClient:
+            case RefType.DreamObjectDatum:
+            case RefType.DreamObjectImage:
+            case RefType.DreamObjectFilter:
+            case RefType.DreamObjectList:
+            case RefType.DreamObjectMob:
+            case RefType.DreamObjectTurf:
+            case RefType.DreamObjectMovable:
+                return new(GetFromRef(@ref));
+
+            case RefType.String:
+                return _objectTree.Strings.Count > refId
+                    ? new DreamValue(_objectTree.Strings[(int)refId])
+                    : DreamValue.Null;
+            case RefType.DreamType:
+                return _objectTree.Types.Length > refId
+                    ? new DreamValue(_objectTree.Types[refId])
+                    : DreamValue.Null;
+            case RefType.DreamResourceIcon: // Alias of DreamResource for now. TODO: Does this *only* contain icon resources?
+            case RefType.DreamResource:
+                if (!_resourceManager.TryLoadResource((int)refId, out var resource))
+                    return DreamValue.Null;
+
+                return new DreamValue(resource);
+            case RefType.DreamAppearance:
+                _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
+                return _appearanceSystem.TryGetAppearanceById(refId, out var appearance)
+                    ? new DreamValue(appearance.ToMutable())
+                    : DreamValue.Null;
+            case RefType.Proc:
+                return _objectTree.Procs.Count > refId
+                    ? new DreamValue(_objectTree.Procs[(int)refId])
+                    : DreamValue.Null;
+            case RefType.Number: // For the oh so few numbers this works with (most numbers clobber the ref type)
+                return new(BitConverter.UInt32BitsToSingle(refId));
+            default:
+                throw new Exception($"Invalid reference type for ref [0x{refId:x}]");
+        }
+    }
+
+    /// <summary>
+    /// Parses the number or tag in a ref() string and returns the DreamValue it refers to
+    /// </summary>
+    /// <remarks>
+    /// May not return the same object that was passed to <see cref="GetRefString(DreamValue)"/> if it was deleted and its ID reused
+    /// </remarks>
+    /// <param name="refStr">The string representation of a ref, or a datum's tag</param>
+    public DreamValue LocateRef(string refStr) {
+        if (refStr.StartsWith('[') && refStr.EndsWith(']')) {
+            // Strip the surrounding []
+            refStr = refStr.Substring(1, refStr.Length - 2);
+
+            // This ref could possibly be a "pointer" (the hex number made up of an id and an index)
+            var canBePointer = refStr.StartsWith("0x");
+
+            if (canBePointer && uint.TryParse(refStr.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out var @ref)) {
+                return LocateRef(@ref);
+            }
+        }
+
+        // Search for an object with this ref as its tag
+        // Note that surrounding [] are stripped out at this point, this is intentional
+        // Doing locate("[abc]") is the same as locate("abc")
+        if (Tags.TryGetValue(refStr, out var tagList) && tagList.Count > 0) {
+            return new DreamValue(tagList[0]);
+        }
+
+        // Nothing found
+        return DreamValue.Null;
+    }
+
+    /// <summary>
+    /// Frees up an object's ID for reuse
+    /// </summary>
+    /// <remarks>
+    /// This does not delete an object, use <see cref="DreamObject.Delete"/> for that
+    /// </remarks>
+    /// <param name="ref">The ref for the object to free</param>
+    public void DeleteRef(uint @ref) {
+        var refType = (RefType)(@ref & RefTypeMask);
+        var bucket = GetBucket(refType);
+
+        bucket.Remove((int)(@ref & RefIdMask));
+    }
+
+    /// <summary>
+    /// Enumerate every alive DreamObject of a certain <see cref="RefType"/>
+    /// </summary>
+    public IEnumerable<DreamObject> EnumerateType(RefType type) {
+        var bucket = GetBucket(type);
+
+        return bucket.Enumerate();
+    }
+
+    /// <summary>
+    /// Find a string's ID if it has one
+    /// </summary>
+    /// <remarks>
+    /// This doesn't include <see cref="RefType.String"/> in the return value,
+    /// so it is not usable with <see cref="LocateRef(uint)"/> as-is
+    /// </remarks>
+    /// <returns>A string's ID, or null if it hasn't been added to the DM string list</returns>
+    public uint? FindStringId(string str) {
+        int idx = _objectTree.Strings.IndexOf(str);
+
+        if (idx < 0) {
+            return null;
+        }
+
+        return (uint)idx;
+    }
+
+    /// <summary>
+    /// Get the amount of alive DreamObjects of type <see cref="RefType"/>
+    /// </summary>
+    public int GetCountOf(RefType refType) {
+        var bucket = GetBucket(refType);
+
+        return bucket.FilledCount;
+    }
+
+    /// <summary>
+    /// Grabs a DreamObject from its bucket using its ref
+    /// </summary>
+    private DreamObject? GetFromRef(uint @ref) {
+        var refType = (RefType)(@ref & RefTypeMask);
+        var refId = (int)(@ref & RefIdMask);
+        var bucket = GetBucket(refType);
+
+        return bucket.Get(refId);
+    }
+
+    /// <summary>
+    /// Get a string's ID, adding it to the DM string list if it's not already in there
+    /// </summary>
+    private uint FindOrAddString(string str) {
+        var idx = FindStringId(str);
+        if (idx == null) {
+            _objectTree.Strings.Add(str);
+            idx = (uint)(_objectTree.Strings.Count - 1);
+        }
+
+        return idx.Value;
+    }
+
+    /// <summary>
+    /// Add a DreamObject to its relevant bucket, creating a ref for it
+    /// </summary>
+    /// <param name="type">The DreamObject's RefType, deciding which bucket it goes in</param>
+    /// <param name="value">The DreamObject to create a ref for</param>
+    /// <returns>The DreamObject's new ref</returns>
+    private uint CreateRef(RefType type, DreamObject value) {
+        var bucket = GetBucket(type);
+
+        return (uint)type | (uint)bucket.Add(value);
+    }
+
+    private Bucket GetBucket(RefType type) {
+        if (!_buckets.TryGetValue(type, out var bucket)) {
+            bucket = new Bucket();
+            _buckets[type] = bucket;
+        }
+
+        return bucket;
+    }
+}
+
+public enum RefType : uint {
+    Null = 0x0,
+    DreamObjectTurf = 0x1000000,
+    DreamObjectMovable = 0x2000000,
+    DreamObjectMob = 0x3000000,
+    DreamObjectArea = 0x4000000,
+    DreamObjectClient = 0x5000000,
+    DreamResourceIcon = 0xC000000,
+    DreamObjectImage = 0xD000000,
+    DreamObjectList = 0xF000000,
+    DreamObjectDatum = 0x21000000,
+    String = 0x6000000,
+    DreamType = 0x9000000, //in byond type is from 0x8 to 0xb, but fuck that
+    DreamResource = 0x27000000, //Equivalent to file
+    DreamAppearance = 0x3A000000,
+    Proc = 0x26000000,
+    Number = 0x2A000000,
+    DreamObjectFilter = 0x53000000
+}

--- a/OpenDreamRuntime/Objects/DreamRefManager.cs
+++ b/OpenDreamRuntime/Objects/DreamRefManager.cs
@@ -66,6 +66,8 @@ public sealed class DreamRefManager {
         }
 
         public void Remove(int refId) {
+            if (refId >= _values.Count)
+                return;
             if (_values[refId] != null)
                 FilledCount--;
 
@@ -89,6 +91,27 @@ public sealed class DreamRefManager {
                     _values[i] = null;
                 }
             }
+        }
+    }
+
+    public void Initialize() {
+        Tags.Clear();
+        _buckets.Clear();
+
+        ReadOnlySpan<RefType> bucketTypes = [
+            RefType.DreamObjectDatum,
+            RefType.DreamObjectTurf,
+            RefType.DreamObjectMob,
+            RefType.DreamObjectArea,
+            RefType.DreamObjectClient,
+            RefType.DreamObjectImage,
+            RefType.DreamObjectFilter,
+            RefType.DreamObjectMovable,
+            RefType.DreamObjectList
+        ];
+
+        foreach (var type in bucketTypes) {
+            _buckets[type] = new();
         }
     }
 
@@ -210,7 +233,7 @@ public sealed class DreamRefManager {
             case RefType.DreamObjectMob:
             case RefType.DreamObjectTurf:
             case RefType.DreamObjectMovable:
-                return new(GetFromRef(@ref));
+                return new(GetFromBucket(@ref));
 
             case RefType.String:
                 return _objectTree.Strings.Count > refId
@@ -282,7 +305,7 @@ public sealed class DreamRefManager {
     /// <param name="ref">The ref for the object to free</param>
     public void DeleteRef(uint @ref) {
         var refType = (RefType)(@ref & RefTypeMask);
-        var bucket = GetBucket(refType);
+        var bucket = _buckets[refType];
 
         bucket.Remove((int)(@ref & RefIdMask));
     }
@@ -290,8 +313,8 @@ public sealed class DreamRefManager {
     /// <summary>
     /// Enumerate every alive DreamObject of a certain <see cref="RefType"/>
     /// </summary>
-    public IEnumerable<DreamObject> EnumerateType(RefType type) {
-        var bucket = GetBucket(type);
+    public IEnumerable<DreamObject> EnumerateType(RefType refType) {
+        var bucket = _buckets[refType];
 
         return bucket.Enumerate();
     }
@@ -318,7 +341,7 @@ public sealed class DreamRefManager {
     /// Get the amount of alive DreamObjects of type <see cref="RefType"/>
     /// </summary>
     public int GetCountOf(RefType refType) {
-        var bucket = GetBucket(refType);
+        var bucket = _buckets[refType];
 
         return bucket.FilledCount;
     }
@@ -326,10 +349,10 @@ public sealed class DreamRefManager {
     /// <summary>
     /// Grabs a DreamObject from its bucket using its ref
     /// </summary>
-    private DreamObject? GetFromRef(uint @ref) {
+    private DreamObject? GetFromBucket(uint @ref) {
         var refType = (RefType)(@ref & RefTypeMask);
         var refId = (int)(@ref & RefIdMask);
-        var bucket = GetBucket(refType);
+        var bucket = _buckets[refType];
 
         return bucket.Get(refId);
     }
@@ -350,22 +373,13 @@ public sealed class DreamRefManager {
     /// <summary>
     /// Add a DreamObject to its relevant bucket, creating a ref for it
     /// </summary>
-    /// <param name="type">The DreamObject's RefType, deciding which bucket it goes in</param>
+    /// <param name="refType">The DreamObject's RefType, deciding which bucket it goes in</param>
     /// <param name="value">The DreamObject to create a ref for</param>
     /// <returns>The DreamObject's new ref</returns>
-    private uint CreateRef(RefType type, DreamObject value) {
-        var bucket = GetBucket(type);
+    private uint CreateRef(RefType refType, DreamObject value) {
+        var bucket = _buckets[refType];
 
-        return (uint)type | (uint)bucket.Add(value);
-    }
-
-    private Bucket GetBucket(RefType type) {
-        if (!_buckets.TryGetValue(type, out var bucket)) {
-            bucket = new Bucket();
-            _buckets[type] = bucket;
-        }
-
-        return bucket;
+        return (uint)refType | (uint)bucket.Add(value);
     }
 }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -624,11 +624,9 @@ public sealed class ClientVerbsList : DreamList {
     public readonly List<DreamProc> Verbs = new();
 
     private readonly DreamObjectClient _client;
-    private readonly ServerVerbSystem? _verbSystem;
 
-    public ClientVerbsList(DreamObjectTree objectTree, ServerVerbSystem? verbSystem, DreamObjectClient client) : base(objectTree.List.ObjectDefinition, 0) {
+    public ClientVerbsList(DreamObjectTree objectTree, DreamObjectClient client) : base(objectTree.List.ObjectDefinition, 0) {
         _client = client;
-        _verbSystem = verbSystem;
 
         var verbs = _client.ObjectDefinition.Verbs?.Values;
         if (verbs == null)
@@ -676,8 +674,8 @@ public sealed class ClientVerbsList : DreamList {
             return; // Even += won't add the verb if it's already in this list
 
         Verbs.Add(verb);
-        _verbSystem?.RegisterVerb(verb);
-        _verbSystem?.UpdateClientVerbs(_client);
+        VerbSystem?.RegisterVerb(verb);
+        VerbSystem?.UpdateClientVerbs(_client);
     }
 
     public override void RemoveValue(DreamValue value) {
@@ -688,7 +686,7 @@ public sealed class ClientVerbsList : DreamList {
 
         if (valueIndex != -1) {
             Verbs.RemoveAt(valueIndex);
-            _verbSystem?.UpdateClientVerbs(_client);
+            VerbSystem?.UpdateClientVerbs(_client);
         }
     }
 
@@ -697,7 +695,7 @@ public sealed class ClientVerbsList : DreamList {
         if (end == 0 || end > verbCount) end = verbCount;
 
         Verbs.RemoveRange(start - 1, end - start);
-        _verbSystem?.UpdateClientVerbs(_client);
+        VerbSystem?.UpdateClientVerbs(_client);
     }
 
     public override int GetLength() {
@@ -711,9 +709,9 @@ public sealed class ClientVerbsList : DreamList {
 
 // atom's verbs list
 // Keeps track of an appearance's verbs (atom.verbs, mutable_appearance.verbs, etc)
-public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManager, ServerVerbSystem? verbSystem, DreamObjectAtom atom) : DreamList(objectTree.List.ObjectDefinition, 0) {
+public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManager, DreamObjectAtom atom) : DreamList(objectTree.List.ObjectDefinition, 0) {
     public override DreamValue GetValue(DreamValue key) {
-        if (verbSystem == null)
+        if (VerbSystem == null)
             return DreamValue.Null;
         if (!key.TryGetValueAsInteger(out var index))
             throw new Exception($"Invalid index into verbs list: {key}");
@@ -722,7 +720,7 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
         if (index < 1 || index > verbs.Length)
             throw new Exception($"Out of bounds index on verbs list: {index}");
 
-        return new DreamValue(verbSystem.GetVerb(verbs[index - 1]));
+        return new DreamValue(VerbSystem.GetVerb(verbs[index - 1]));
     }
 
     public override List<DreamValue> GetValues() {
@@ -731,11 +729,11 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
 
     public override IEnumerable<DreamValue> EnumerateValues() {
         var appearance = atomManager.MustGetAppearance(atom);
-        if (verbSystem == null)
+        if (VerbSystem == null)
             yield break;
 
         foreach (var verbId in appearance.Verbs) {
-            var verb = verbSystem.GetVerb(verbId);
+            var verb = VerbSystem.GetVerb(verbId);
 
             yield return new(verb);
         }
@@ -760,7 +758,7 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
 
         atomManager.UpdateAppearance(atom, appearance => {
             if (!verb.VerbId.HasValue)
-                verbSystem?.RegisterVerb(verb);
+                VerbSystem?.RegisterVerb(verb);
             if (!verb.VerbId.HasValue || appearance.Verbs.Contains(verb.VerbId.Value))
                 return; // Even += won't add the verb if it's already in this list
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -45,7 +45,7 @@ public class DreamObjectAtom : DreamObject {
                 value = new(Underlays);
                 return true;
             case "verbs":
-                value = new(new VerbsList(ObjectTree, AtomManager, VerbSystem, this));
+                value = new(new VerbsList(ObjectTree, AtomManager, this));
                 return true;
             case "filters":
                 value = new(Filters);

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -13,20 +13,6 @@ public class DreamObjectAtom : DreamObject {
         Underlays = new(ObjectTree.List.ObjectDefinition, this, AppearanceSystem, true);
         VisContents = new(ObjectTree.List.ObjectDefinition, PvsOverrideSystem, this);
         Filters = new(ObjectTree.List.ObjectDefinition, this);
-
-        AtomManager.AddAtom(this);
-    }
-
-    protected override void HandleDeletion(bool possiblyThreaded) {
-        // SAFETY: RemoveAtom is not threadsafe.
-        if (possiblyThreaded) {
-            EnterIntoDelQueue();
-            return;
-        }
-
-        AtomManager.RemoveAtom(this);
-
-        base.HandleDeletion(possiblyThreaded);
     }
 
     public string GetRTEntityDesc() {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -19,7 +19,7 @@ public sealed class DreamObjectClient : DreamObject {
     public DreamObjectClient(DreamObjectDefinition objectDefinition, DreamConnection connection, ServerScreenOverlaySystem? screenOverlaySystem, ServerClientImagesSystem? clientImagesSystem) : base(objectDefinition) {
         Connection = connection;
         Screen = new(ObjectTree, screenOverlaySystem, Connection);
-        ClientVerbs = new(ObjectTree, VerbSystem, this);
+        ClientVerbs = new(ObjectTree, this);
         Images = new(ObjectTree, clientImagesSystem, Connection);
 
         DreamManager.Clients.Add(this);

--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -244,8 +244,8 @@ public sealed class DreamObjectImage : DreamObject {
         }
     }
 
-    public DreamObject? GetAttachedLoc(){
-        return this._loc;
+    public DreamObject? GetAttachedLoc() {
+        return _loc;
     }
 
     protected override void HandleDeletion(bool possiblyThreaded) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -129,9 +129,6 @@ public sealed class DreamObjectSavefile : DreamObject {
             return;
         }
 
-        if (Deleted)
-            return;
-
         if (Resource is null)
             return; // Seemingly a long-standing issue, I don't know how to fix this, and it only now appears due to the fact objects always Del() now.
                     // Why we can get here? who knows lol

--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -108,18 +108,12 @@ public sealed class DreamObjectWorld : DreamObject {
             return;
         }
 
+        // There shouldn't be two instances of world, but to be safe
+        var isServerWorld = (this == DreamManager.WorldInstance);
+
         base.HandleDeletion(possiblyThreaded);
-
-        _server.Shutdown("world was deleted");
-    }
-
-    ~DreamObjectWorld() {
-        if (this != DreamManager.WorldInstance) {
-            Deleted = true;
-            return;
-        }
-
-        Delete(true);
+        if (isServerWorld)
+            _server.Shutdown("world was deleted");
     }
 
     protected override bool TryGetVar(string varName, out DreamValue value) {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -172,7 +172,9 @@ namespace OpenDreamRuntime.Procs {
             }
 
             if (type.ObjectDefinition.IsSubtypeOf(state.Proc.ObjectTree.Datum)) {
-                state.Enumerators[enumeratorId] = new DreamObjectEnumerator(state.DreamManager.IterateDatums(), type);
+                var datumEnumerator = state.Proc.RefManager.EnumerateType(RefType.DreamObjectDatum);
+
+                state.Enumerators[enumeratorId] = new DreamObjectEnumerator(datumEnumerator, type);
                 return ProcStatus.Continue;
             }
 
@@ -431,7 +433,9 @@ namespace OpenDreamRuntime.Procs {
                         continue;
                     }
                     case FormatSuffix.ReferenceOfValue: {
-                        formattedString.Append(state.DreamManager.CreateRef(interps[nextInterpIndex]));
+                        var refStr = state.Proc.RefManager.GetRefString(interps[nextInterpIndex]);
+                        formattedString.Append(refStr);
+
                         //suffix macro marker is not updated because suffixes do not point to \ref[] interpolations
                         nextInterpIndex++;
                         continue;
@@ -2425,7 +2429,7 @@ suffix
             }
 
             if (value.TryGetValueAsString(out var refString)) {
-                var refValue = state.DreamManager.LocateRef(refString);
+                var refValue = state.Proc.RefManager.LocateRef(refString);
                 if(container is not DreamObjectWorld && containerList is not null) { //if it's a valid ref, it's in world, we don't need to check
                     state.Push(containerList.ContainsValue(refValue) ? refValue : DreamValue.Null);
                     return ProcStatus.Continue;

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -24,6 +24,7 @@ public sealed class DMProc : DreamProc {
 
     public readonly AtomManager AtomManager;
     public readonly DreamManager DreamManager;
+    public readonly DreamRefManager RefManager;
     public readonly ProcScheduler ProcScheduler;
     public readonly IDreamMapManager DreamMapManager;
     public readonly IDreamDebugManager DreamDebugManager;
@@ -33,7 +34,7 @@ public sealed class DMProc : DreamProc {
 
     private readonly int _maxStackSize;
 
-    public DMProc(int id, TreeEntry owningType, ProcDefinitionJson json, string? name, DreamManager dreamManager, AtomManager atomManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, DreamObjectTree objectTree, ProcScheduler procScheduler, ServerVerbSystem verbSystem)
+    public DMProc(int id, TreeEntry owningType, ProcDefinitionJson json, string? name, DreamManager dreamManager, DreamRefManager refManager, AtomManager atomManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, DreamObjectTree objectTree, ProcScheduler procScheduler, ServerVerbSystem verbSystem)
         : base(id, owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbSrc, json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility, json.IsVerb) {
         Bytecode = json.Bytecode ?? [];
         LocalNames = json.Locals ?? [];
@@ -43,6 +44,7 @@ public sealed class DMProc : DreamProc {
 
         AtomManager = atomManager;
         DreamManager = dreamManager;
+        RefManager = refManager;
         ProcScheduler = procScheduler;
         DreamMapManager = dreamMapManager;
         DreamDebugManager = dreamDebugManager;

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -30,11 +30,11 @@ public sealed class DMProc : DreamProc {
     public readonly IDreamDebugManager DreamDebugManager;
     public readonly DreamResourceManager DreamResourceManager;
     public readonly DreamObjectTree ObjectTree;
-    public readonly ServerVerbSystem VerbSystem;
+    public readonly ServerVerbSystem? VerbSystem;
 
     private readonly int _maxStackSize;
 
-    public DMProc(int id, TreeEntry owningType, ProcDefinitionJson json, string? name, DreamManager dreamManager, DreamRefManager refManager, AtomManager atomManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, DreamObjectTree objectTree, ProcScheduler procScheduler, ServerVerbSystem verbSystem)
+    public DMProc(int id, TreeEntry owningType, ProcDefinitionJson json, string? name, DreamManager dreamManager, DreamRefManager refManager, AtomManager atomManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, DreamObjectTree objectTree, ProcScheduler procScheduler, ServerVerbSystem? verbSystem)
         : base(id, owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbSrc, json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility, json.IsVerb) {
         Bytecode = json.Bytecode ?? [];
         LocalNames = json.Locals ?? [];

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -24,8 +24,6 @@ using DreamValueType = OpenDreamRuntime.DreamValue.DreamValueType;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
 using Robust.Server;
 using Robust.Shared.Asynchronous;
-using OpenDreamShared.Rendering;
-using System.ComponentModel;
 
 namespace OpenDreamRuntime.Procs.Native;
 
@@ -1980,7 +1978,10 @@ internal static class DreamProcNativeRoot {
     [DreamProc("ref")]
     [DreamProcParameter("Object", Type = DreamValueTypeFlag.DreamObject)]
     public static DreamValue NativeProc_ref(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        return new DreamValue(bundle.DreamManager.CreateRef(bundle.GetArgument(0, "Object")));
+        var value = bundle.GetArgument(0, "Object");
+        var dreamRef = bundle.RefManager.GetRefString(value);
+
+        return new DreamValue(dreamRef);
     }
 
     [DreamProc("regex")]
@@ -2639,15 +2640,15 @@ internal static class DreamProcNativeRoot {
         return NativeProc_splittext(bundle, src, usr);
     }
 
-    private static void OutputToStatPanel(DreamManager dreamManager, DreamConnection connection, DreamValue name, DreamValue value) {
+    private static void OutputToStatPanel(DreamRefManager refManager, DreamConnection connection, DreamValue name, DreamValue value) {
         if (name.IsNull && value.TryGetValueAsDreamList(out var list)) {
             foreach (var item in list.EnumerateValues())
-                OutputToStatPanel(dreamManager, connection, name, item);
+                OutputToStatPanel(refManager, connection, name, item);
         } else {
             string nameStr = name.Stringify();
             string? atomRef = null;
             if (value.TryGetValueAsDreamObject<DreamObjectAtom>(out _)) // Atoms are clickable
-                atomRef = dreamManager.CreateRef(value);
+                atomRef = refManager.GetRefString(value);
 
             connection.AddStatPanelLine(nameStr, value.Stringify(), atomRef);
         }
@@ -2661,7 +2662,7 @@ internal static class DreamProcNativeRoot {
         DreamValue value = bundle.GetArgument(1, "Value");
 
         if (usr is DreamObjectMob { Connection: {} usrConnection })
-            OutputToStatPanel(bundle.DreamManager, usrConnection, name, value);
+            OutputToStatPanel(bundle.RefManager, usrConnection, name, value);
 
         return DreamValue.Null;
     }
@@ -2678,7 +2679,7 @@ internal static class DreamProcNativeRoot {
         if (usr is DreamObjectMob { Connection: {} connection }) {
             connection.SetOutputStatPanel(panel);
             if (!name.IsNull || !value.IsNull) {
-                OutputToStatPanel(bundle.DreamManager, connection, name, value);
+                OutputToStatPanel(bundle.RefManager, connection, name, value);
             }
 
             return new DreamValue(connection.SelectedStatPanel == panel ? 1 : 0);

--- a/OpenDreamRuntime/Procs/NativeProc.cs
+++ b/OpenDreamRuntime/Procs/NativeProc.cs
@@ -41,36 +41,26 @@ public sealed unsafe class NativeProc : DreamProc {
     }
 
     private readonly DreamManager _dreamManager;
+    private readonly DreamRefManager _refManager;
     private readonly AtomManager _atomManager;
     private readonly IDreamMapManager _mapManager;
     private readonly DreamResourceManager _resourceManager;
     private readonly WalkManager _walkManager;
     private readonly DreamObjectTree _objectTree;
 
-    public readonly ref struct Bundle {
-        public readonly NativeProc Proc;
+    public readonly ref struct Bundle(NativeProc proc, DreamProcArguments arguments) {
+        public readonly NativeProc Proc = proc;
 
         // NOTE: Deliberately not using DreamProcArguments here, tis slow.
-        public readonly ReadOnlySpan<DreamValue> Arguments;
+        public readonly ReadOnlySpan<DreamValue> Arguments = arguments.Values;
 
         public DreamManager DreamManager => Proc._dreamManager;
+        public DreamRefManager RefManager => Proc._refManager;
         public AtomManager AtomManager => Proc._atomManager;
         public IDreamMapManager MapManager => Proc._mapManager;
         public DreamResourceManager ResourceManager => Proc._resourceManager;
         public WalkManager WalkManager => Proc._walkManager;
         public DreamObjectTree ObjectTree => Proc._objectTree;
-        private readonly DreamThread _thread;
-
-        public DreamValue? LastAnimatedObject {
-            get => _thread.LastAnimatedObject;
-            set => _thread.LastAnimatedObject = value;
-        }
-
-        public Bundle(NativeProc proc, DreamThread thread, DreamProcArguments arguments) {
-            Proc = proc;
-            Arguments = arguments.Values;
-            _thread = thread;
-        }
 
         [Pure]
         public DreamValue GetArgument(int argumentPosition, string argumentName) {
@@ -90,12 +80,13 @@ public sealed unsafe class NativeProc : DreamProc {
     private readonly Dictionary<string, DreamValue>? _defaultArgumentValues;
     private readonly delegate*<Bundle, DreamObject?, DreamObject?, DreamValue> _handler;
 
-    public NativeProc(int id, TreeEntry owningType, string name, List<string> argumentNames, Dictionary<string, DreamValue> defaultArgumentValues, HandlerFn handler, DreamManager dreamManager, AtomManager atomManager, IDreamMapManager mapManager, DreamResourceManager resourceManager, WalkManager walkManager, DreamObjectTree objectTree)
+    public NativeProc(int id, TreeEntry owningType, string name, List<string> argumentNames, Dictionary<string, DreamValue> defaultArgumentValues, HandlerFn handler, DreamManager dreamManager, DreamRefManager refManager, AtomManager atomManager, IDreamMapManager mapManager, DreamResourceManager resourceManager, WalkManager walkManager, DreamObjectTree objectTree)
         : base(id, owningType, name, null, ProcAttributes.None, argumentNames, null, null, null, null, null, 0) {
         _defaultArgumentValues = defaultArgumentValues;
         _handler = (delegate*<Bundle, DreamObject?, DreamObject?, DreamValue>)handler.Method.MethodHandle.GetFunctionPointer();
 
         _dreamManager = dreamManager;
+        _refManager = refManager;
         _atomManager = atomManager;
         _mapManager = mapManager;
         _resourceManager = resourceManager;
@@ -109,7 +100,7 @@ public sealed unsafe class NativeProc : DreamProc {
     }
 
     public DreamValue Call(DreamThread thread, DreamObject? src, DreamObject? usr, DreamProcArguments arguments) {
-        var bundle = new Bundle(this, thread, arguments);
+        var bundle = new Bundle(this, arguments);
 
         // TODO: Include this call in the thread's stack in error traces
         return _handler(bundle, src, usr);

--- a/OpenDreamRuntime/ServerContentIoC.cs
+++ b/OpenDreamRuntime/ServerContentIoC.cs
@@ -9,6 +9,7 @@ namespace OpenDreamRuntime;
 public static class ServerContentIoC {
     public static void Register(bool unitTests = false) {
         IoCManager.Register<DreamManager>();
+        IoCManager.Register<DreamRefManager>();
         IoCManager.Register<DreamObjectTree>();
         IoCManager.Register<AtomManager>();
         IoCManager.Register<ProcScheduler>();


### PR DESCRIPTION
Moved all the `ref()` and `locate()` helpers to a new `DreamRefManager`, which holds collections of every DreamObject with its own [`RefType`](https://github.com/wixoaGit/OpenDreamFork/blob/c66d51ae646cb460d19804bb3777f9913b61eb14/OpenDreamRuntime/Objects/DreamRefManager.cs#L372). This gets rid of a fair amount of code duplication, makes new ref types easier to create, and moves some code to a place that makes more sense.

Fixes #2530, which hopefully fixes the routine Paradise server crashes. This is also an important step in moving towards having our own garbage collector/optimizing DreamValue since every datum would need to get assigned an ID.