### PR TITLE
Fix `params2list()` duplicate key behavior

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/params2list.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/params2list.dm
@@ -3,4 +3,4 @@
 	ASSERT(json_encode(params2list("a;a;a")) == @#{"a":["","",""]}#)
 
 	ASSERT(params2list("a=1;b=2") ~= list(a="1", b="2"))
-	ASSERT(params2list("a=1;a=2") ~= list(a="2"))
+	ASSERT(params2list("a=1;a=2")["a"] ~= list("1","2"))

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1886,9 +1886,11 @@ internal static class DreamProcNativeRoot {
                     }
                 }
             } else {
-                string queryValue = queryValues[^1]; //Use the last appearance of the key in the query
-
-                list.SetValue(new DreamValue(queryKey), new DreamValue(queryValue));
+                // NOTE: At some point BYOND's handling of duplicate keys changed from "use the last value" to "create a list of values for that key"
+                if (queryValues.Length > 1)
+                    list.SetValue(new DreamValue(queryKey), new DreamValue(objectTree.CreateList(queryValues)));
+                else
+                    list.SetValue(new DreamValue(queryKey), new DreamValue(queryValues[0]));
             }
         }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1886,7 +1886,6 @@ internal static class DreamProcNativeRoot {
                     }
                 }
             } else {
-                // NOTE: At some point BYOND's handling of duplicate keys changed from "use the last value" to "create a list of values for that key"
                 if (queryValues.Length > 1)
                     list.SetValue(new DreamValue(queryKey), new DreamValue(objectTree.CreateList(queryValues)));
                 else


### PR DESCRIPTION
~~At some point BYOND changed duplicate key behavior from "use the last value" to "make a list of all the values".~~

From [the ref](https://www.byond.com/docs/ref/#/proc/params2list):

> If you have multiple items with the same name, they will be combined into a list of text strings. For example, "key=value1;key=value2" would set list["key"] to a list containing "value1" and "value2", not necessarily in that order.

See also https://github.com/OpenDreamProject/OpenDream/pull/2444 and https://github.com/OpenDreamProject/OpenDream/issues/2427. This ticks a box on the latter.