### PR TITLE
Strip Player-Facing String Formatting

### DIFF
--- a/DMCompiler/Bytecode/StringFormatEncoder.cs
+++ b/DMCompiler/Bytecode/StringFormatEncoder.cs
@@ -90,26 +90,10 @@ public static class StringFormatEncoder {
         return true;
     }
 
-    public static bool Decode(char c) {
-        ushort bytes = c;
-        return (bytes & FormatPrefix) == FormatPrefix; // Could also check that the lower byte is a valid enum but... ehhhhh
-    }
-
     /// <returns>true if argument is a marker for an interpolated value, one of them [] things. false if not.</returns>
     public static bool IsInterpolation(FormatSuffix suffix) {
         //This logic requires that all the interpolated-value enums keep separated from the others.
         //I'd write some type-engine code to catch a discrepancy in that but alas, this language is just not OOPy enough.
         return suffix <= FormatSuffix.ReferenceOfValue;
-    }
-
-    /// <returns>A new version of the string, with all formatting characters removed.</returns>
-    public static string RemoveFormatting(string input) {
-        StringBuilder ret = new StringBuilder(input.Length); // Trying to keep it to one malloc here
-        foreach(char c in input) {
-            if(!Decode(c))
-                ret.Append(c);
-        }
-
-        return ret.ToString();
     }
 }

--- a/OpenDreamClient/Input/ContextMenu/ContextMenuPopup.xaml.cs
+++ b/OpenDreamClient/Input/ContextMenu/ContextMenuPopup.xaml.cs
@@ -62,7 +62,7 @@ internal sealed partial class ContextMenuPopup : Popup {
                 continue;
 
             var reference = new ClientObjectReference(_entityManager.GetNetEntity(uid));
-            var name = _appearanceSystem.GetName(reference);
+            var name = _appearanceSystem.GetNameUnformatted(reference);
             ContextMenu.AddChild(new ContextMenuItem(this, reference, name, sprite.Icon));
         }
 
@@ -74,7 +74,7 @@ internal sealed partial class ContextMenuPopup : Popup {
             if (_spriteQuery.TryGetComponent(uid, out var sprite) &&
                 sprite.Icon.Appearance?.MouseOpacity != MouseOpacity.Transparent) {
                 var reference = new ClientObjectReference(_entityManager.GetNetEntity(uid));
-                var name = _appearanceSystem.GetName(reference);
+                var name = _appearanceSystem.GetNameUnformatted(reference);
                 ContextMenu.AddChild(new ContextMenuItem(this, reference, name, sprite.Icon));
             }
         }
