### PR TITLE
Batch new appearances

### DIFF
--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -75,7 +75,7 @@ internal sealed partial class ClientAppearanceSystem : SharedAppearanceSystem {
     public override void Initialize() {
         UpdatesOutsidePrediction = true;
 
-        SubscribeNetworkEvent<NewAppearanceEvent>(OnNewAppearance);
+        SubscribeNetworkEvent<NewAppearancesEvent>(OnNewAppearances);
         SubscribeNetworkEvent<RemoveAppearancesEvent>(OnRemoveAppearances);
         SubscribeNetworkEvent<AnimationEvent>(OnAnimation);
         SubscribeNetworkEvent<FlickEvent>(OnFlick);
@@ -153,16 +153,18 @@ internal sealed partial class ClientAppearanceSystem : SharedAppearanceSystem {
         return icon;
     }
 
-    private void OnNewAppearance(NewAppearanceEvent e) {
-        uint appearanceId = e.Appearance.MustGetId();
-        _appearances[appearanceId] = e.Appearance;
+    private void OnNewAppearances(NewAppearancesEvent e) {
+        foreach (var appearance in e.Appearances) {
+            uint appearanceId = appearance.MustGetId();
+            _appearances[appearanceId] = appearance;
 
-        // If we haven't received the MsgAllAppearances yet, leave this initialization for later
-        if (_receivedAllAppearancesMsg) {
-            _appearances[appearanceId].ResolveOverlays(this);
+            // If we haven't received the MsgAllAppearances yet, leave this initialization for later
+            if (_receivedAllAppearancesMsg) {
+                _appearances[appearanceId].ResolveOverlays(this);
 
-            if (_appearanceLoadCallbacks.TryGetValue(appearanceId, out var callbacks)) {
-                foreach (var callback in callbacks) callback(_appearances[appearanceId]);
+                if (_appearanceLoadCallbacks.TryGetValue(appearanceId, out var callbacks)) {
+                    foreach (var callback in callbacks) callback(_appearances[appearanceId]);
+                }
             }
         }
     }

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -27,6 +27,7 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
     private readonly Lock _lock = new();
 
     private readonly Queue<uint> _appearanceRemovalQueue = new();
+    private readonly List<ImmutableAppearance> _appearanceSendQueue = new();
     private readonly Dictionary<uint, ProxyWeakRef> _idToAppearance = new();
     private uint _counter;
 
@@ -57,6 +58,11 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
 
     public override void Update(float frameTime) {
         lock (_lock) {
+            if (_appearanceSendQueue.Count > 0) {
+                RaiseNetworkEvent(new NewAppearancesEvent(_appearanceSendQueue.ToArray()));
+                _appearanceSendQueue.Clear();
+            }
+
             if (_appearanceRemovalQueue.Count > 0) {
                 var removalEvent = new RemoveAppearancesEvent(_appearanceRemovalQueue.ToArray());
                 RaiseNetworkEvent(removalEvent);
@@ -99,11 +105,11 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
 
     private void RegisterAppearance(ImmutableAppearance immutableAppearance) {
         immutableAppearance.MarkRegistered(_counter++); //lets this appearance know it needs to do GC finaliser & get an ID
+
         ProxyWeakRef proxyWeakRef = new(immutableAppearance);
         _appearanceLookup.Add(proxyWeakRef);
         _idToAppearance.Add(immutableAppearance.MustGetId(), proxyWeakRef);
-
-        RaiseNetworkEvent(new NewAppearanceEvent(immutableAppearance));
+        _appearanceSendQueue.Add(immutableAppearance);
     }
 
     public ImmutableAppearance AddAppearance(MutableAppearance appearance, bool registerAppearance = true) {

--- a/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
+++ b/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
@@ -10,8 +10,8 @@ public abstract class SharedAppearanceSystem : EntitySystem {
     public abstract void RemoveAppearance(ImmutableAppearance appearance);
 
     [Serializable, NetSerializable]
-    public sealed class NewAppearanceEvent(ImmutableAppearance appearance) : EntityEventArgs {
-        public ImmutableAppearance Appearance { get; } = appearance;
+    public sealed class NewAppearancesEvent(ImmutableAppearance[] appearances) : EntityEventArgs {
+        public ImmutableAppearance[] Appearances { get; } = appearances;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
Similar to #2566, but with new appearances sent to clients. This stops `NewAppearanceEvent` from clogging the client when there are a lot of new appearances, such as during SS13 round init or round start.