### PR TITLE
Optimize turf creation

### DIFF
--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -26,16 +26,11 @@ public sealed class DummyDreamMapManager : IDreamMapManager {
 
     public void SetTurf(DreamObjectTurf turf, DreamObjectDefinition type, DreamProcArguments creationArguments) { }
 
+    public void SetTurfAppearance(DreamObjectTurf turf, ImmutableAppearance appearance) { }
+
     public void SetTurfAppearance(DreamObjectTurf turf, MutableAppearance appearance) { }
 
     public void SetAreaAppearance(DreamObjectArea area, MutableAppearance appearance) { }
-
-    public void SetArea(DreamObjectTurf turf, DreamObjectArea area) { }
-
-    public bool TryGetCellFromTransform(TransformComponent transform, [NotNullWhen(true)] out IDreamMapManager.Cell? cell) {
-        cell = null;
-        return false;
-    }
 
     public bool TryGetCellAt(Vector2i pos, int z, [NotNullWhen(true)] out IDreamMapManager.Cell? cell) {
         cell = null;

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -619,6 +619,7 @@ public sealed class AtomManager {
         return false;
     }
 
+    // TODO: This should probably return an ImmutableAppearance so they don't have to be sent through ServerAppearanceSystem.AddAppearance()
     public MutableAppearance GetAppearanceFromDefinition(DreamObjectDefinition def) {
         if (_definitionAppearanceCache.TryGetValue(def, out var appearance))
             return appearance;

--- a/OpenDreamRuntime/Map/DreamMapManager.cs
+++ b/OpenDreamRuntime/Map/DreamMapManager.cs
@@ -41,6 +41,7 @@ public sealed partial class DreamMapManager : IDreamMapManager {
 
     private List<DreamMapJson>? _jsonMaps = new();
     private readonly HashSet<EntityUid> _entityLookupSet = new();
+    private readonly Dictionary<DreamObjectDefinition, ImmutableAppearance> _defaultTurfAppearanceCache = new();
 
     public void Initialize() {
         _appearanceSystem = _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
@@ -76,7 +77,7 @@ public sealed partial class DreamMapManager : IDreamMapManager {
 
             List<(Vector2i, Tile)> tiles = new(level.QueuedTileUpdates.Count);
             foreach (var tileUpdate in level.QueuedTileUpdates) {
-                tiles.Add( (tileUpdate.Key, tileUpdate.Value) );
+                tiles.Add(tileUpdate);
             }
 
             _mapSystem.SetTiles(level.Grid, tiles);
@@ -165,8 +166,14 @@ public sealed partial class DreamMapManager : IDreamMapManager {
 
         cell.Turf.SetTurfType(type);
 
-        MutableAppearance turfAppearance = _atomManager.GetAppearanceFromDefinition(cell.Turf.ObjectDefinition);
-        SetTurfAppearance(cell.Turf, turfAppearance);
+        if (!_defaultTurfAppearanceCache.TryGetValue(cell.Turf.ObjectDefinition, out var appearance)) {
+            var mutable = _atomManager.GetAppearanceFromDefinition(cell.Turf.ObjectDefinition);
+
+            appearance = _appearanceSystem.AddAppearance(mutable);
+            _defaultTurfAppearanceCache.Add(cell.Turf.ObjectDefinition, appearance);
+        }
+
+        SetTurfAppearance(cell.Turf, appearance);
 
         cell.Turf.InitSpawn(creationArguments);
     }
@@ -179,28 +186,36 @@ public sealed partial class DreamMapManager : IDreamMapManager {
     /// Caches the turf/area appearance pair instead of recreating and re-registering it for every turf in the game.
     /// This is cleared out when an area appearance changes
     /// </summary>
-    private readonly Dictionary<ValueTuple<MutableAppearance, uint>, MutableAppearance> _turfAreaLookup = new();
+    private readonly Dictionary<ValueTuple<ImmutableAppearance, uint>, ImmutableAppearance> _turfAreaLookup = new();
 
-    public void SetTurfAppearance(DreamObjectTurf turf, MutableAppearance appearance) {
+    public void SetTurfAppearance(DreamObjectTurf turf, ImmutableAppearance appearance) {
         appearance.EnabledMouseEvents = _atomManager.GetEnabledMouseEvents(turf);
 
-        if(turf.Cell.Area.Appearance != _appearanceSystem.DefaultAppearance)
-            if(!appearance.Overlays.Contains(turf.Cell.Area.Appearance)) {
-                if(!_turfAreaLookup.TryGetValue((appearance, turf.Cell.Area.Appearance.MustGetId()), out var newAppearance)) {
-                    newAppearance = MutableAppearance.GetCopy(appearance);
-                    newAppearance.Overlays.Add(turf.Cell.Area.Appearance);
+        if (turf.Cell.Area.Appearance != _appearanceSystem.DefaultAppearance) {
+            if (!appearance.Overlays.Contains(turf.Cell.Area.Appearance)) {
+                if (!_turfAreaLookup.TryGetValue((appearance, turf.Cell.Area.Appearance.MustGetId()), out var newAppearance)) {
+                    var mutable = appearance.ToMutable();
+
+                    mutable.Overlays.Add(turf.Cell.Area.Appearance);
+                    newAppearance = _appearanceSystem.AddAppearance(mutable);
                     _turfAreaLookup.Add((appearance, turf.Cell.Area.Appearance.MustGetId()), newAppearance);
                 }
 
                 appearance = newAppearance;
             }
-
-        var immutableAppearance = _appearanceSystem.AddAppearance(appearance);
+        }
 
         var level = _levels[turf.Z - 1];
-        uint turfId = immutableAppearance.MustGetId();
-        level.QueuedTileUpdates[(turf.X, turf.Y)] = new Tile((int)turfId);
-        turf.Appearance = immutableAppearance;
+        var turfId = appearance.MustGetId();
+        var turfPos = new Vector2i(turf.X, turf.Y);
+        level.QueuedTileUpdates.Add( (turfPos, new Tile((int)turfId)) );
+        turf.Appearance = appearance;
+    }
+
+    public void SetTurfAppearance(DreamObjectTurf turf, MutableAppearance appearance) {
+        var immutable = _appearanceSystem.AddAppearance(appearance);
+
+        SetTurfAppearance(turf, immutable);
     }
 
     public void SetAreaAppearance(DreamObjectArea area, MutableAppearance appearance) {
@@ -229,8 +244,9 @@ public sealed partial class DreamMapManager : IDreamMapManager {
             }
 
             var level = _levels[turf.Z - 1];
-            uint turfId = newAppearance.MustGetId();
-            level.QueuedTileUpdates[(turf.X, turf.Y)] = new Tile((int)turfId);
+            var turfId = newAppearance.MustGetId();
+            var turfPos = new Vector2i(turf.X, turf.Y);
+            level.QueuedTileUpdates.Add( (turfPos, new Tile((int)turfId)));
         }
     }
 
@@ -462,7 +478,7 @@ public interface IDreamMapManager {
         public readonly int Z;
         public readonly Entity<MapGridComponent> Grid;
         public Cell[,] Cells;
-        public readonly Dictionary<Vector2i, Tile> QueuedTileUpdates = new();
+        public readonly List<(Vector2i, Tile)> QueuedTileUpdates = new();
 
         public Level(int z, Entity<MapGridComponent> grid, DreamObjectDefinition turfType, DreamObjectArea area, Vector2i size) {
             Z = z;
@@ -521,6 +537,7 @@ public interface IDreamMapManager {
     public void UpdateTiles();
 
     public void SetTurf(DreamObjectTurf turf, DreamObjectDefinition type, DreamProcArguments creationArguments);
+    public void SetTurfAppearance(DreamObjectTurf turf, ImmutableAppearance appearance);
     public void SetTurfAppearance(DreamObjectTurf turf, MutableAppearance appearance);
     public void SetAreaAppearance(DreamObjectArea area, MutableAppearance appearance);
     public bool TryGetCellAt(Vector2i pos, int z, [NotNullWhen(true)] out Cell? cell);

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -961,8 +961,6 @@ public sealed class DreamOverlaysList(DreamObjectDefinition listDef, DreamObject
 // atom.vis_contents list
 // Operates on an atom's appearance
 public sealed class DreamVisContentsList : DreamList {
-    [Dependency] private readonly AtomManager _atomManager = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
     private readonly PvsOverrideSystem? _pvsOverrideSystem;
 
     private readonly List<DreamObjectAtom> _visContents = new();
@@ -989,7 +987,7 @@ public sealed class DreamVisContentsList : DreamList {
         if (end == 0 || end > count) end = count;
 
         _visContents.RemoveRange(start - 1, end - start);
-        _atomManager.UpdateAppearance(_atom, appearance => {
+        AtomManager.UpdateAppearance(_atom, appearance => {
             appearance.VisContents.RemoveRange(start - 1, end - start);
         });
     }
@@ -1029,9 +1027,9 @@ public sealed class DreamVisContentsList : DreamList {
         if (entity != EntityUid.Invalid)
             _pvsOverrideSystem?.AddGlobalOverride(entity);
 
-        _atomManager.UpdateAppearance(_atom, appearance => {
+        AtomManager.UpdateAppearance(_atom, appearance => {
             // Add even an invalid UID to keep this and _visContents in sync
-            appearance.VisContents.Add(_entityManager.GetNetEntity(entity));
+            appearance.VisContents.Add(EntityManager.GetNetEntity(entity));
         });
     }
 
@@ -1040,8 +1038,8 @@ public sealed class DreamVisContentsList : DreamList {
             return;
 
         _visContents.Remove(movable);
-        _atomManager.UpdateAppearance(_atom, appearance => {
-            appearance.VisContents.Remove(_entityManager.GetNetEntity(movable.Entity));
+        AtomManager.UpdateAppearance(_atom, appearance => {
+            appearance.VisContents.Remove(EntityManager.GetNetEntity(movable.Entity));
         });
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -1,21 +1,20 @@
 ﻿namespace OpenDreamRuntime.Objects.Types;
 
 [Virtual]
-public class DreamObjectAtom : DreamObject {
-    public readonly DreamOverlaysList Overlays;
-    public readonly DreamOverlaysList Underlays;
-    public readonly DreamVisContentsList VisContents;
-    public readonly DreamFilterList Filters;
-    public DreamList? VisLocs; // TODO: Implement
+public class DreamObjectAtom(DreamObjectDefinition objectDefinition) : DreamObject(objectDefinition) {
+    private DreamOverlaysList Overlays => _overlays ??= new(ObjectTree.List.ObjectDefinition, this, AppearanceSystem, false);
+    private DreamOverlaysList Underlays => _underlays ??= new(ObjectTree.List.ObjectDefinition, this, AppearanceSystem, true);
+    private DreamVisContentsList VisContents => _visContents ??= new(ObjectTree.List.ObjectDefinition, PvsOverrideSystem, this);
+    private DreamFilterList Filters => _filters ??= new(ObjectTree.List.ObjectDefinition, this);
+    private DreamList VisLocs => _visLocs ??= ObjectTree.CreateList();
 
-    public DreamObjectAtom(DreamObjectDefinition objectDefinition) : base(objectDefinition) {
-        Overlays = new(ObjectTree.List.ObjectDefinition, this, AppearanceSystem, false);
-        Underlays = new(ObjectTree.List.ObjectDefinition, this, AppearanceSystem, true);
-        VisContents = new(ObjectTree.List.ObjectDefinition, PvsOverrideSystem, this);
-        Filters = new(ObjectTree.List.ObjectDefinition, this);
-    }
+    private DreamOverlaysList? _overlays;
+    private DreamOverlaysList? _underlays;
+    private DreamVisContentsList? _visContents;
+    private DreamFilterList? _filters;
+    private DreamList? _visLocs; // TODO: Implement
 
-    public string GetRTEntityDesc() {
+    protected string GetRTEntityDesc() {
         if (AtomManager.TryGetAppearance(this, out var appearance) && appearance.Desc != null)
             return appearance.Desc;
 
@@ -23,11 +22,11 @@ public class DreamObjectAtom : DreamObject {
     }
 
     protected override void HandleDeletion() {
-        Overlays.DecRef();
-        Underlays.DecRef();
-        VisContents.DecRef();
-        Filters.DecRef();
-        VisLocs?.DecRef();
+        _overlays?.DecRef();
+        _underlays?.DecRef();
+        _visContents?.DecRef();
+        _filters?.DecRef();
+        _visLocs?.DecRef();
 
         base.HandleDeletion();
     }
@@ -64,7 +63,6 @@ public class DreamObjectAtom : DreamObject {
                 value = new(Filters);
                 return true;
             case "vis_locs":
-                VisLocs ??= ObjectTree.CreateList();
                 VisLocs.IncRef();
                 value = new(VisLocs);
                 return true;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
@@ -17,8 +17,8 @@ public sealed class DreamObjectTurf : DreamObjectAtom {
         Z = z;
 
         Cell = default!; // NEEDS to be set by DreamMapManager after creation
+        Appearance = default!; // This will be set by DreamMapManager
         Contents = new TurfContentsList(ObjectTree.List.ObjectDefinition, this);
-        Appearance = AppearanceSystem!.AddAppearance(AtomManager.GetAppearanceFromDefinition(ObjectDefinition));
     }
 
     public override void Initialize(DreamProcArguments args) {

--- a/OpenDreamShared/Dream/ImmutableAppearance.cs
+++ b/OpenDreamShared/Dream/ImmutableAppearance.cs
@@ -64,11 +64,7 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
     [ViewVariables] public int MouseDropPointer = MutableAppearance.Default.MouseDropPointer;
 
     /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
-    [ViewVariables] public readonly float[] Transform = [
-        1, 0,   // a d
-        0, 1,   // b e
-        0, 0    // c f
-    ];
+    [ViewVariables] public readonly float[] Transform = MutableAppearance.Default.Transform;
 
     // PixelOffset2 behaves the same as PixelOffset in top-down mode, so this is used
     public Vector2i TotalPixelOffset => PixelOffset + PixelOffset2;
@@ -120,8 +116,10 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         Verbs = appearance.Verbs.ToArray();
         Override = appearance.Override;
 
-        for (int i = 0; i < 6; i++) {
-            Transform[i] = appearance.Transform[i];
+        if (appearance.Transform != MutableAppearance.Default.Transform) {
+            for (int i = 0; i < 6; i++) {
+                Transform[i] = appearance.Transform[i];
+            }
         }
     }
 
@@ -533,7 +531,9 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         result.VisContents.AddRange(VisContents);
         result.Filters.AddRange(Filters);
         result.Verbs.AddRange(Verbs);
-        Array.Copy(Transform, result.Transform, 6);
+
+        if (Transform != MutableAppearance.Default.Transform)
+            Array.Copy(Transform, result.Transform, 6);
 
         return result;
     }

--- a/OpenDreamShared/Dream/ImmutableAppearance.cs
+++ b/OpenDreamShared/Dream/ImmutableAppearance.cs
@@ -50,7 +50,7 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
     [ViewVariables] public readonly MouseOpacity MouseOpacity = MutableAppearance.Default.MouseOpacity;
     [ViewVariables] public readonly ImmutableAppearance[] Overlays;
     [ViewVariables] public readonly ImmutableAppearance[] Underlays;
-    [ViewVariables] public readonly Robust.Shared.GameObjects.NetEntity[] VisContents;
+    [ViewVariables] public readonly NetEntity[] VisContents;
     [ViewVariables] public readonly DreamFilter[] Filters;
     [ViewVariables] public readonly int[] Verbs;
     [ViewVariables] public readonly ColorMatrix ColorMatrix = ColorMatrix.Identity;
@@ -117,9 +117,8 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         Override = appearance.Override;
 
         if (appearance.Transform != MutableAppearance.Default.Transform) {
-            for (int i = 0; i < 6; i++) {
-                Transform[i] = appearance.Transform[i];
-            }
+            Transform = new float[6];
+            Array.Copy(appearance.Transform, Transform, 6);
         }
     }
 


### PR DESCRIPTION
I put this code in TestGame:
```dm
/world/New()
	var/start = world.timeofday
	world.maxx = world.maxy = 200
	world.maxz = 100
	world.log << "[(world.timeofday - start) / 10] seconds"
```
and optimized a few things that showed up in the profiler.
* ImmutableAppearance's Transform now defaults to `MutableAppearance.Default.Transform` instead of creating a new array every time
* DreamObjectAtom now lazy-loads `overlays`, `underlays`, `vis_contents`, `vis_locs`, and `filters`
* Turfs now cache their default ImmutableAppearance so AppearanceSystem doesn't have to search for it on every turf creation
* Turfs don't duplicate work by setting `Appearance` in their constructor
* DreamVisContentsList doesn't use IoCManager for dependencies it already has access to
* `QueuedTileUpdates` did not need to be a Dictionary

Before:
`[INFO] world.log: 17.6 seconds`
After:
`[INFO] world.log: 4.7 seconds`