### PR TITLE
fix CanConstFold not being set by opendream_compiletimereadonly

### DIFF
--- a/DMCompiler/DM/DMVariable.cs
+++ b/DMCompiler/DM/DMVariable.cs
@@ -17,7 +17,7 @@ internal sealed class DMVariable {
     /// </remarks>
     public readonly bool IsConst;
 
-    private bool CanConstFold => (IsConst || ValType.Type.HasFlag(DMValueType.CompiletimeReadonly)) &&
+    private bool CanConstFold => (IsConst || ValType.IsCompileTimeReadOnly) &&
                                  !ValType.Type.HasFlag(DMValueType.NoConstFold);
 
     public DMVariable(DreamPath? type, string name, bool isGlobal, bool isConst, bool isFinal, bool isTmp, DMComplexValueType? valType = null) {


### PR DESCRIPTION
At some point, `CompiletimeReadonly` was moved from being a flag on `ValType.Type` to being a bool on `ValType`. It was checking the flag and always returned false. Fixes #2540

Tested by marking a variable as `opendream_compiletimereadonly` in DMStandard and trying to change it in DM.
```
Error OD0501 at test.dm:2:2: Cannot write to const var
Compilation failed with 1 errors and 1 warnings
```