@@ -82,7 +82,7 @@ internal sealed partial class ContextMenuPopup : Popup {
         // Append the turf to the end of the context menu
         var turfUnderMouse = _mouseInputSystem.GetTurfUnderMouse(mapCoords, out var turfId)?.Atom;
         if (turfUnderMouse is not null && turfId is not null) {
-            var name = _appearanceSystem.GetName(turfUnderMouse.Value);
+            var name = _appearanceSystem.GetNameUnformatted(turfUnderMouse.Value);
             var icon = _appearanceSystem.GetTurfIcon(turfId.Value);
 
             ContextMenu.AddChild(new ContextMenuItem(this, turfUnderMouse.Value, name, icon));

--- a/OpenDreamClient/Interface/Controls/ControlMap.cs
+++ b/OpenDreamClient/Interface/Controls/ControlMap.cs
@@ -140,7 +140,7 @@ public sealed class ControlMap(ControlDescriptor controlDescriptor, ControlWindo
     private void UpdateAtomUnderMouse(ClientObjectReference? atom, Vector2 relativePos, Vector2i iconPos) {
         if (!_atomUnderMouse.Equals(atom)) {
             _entitySystemManager.Resolve(ref _appearanceSystem);
-            var name = (atom != null) ? _appearanceSystem.GetName(atom.Value) : string.Empty;
+            var name = (atom != null) ? _appearanceSystem.GetNameUnformatted(atom.Value) : string.Empty;
             Window?.SetStatus(name);
 
             if (_atomUnderMouse != null)

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -350,7 +350,7 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
         return false;
     }
 
-    public string GetName(ClientObjectReference reference) {
+    public string GetNameUnformatted(ClientObjectReference reference) {
         switch (reference.Type) {
             case ClientObjectReference.RefType.Client:
                 return _playerManager.LocalSession?.Name ?? "<unknown>";
@@ -359,7 +359,7 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
                 if (!TryGetAppearance(reference, out var appearance))
                     break;
 
-                return appearance.Name;
+                return StringFormatDecoder.RemoveFormatting(appearance.Name);
         }
 
         return "<unknown>";

--- a/OpenDreamClient/Rendering/MapTextRenderer.cs
+++ b/OpenDreamClient/Rendering/MapTextRenderer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Contracts;
 using System.Text;
 using OpenDreamClient.Interface.Html;
+using OpenDreamShared.Dream;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface.RichText;
@@ -26,7 +27,7 @@ public sealed class MapTextRenderer(IResourceCache resourceCache, MarkupTagManag
             handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(texture.Size, Vector2.Zero));
 
             var message = new FormattedMessage();
-            HtmlParser.Parse(maptext, message);
+            HtmlParser.Parse(StringFormatDecoder.RemoveFormatting(maptext), message);
 
             var (height, lineBreaks) = ProcessWordWrap(message, texture.Size.X);
             var lineHeight = _defaultFont.GetLineHeight(Scale);

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -284,7 +284,7 @@ public sealed class DreamConnection {
 
         // Prune any remaining formatting
         var message = value.Stringify();
-        message = StringFormatEncoder.RemoveFormatting(message);
+        message = StringFormatDecoder.RemoveFormatting(message);
 
         OutputControl(message, null);
     }

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -7,6 +7,7 @@ using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
+using OpenDreamShared.Dream;
 using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
 using Robust.Shared.Map;
@@ -371,7 +372,7 @@ public class DreamObject {
 
         var name = GetRawName();
         bool isProper = StringIsProper(name);
-        name = StringFormatEncoder.RemoveFormatting(name); // TODO: Care about other formatting macros for obj names beyond \proper & \improper
+        name = StringFormatDecoder.RemoveFormatting(name); // TODO: Care about other formatting macros for obj names beyond \proper & \improper
         if(!isProper) {
             return name;
         }
@@ -390,7 +391,7 @@ public class DreamObject {
     /// Similar to <see cref="GetDisplayName"/> except it just returns the name as plaintext, with formatting removed. No article or anything.
     /// </summary>
     public string GetNameUnformatted() {
-        return StringFormatEncoder.RemoveFormatting(GetRawName());
+        return StringFormatDecoder.RemoveFormatting(GetRawName());
     }
 
     /// <summary>

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -444,7 +444,7 @@ namespace OpenDreamRuntime.Procs {
                         if (interps[nextInterpIndex].TryGetValueAsDreamObject<DreamObject>(out var dreamObject)) {
                             formattedString.Append(dreamObject.GetNameUnformatted());
                         } else if (interps[nextInterpIndex].TryGetValueAsString(out var interpStr)) {
-                            formattedString.Append(StringFormatEncoder.RemoveFormatting(interpStr));
+                            formattedString.Append(StringFormatDecoder.RemoveFormatting(interpStr));
                         }
 
                         // NOTE probably should put this above the TryGetAsDreamObject function and continue if formatting has occured

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1233,7 +1233,7 @@ internal static class DreamProcNativeRoot {
                 writer.WriteEndObject();
             }
         } else if (value.TryGetValueAsString(out var text))
-            writer.WriteStringValue(text);
+            writer.WriteStringValue(StringFormatDecoder.RemoveFormatting(text));
         else if (value.TryGetValueAsType(out var type))
             writer.WriteStringValue(type.Path);
         else if (value.TryGetValueAsProc(out var proc))

--- a/OpenDreamRuntime/Resources/ConsoleOutputResource.cs
+++ b/OpenDreamRuntime/Resources/ConsoleOutputResource.cs
@@ -1,5 +1,5 @@
-using DMCompiler.Bytecode;
 using OpenDreamRuntime.Procs.DebugAdapter;
+using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Resources;
 
@@ -22,7 +22,7 @@ sealed class ConsoleOutputResource : DreamResource {
     public override void Output(DreamValue value) {
         // Prune any remaining formatting
         var message = value.Stringify();
-        message = StringFormatEncoder.RemoveFormatting(message);
+        message = StringFormatDecoder.RemoveFormatting(message);
 
         WriteConsole(LogLevel.Info, "world.log", message);
     }

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
-using DMCompiler.Bytecode;
-using System.Runtime.CompilerServices;
 using System.Text;
+using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Resources;
 
@@ -80,7 +79,7 @@ public class DreamResource(int id, string? filePath, string? resourcePath) {
         }
 
         // Prune any remaining formatting
-        text = StringFormatEncoder.RemoveFormatting(text);
+        text = StringFormatDecoder.RemoveFormatting(text);
 
         CreateDirectory();
         File.AppendAllText(ResourcePath, text + "\r\n");

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -1,4 +1,6 @@
 ﻿using System.IO;
+// ReSharper disable once RedundantUsingDirective
+using System.Runtime.CompilerServices;
 using System.Text;
 using OpenDreamShared.Dream;
 

--- a/OpenDreamShared/Dream/StringFormatDecoder.cs
+++ b/OpenDreamShared/Dream/StringFormatDecoder.cs
@@ -8,18 +8,18 @@ public static class StringFormatDecoder {
     /// </summary>
     private static readonly ushort FormatPrefix = 0xFF00;
 
-    private static readonly StringBuilder UnformattedString = new();
+    private static readonly StringBuilder UnformattedStringBuilder = new();
 
     /// <returns>A new version of the string, with all formatting characters removed.</returns>
     public static string RemoveFormatting(string input) {
-        UnformattedString.Clear();
-        UnformattedString.EnsureCapacity(input.Length); // Trying to keep it to one malloc here
+        UnformattedStringBuilder.Clear();
+        UnformattedStringBuilder.EnsureCapacity(input.Length); // Trying to keep it to one malloc here
         foreach(char c in input) {
             ushort bytes = c;
             if((bytes & FormatPrefix) != FormatPrefix)
-                UnformattedString.Append(c);
+                UnformattedStringBuilder.Append(c);
         }
 
-        return UnformattedString.ToString();
+        return UnformattedStringBuilder.ToString();
     }
 }

--- a/OpenDreamShared/Dream/StringFormatDecoder.cs
+++ b/OpenDreamShared/Dream/StringFormatDecoder.cs
@@ -1,0 +1,25 @@
+using System.Text;
+
+namespace OpenDreamShared.Dream;
+
+public static class StringFormatDecoder {
+    /// <summary>
+    /// Refer to DMCompiler.Bytecode.StringFormatEncoder for documentation (can't cref cross-project)
+    /// </summary>
+    private static readonly ushort FormatPrefix = 0xFF00;
+
+    private static readonly StringBuilder UnformattedString = new();
+
+    /// <returns>A new version of the string, with all formatting characters removed.</returns>
+    public static string RemoveFormatting(string input) {
+        UnformattedString.Clear();
+        UnformattedString.EnsureCapacity(input.Length); // Trying to keep it to one malloc here
+        foreach(char c in input) {
+            ushort bytes = c;
+            if((bytes & FormatPrefix) != FormatPrefix)
+                UnformattedString.Append(c);
+        }
+
+        return UnformattedString.ToString();
+    }
+}


### PR DESCRIPTION
Strips formatting chars from the following places:
- `json_encode()`
- maptext
- context menu
- `ClientAppearanceSystem.GetName()` (now `ClientAppearanceSystem.GetNameUnformatted()`)

Stringifying a dream object already deals with formatting chars.

Does not touch OD's debug UIs.

Fixes https://github.com/OpenDreamProject/OpenDream/issues/2508
Fixes https://github.com/OpenDreamProject/OpenDream/issues/2515
Fixes https://github.com/OpenDreamProject/OpenDream/issues/2519