### PR TITLE
Compress `NewAppearancesEvent`

### DIFF
--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -7,9 +7,11 @@ using Robust.Client.Graphics;
 using Robust.Shared.Prototypes;
 using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
+using OpenDreamShared.Network.Messages;
 using OpenDreamShared.Resources;
 using Robust.Client.Player;
 using Robust.Shared.Map;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
 namespace OpenDreamClient.Rendering;
@@ -70,6 +72,7 @@ internal sealed partial class ClientAppearanceSystem : SharedAppearanceSystem {
     [Dependency] private IMapManager _mapManager = default!;
     [Dependency] private MapSystem _mapSystem = default!;
     [Dependency] private IPrototypeManager _protoManager = default!;
+    [Dependency] private IRobustSerializer _serializer = default!;
     [Dependency] private ClientVerbSystem _verbSystem = default!;
 
     public override void Initialize() {
@@ -154,7 +157,11 @@ internal sealed partial class ClientAppearanceSystem : SharedAppearanceSystem {
     }
 
     private void OnNewAppearances(NewAppearancesEvent e) {
-        foreach (var appearance in e.Appearances) {
+        var decompressed = MsgAllAppearances.DecompressAppearances(new(e.Data));
+        var count = decompressed.ReadInt32();
+
+        for (int i = 0; i < count; i++) {
+            var appearance = new ImmutableAppearance(decompressed, _serializer);
             uint appearanceId = appearance.MustGetId();
             _appearances[appearanceId] = appearance;
 

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Player;
 using System.Diagnostics;
 using System.Threading;
 using OpenDreamRuntime.Objects.Types;
+using Robust.Shared.Serialization;
 using SharedAppearanceSystem = OpenDreamShared.Rendering.SharedAppearanceSystem;
 
 namespace OpenDreamRuntime.Rendering;
@@ -33,6 +34,7 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
 
     [Dependency] private DreamManager _dreamManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
+    [Dependency] private IRobustSerializer _serializer = default!;
 
     public override void Initialize() {
         UpdatesOutsidePrediction = true;
@@ -59,7 +61,9 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
     public override void Update(float frameTime) {
         lock (_lock) {
             if (_appearanceSendQueue.Count > 0) {
-                RaiseNetworkEvent(new NewAppearancesEvent(_appearanceSendQueue.ToArray()));
+                using var compressed = MsgAllAppearances.CompressAppearances(_appearanceSendQueue, _appearanceSendQueue.Count, _serializer);
+
+                RaiseNetworkEvent(new NewAppearancesEvent(compressed.ToArray()));
                 _appearanceSendQueue.Clear();
             }
 

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -16,15 +16,8 @@ public sealed class MsgAllAppearances(Dictionary<uint, ImmutableAppearance> allA
     public MsgAllAppearances() : this(new()) { }
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
-        var compressedData = new MemoryStream(buffer.Data, buffer.PositionInBytes, buffer.LengthBytes - buffer.PositionInBytes);
-        using var decompressStream = new DeflateStream(compressedData, CompressionMode.Decompress);
-        var decompressedData = decompressStream.CopyToArray();
-        var decompressed = new NetBuffer {
-            Data = decompressedData,
-            LengthBytes = decompressedData.Length,
-            Position = 0
-        };
-
+        using var compressed = new MemoryStream(buffer.Data, buffer.PositionInBytes, buffer.LengthBytes - buffer.PositionInBytes);
+        var decompressed = DecompressAppearances(compressed);
         var count = decompressed.ReadInt32();
         AllAppearances = new(count);
 
@@ -35,10 +28,27 @@ public sealed class MsgAllAppearances(Dictionary<uint, ImmutableAppearance> allA
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
+        using var compressed = CompressAppearances(AllAppearances.Values, AllAppearances.Count, serializer);
+
+        buffer.Write(compressed.GetBuffer(), 0, (int)compressed.Position);
+    }
+
+    public static NetBuffer DecompressAppearances(MemoryStream data) {
+        using var decompressStream = new DeflateStream(data, CompressionMode.Decompress);
+        var decompressedData = decompressStream.CopyToArray();
+
+        return new NetBuffer {
+            Data = decompressedData,
+            LengthBytes = decompressedData.Length,
+            Position = 0
+        };
+    }
+
+    public static MemoryStream CompressAppearances(IEnumerable<ImmutableAppearance> appearances, int count, IRobustSerializer serializer) {
         var beforeCompress = new NetBuffer();
-        beforeCompress.Write(AllAppearances.Count);
-        foreach (var pair in AllAppearances) {
-            pair.Value.WriteToBuffer(beforeCompress, serializer);
+        beforeCompress.Write(count);
+        foreach (var appearance in appearances) {
+            appearance.WriteToBuffer(beforeCompress, serializer);
         }
 
         var compressBound = ZStd.CompressBound(beforeCompress.LengthBytes);
@@ -47,6 +57,8 @@ public sealed class MsgAllAppearances(Dictionary<uint, ImmutableAppearance> allA
 
         compressStream.Write(beforeCompress.Data, 0, beforeCompress.LengthBytes);
         compressStream.Flush();
+        var buffer = new MemoryStream();
         buffer.Write(compressedData.GetBuffer(), 0, (int)compressedData.Position);
+        return buffer;
     }
 }

--- a/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
+++ b/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
@@ -10,8 +10,8 @@ public abstract class SharedAppearanceSystem : EntitySystem {
     public abstract void RemoveAppearance(ImmutableAppearance appearance);
 
     [Serializable, NetSerializable]
-    public sealed class NewAppearancesEvent(ImmutableAppearance[] appearances) : EntityEventArgs {
-        public ImmutableAppearance[] Appearances { get; } = appearances;
+    public sealed class NewAppearancesEvent(byte[] data) : EntityEventArgs {
+        public byte[] Data { get; } = data;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
Brings the size down to ~10-20% of the original for larger events (hundreds or thousands). For example:
`Received 4891 appearances : decompressed 310415 bytes : compressed 61797 bytes : 19.907866%`