### PR TITLE
Fix `world.GetConfig()` parity

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/world_config.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/world_config.dm
@@ -17,4 +17,4 @@
 
 	world.SetConfig("env", env_var, env_value)
 	world.SetConfig("env", env_var, 17)
-	ASSERT(world.GetConfig("env", env_var) == null)
+	ASSERT(world.GetConfig("env", env_var) == "")

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -100,7 +100,7 @@ internal static class DreamProcNativeWorld {
                     return DreamValue.Null;
                 }
 
-                if (param.TryGetValueAsString(out var paramString) && Environment.GetEnvironmentVariable(paramString) is string strValue) {
+                if (param.TryGetValueAsString(out var paramString) && Environment.GetEnvironmentVariable(paramString) is { } strValue) {
                     return new DreamValue(strValue);
                 }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -98,11 +98,13 @@ internal static class DreamProcNativeWorld {
                     // DM ref says: "If no parameter is specified, a list of the names of all available parameters is returned."
                     // but apparently it's actually just null for "env".
                     return DreamValue.Null;
-                } else if (param.TryGetValueAsString(out var paramString) && Environment.GetEnvironmentVariable(paramString) is string strValue) {
-                    return new DreamValue(strValue);
-                } else {
-                    return DreamValue.Null;
                 }
+
+                if (param.TryGetValueAsString(out var paramString) && Environment.GetEnvironmentVariable(paramString) is string strValue) {
+                    return new DreamValue(strValue);
+                }
+
+                return DreamValue.EmptyString;
             case "ban":
             case "keyban":
             case "ipban":


### PR DESCRIPTION
Ticks a box on https://github.com/OpenDreamProject/OpenDream/issues/2427

See also #2444