### PR TITLE
Proc overrides inherit `waitfor = FALSE`

### DIFF
--- a/DMCompiler/DM/DMCodeTree.Procs.cs
+++ b/DMCompiler/DM/DMCodeTree.Procs.cs
@@ -37,8 +37,10 @@ internal partial class DMCodeTree {
                 var procs = dmObject.GetProcs(procDef.Name);
                 if (procs != null) {
                       var parent = compiler.DMObjectTree.AllProcs[procs[0]];
-                      proc.IsVerb = parent.IsVerb;
-                      if (proc.IsVerb) {
+                      if (parent.Attributes.HasFlag(ProcAttributes.DisableWaitfor))
+                          proc.Attributes |= ProcAttributes.DisableWaitfor;
+                      if (parent.IsVerb) {
+                          proc.IsVerb = true;
                           proc.VerbName = parent.VerbName;
                           proc.VerbCategory = parent.VerbCategory;
                           proc.VerbDesc = parent.VerbDesc;

--- a/OpenDreamRuntime/ServerVerbSystem.cs
+++ b/OpenDreamRuntime/ServerVerbSystem.cs
@@ -179,7 +179,7 @@ public sealed class ServerVerbSystem : VerbSystem {
         }
     }
 
-    private void RunVerb(DreamProc verb, string name, DreamObject? src, DreamConnection usr, params DreamValue[] arguments) {
+    private void RunVerb(DreamProc verb, string name, DreamObject src, DreamConnection usr, params DreamValue[] arguments) {
         using var _ = Profiler.BeginZone("DM Execution", color: (uint)Color.LightPink.ToArgb());
 
         DreamThread.Run($"Execute {name} by {usr.Session!.Name}", async state => {

--- a/OpenDreamRuntime/WalkManager.cs
+++ b/OpenDreamRuntime/WalkManager.cs
@@ -48,7 +48,7 @@ public sealed class WalkManager {
                     break;
 
                 DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, (AtomDirection)dir);
-                await state.Call(moveProc, movable, null, new(newLoc), new(dir));
+                await state.CallNoWait(moveProc, movable, null, new(newLoc), new(dir));
             }
 
             return DreamValue.Null;
@@ -75,7 +75,7 @@ public sealed class WalkManager {
                     break;
                 var dir = DreamProcNativeHelpers.GetRandomDirection(_dreamManager);
                 DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, dir);
-                await state.Call(moveProc, movable, null, new(newLoc), new((int)dir));
+                await state.CallNoWait(moveProc, movable, null, new(newLoc), new((int)dir));
             }
 
             return DreamValue.Null;
@@ -106,7 +106,7 @@ public sealed class WalkManager {
                     continue;
 
                 DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, dir);
-                await state.Call(moveProc, movable, null, new(newLoc), new((int)dir));
+                await state.CallNoWait(moveProc, movable, null, new(newLoc), new((int)dir));
             }
 
             return DreamValue.Null;
@@ -141,7 +141,7 @@ public sealed class WalkManager {
 
                 var dir = enumerator.Current;
                 var newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, dir);
-                await state.Call(moveProc, movable, null, new(newLoc), new((int)dir));
+                await state.CallNoWait(moveProc, movable, null, new(newLoc), new((int)dir));
             }
 
             return DreamValue.Null;


### PR DESCRIPTION
Overriding a proc was setting `waitfor` back to true. This fixes windoors freezing everybody's movement when you bump into them, since `/obj/machinery/door/window/proc/open_and_close()` was calling `sleep()` and `/atom/movable/keyLoop()` broke the `waitfor`.

I also made the walk procs call `Move()` with a forced `set waitfor = FALSE`, which is BYOND behavior.