### PR TITLE
Mark atom.loc as `opendream_compiletimereadonly`. Redefines atom/movable.loc as a non-const.

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/Movable.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Movable.dm
@@ -1,6 +1,8 @@
 ﻿/atom/movable
 	var/screen_loc
-
+	
+	var/loc // Re-declared as atom.loc is a const, but movable.loc isnt.
+	
 	var/animate_movement = FORWARD_STEPS as opendream_unimplemented
 	var/list/locs = null as opendream_unimplemented
 	var/glide_size = 0

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -14,7 +14,7 @@
 	var/tmp/list/vis_locs = null as opendream_unimplemented
 	var/list/vis_contents = null
 
-	var/tmp/atom/loc
+	var/tmp/atom/loc as opendream_compiletimereadonly
 	var/dir = SOUTH
 	var/tmp/x = 0
 	var/tmp/y = 0


### PR DESCRIPTION
BYONDs atom.loc is a const (alongside turf.loc etc). This re-declares `loc` on movables so that's not a constant. It appeared to run fine ingame. Wish I knew how to test it better beyond just running around in world, but alas. Also dropped a bunch of bombs to get more entities moving around and such. No runtimes or crashes :D

Fixes #2378