### PR TITLE
Batch appearance removals

### DIFF
--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -76,7 +76,7 @@ internal sealed partial class ClientAppearanceSystem : SharedAppearanceSystem {
         UpdatesOutsidePrediction = true;
 
         SubscribeNetworkEvent<NewAppearanceEvent>(OnNewAppearance);
-        SubscribeNetworkEvent<RemoveAppearanceEvent>(e => _appearances.Remove(e.AppearanceId));
+        SubscribeNetworkEvent<RemoveAppearancesEvent>(OnRemoveAppearances);
         SubscribeNetworkEvent<AnimationEvent>(OnAnimation);
         SubscribeNetworkEvent<FlickEvent>(OnFlick);
         SubscribeLocalEvent<DMISpriteComponent, WorldAABBEvent>(OnWorldAABB);
@@ -164,6 +164,13 @@ internal sealed partial class ClientAppearanceSystem : SharedAppearanceSystem {
             if (_appearanceLoadCallbacks.TryGetValue(appearanceId, out var callbacks)) {
                 foreach (var callback in callbacks) callback(_appearances[appearanceId]);
             }
+        }
+    }
+
+    private void OnRemoveAppearances(RemoveAppearancesEvent e) {
+        foreach (var appearanceId in e.Appearances) {
+            _appearances.Remove(appearanceId);
+            _appearanceLoadCallbacks.Remove(appearanceId);
         }
     }
 

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -26,6 +26,7 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
     /// </summary>
     private readonly Lock _lock = new();
 
+    private readonly Queue<uint> _appearanceRemovalQueue = new();
     private readonly Dictionary<uint, ProxyWeakRef> _idToAppearance = new();
     private uint _counter;
 
@@ -33,6 +34,8 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
     [Dependency] private IPlayerManager _playerManager = default!;
 
     public override void Initialize() {
+        UpdatesOutsidePrediction = true;
+
         DefaultAppearance = new ImmutableAppearance(MutableAppearance.Default, this);
         DefaultAppearance.MarkRegistered(_counter++); //first appearance registered gets id 0, this is the blank default appearance
         ProxyWeakRef proxyWeakRef = new(DefaultAppearance);
@@ -50,6 +53,31 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
             _appearanceLookup.Clear();
             _idToAppearance.Clear();
         }
+    }
+
+    public override void Update(float frameTime) {
+        lock (_lock) {
+            if (_appearanceRemovalQueue.Count > 0) {
+                var removalEvent = new RemoveAppearancesEvent(_appearanceRemovalQueue.ToArray());
+                RaiseNetworkEvent(removalEvent);
+
+                while (_appearanceRemovalQueue.TryDequeue(out var appearanceId)) {
+                    var proxyWeakRef = _idToAppearance[appearanceId];
+
+                    proxyWeakRef.TryGetTarget(out var appearance);
+                    if (_appearanceLookup.TryGetValue(proxyWeakRef, out var weakRef)) {
+                        //it is possible that a new appearance was created with the same hash before the GC got around to cleaning up the old one
+                        if (weakRef.TryGetTarget(out var target) && !ReferenceEquals(target, appearance))
+                            continue;
+
+                        _appearanceLookup.Remove(proxyWeakRef);
+                        _idToAppearance.Remove(appearanceId);
+                    }
+                }
+            }
+        }
+
+        base.Update(frameTime);
     }
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e) {
@@ -101,15 +129,7 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
     [Access(typeof(ImmutableAppearance))]
     public override void RemoveAppearance(ImmutableAppearance appearance) {
         lock (_lock) {
-            ProxyWeakRef proxyWeakRef = new(appearance);
-            if(_appearanceLookup.TryGetValue(proxyWeakRef, out var weakRef)) {
-                //it is possible that a new appearance was created with the same hash before the GC got around to cleaning up the old one
-                if(weakRef.TryGetTarget(out var target) && !ReferenceEquals(target,appearance))
-                    return;
-                _appearanceLookup.Remove(proxyWeakRef);
-                _idToAppearance.Remove(appearance.MustGetId());
-                RaiseNetworkEvent(new RemoveAppearanceEvent(appearance.MustGetId()));
-            }
+            _appearanceRemovalQueue.Enqueue(appearance.MustGetId());
         }
     }
 

--- a/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
+++ b/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
@@ -15,8 +15,8 @@ public abstract class SharedAppearanceSystem : EntitySystem {
     }
 
     [Serializable, NetSerializable]
-    public sealed class RemoveAppearanceEvent(uint appearanceId) : EntityEventArgs {
-        public uint AppearanceId { get; } = appearanceId;
+    public sealed class RemoveAppearancesEvent(uint[] appearances) : EntityEventArgs {
+        public uint[] Appearances { get; } = appearances;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
The garbage collector collects hundreds or thousands `ImmutableAppearance` objects at a time.
```cs
~ImmutableAppearance() {
    if(_needsFinalizer && _registeredId is not null)
        _appearanceSystem!.RemoveAppearance(this);
}
```
This floods the client with tons of `RemoveAppearanceEvent` events to process, which happens slowly and prevents other events from firing. This PR batches these removals and sends them all in a single event once per tick.

Fixes #2510