### PR TITLE
Cap pathfinding distance

### DIFF
--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -54,7 +54,7 @@ public sealed class DummyDreamMapManager : IDreamMapManager {
         yield break;
     }
 
-    public IEnumerable<AtomDirection> CalculateSteps((int X, int Y, int Z) loc, (int X, int Y, int Z) dest, int distance) {
+    public IEnumerable<AtomDirection> CalculateSteps((int X, int Y, int Z) loc, (int X, int Y, int Z) dest, int targetDistance, int maxSteps) {
         yield break;
     }
 }

--- a/OpenDreamRuntime/Map/DreamMapManager.Pathfinding.cs
+++ b/OpenDreamRuntime/Map/DreamMapManager.Pathfinding.cs
@@ -40,7 +40,7 @@ public partial class DreamMapManager {
         }
     }
 
-    public IEnumerable<AtomDirection> CalculateSteps((int X, int Y, int Z) loc, (int X, int Y, int Z) dest, int distance) {
+    public IEnumerable<AtomDirection> CalculateSteps((int X, int Y, int Z) loc, (int X, int Y, int Z) dest, int targetDistance, int maxSteps) {
         int z = loc.Z;
         if (z != dest.Z) // Different Z-levels are unreachable
             yield break;
@@ -55,6 +55,8 @@ public partial class DreamMapManager {
             var nextY = current.Y + offsetY;
             if (nextX < 1 || nextX > Size.X || nextY < 1 || nextY > Size.Y)
                 return; // This is outside of map bounds
+            if (current.NeededSteps >= maxSteps)
+                return; // We won't search any further than maxSteps
 
             var next = PathFindNode.GetNode(nextX, nextY);
             if (explored.Contains(next))
@@ -74,7 +76,7 @@ public partial class DreamMapManager {
         while (toExplore.TryDequeue(out var node)) {
             var distX = node.X - dest.X;
             var distY = node.Y - dest.Y;
-            if (Math.Sqrt(distX * distX + distY * distY) <= distance) { // Path to the destination was found
+            if ((int)Math.Sqrt(distX * distX + distY * distY) <= targetDistance) { // Path to the destination was found
                 Stack<AtomDirection> path = new(node.NeededSteps);
 
                 while (node.Parent != null) {

--- a/OpenDreamRuntime/Map/DreamMapManager.cs
+++ b/OpenDreamRuntime/Map/DreamMapManager.cs
@@ -548,5 +548,5 @@ public interface IDreamMapManager {
 
     public IEnumerable<DreamObjectMob> GetMobsInRange((int X, int Y, int Z) loc, int distance);
 
-    public IEnumerable<AtomDirection> CalculateSteps((int X, int Y, int Z) loc, (int X, int Y, int Z) dest, int distance);
+    public IEnumerable<AtomDirection> CalculateSteps((int X, int Y, int Z) loc, (int X, int Y, int Z) dest, int targetDistance, int maxSteps);
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -841,7 +841,9 @@ internal static class DreamProcNativeRoot {
 
         var loc = bundle.AtomManager.GetAtomPosition(refAtom);
         var dest = bundle.AtomManager.GetAtomPosition(trgAtom);
-        var steps = bundle.MapManager.CalculateSteps(loc, dest, minArg);
+        var worldView = bundle.DreamManager.WorldInstance.DefaultView;
+        var maxSteps = Math.Max(worldView.Width, worldView.Height) - 1;
+        var steps = bundle.MapManager.CalculateSteps(loc, dest, minArg, maxSteps);
 
         // We perform a whole path-find then return only the first step
         // Truly, DM's most optimized proc
@@ -872,7 +874,12 @@ internal static class DreamProcNativeRoot {
 
         var loc = bundle.AtomManager.GetAtomPosition(refAtom);
         var dest = bundle.AtomManager.GetAtomPosition(trgAtom);
-        var steps = bundle.MapManager.CalculateSteps(loc, dest, minArg);
+        var worldView = bundle.DreamManager.WorldInstance.DefaultView;
+        var maxSteps = Math.Max(worldView.Width, worldView.Height) - 1;
+
+        // TODO: The DM ref says null is returned if this needs more than world.view*2 steps, so that's what we do.
+        //       However, that's pretty far off what actually happens. It seems to still try to move you towards the goal in some way.
+        var steps = bundle.MapManager.CalculateSteps(loc, dest, minArg, maxSteps);
         var result = bundle.ObjectTree.CreateList();
 
         foreach (var step in steps) {

--- a/OpenDreamRuntime/WalkManager.cs
+++ b/OpenDreamRuntime/WalkManager.cs
@@ -140,7 +140,9 @@ public sealed class WalkManager {
 
                 var currentLoc = _atomManager.GetAtomPosition(movable);
                 var targetLoc = _atomManager.GetAtomPosition(target);
-                var steps = _dreamMapManager.CalculateSteps(currentLoc, targetLoc, min);
+                var worldView = _dreamManager.WorldInstance.DefaultView;
+                var maxSteps = Math.Max(worldView.Width, worldView.Height) - 1;
+                var steps = _dreamMapManager.CalculateSteps(currentLoc, targetLoc, min, maxSteps);
                 using var enumerator = steps.GetEnumerator();
                 if (!enumerator.MoveNext()) // No more steps to take
                     break;


### PR DESCRIPTION
The /tg/ server would regularly stutter because it was attempting impossible pathfinds and spending >200ms searching over 180 turfs away.

The DM ref says `get_step_to()`/`get_steps_to()` returns null when it needs more than `world.view*2` steps so that's what I capped it to. The DM ref is totally wrong in my testing, but this works well enough for our case right now.