### PR TITLE
Only send animation events to clients in PVS range

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -543,7 +543,6 @@ public sealed partial class AtomManager {
         MutableAppearance appearance;
         EntityUid targetEntity;
         DMISpriteComponent? targetComponent = null;
-        NetEntity ent = NetEntity.Invalid;
         uint? turfId = null;
 
         if (atom is DreamObjectMovable movable) {
@@ -573,7 +572,6 @@ public sealed partial class AtomManager {
         animate(appearance);
 
         if(targetComponent is not null) {
-            ent = _entityManager.GetNetEntity(targetEntity);
             // Don't send the updated appearance to clients, they will animate it
             DMISpriteSystem?.SetSpriteAppearance(new(targetEntity, targetComponent), appearance, dirty: false);
         } else if (atom is DreamObjectTurf turf) {
@@ -584,7 +582,7 @@ public sealed partial class AtomManager {
             //fuck knows, this will trigger a bunch of turf updates to? idek
         }
 
-        AppearanceSystem?.Animate(ent, appearance, duration, easing, loop, flags, delay, chainAnim, turfId);
+        AppearanceSystem?.Animate(targetEntity, appearance, duration, easing, loop, flags, delay, chainAnim, turfId);
     }
 
     public bool TryCreateAppearanceFrom(DreamValue value, [NotNullWhen(true)] out MutableAppearance? appearance) {

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Player;
 using System.Diagnostics;
 using System.Threading;
 using OpenDreamRuntime.Objects.Types;
+using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 using SharedAppearanceSystem = OpenDreamShared.Rendering.SharedAppearanceSystem;
 
@@ -33,6 +34,7 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
     private uint _counter;
 
     [Dependency] private DreamManager _dreamManager = default!;
+    [Dependency] private AtomManager _atomManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IRobustSerializer _serializer = default!;
 
@@ -158,14 +160,24 @@ public sealed partial class ServerAppearanceSystem : SharedAppearanceSystem {
         }
     }
 
-    public void Animate(NetEntity entity, MutableAppearance targetAppearance, TimeSpan duration, AnimationEasing easing, int loop, AnimationFlags flags, int delay, bool chainAnim, uint? turfId) {
-        uint appearanceId = AddAppearance(targetAppearance).MustGetId();
+    public void Animate(EntityUid entity, MutableAppearance targetAppearance, TimeSpan duration, AnimationEasing easing, int loop, AnimationFlags flags, int delay, bool chainAnim, uint? turfId) {
+        var appearanceId = AddAppearance(targetAppearance).MustGetId();
+        var netEntity = GetNetEntity(entity);
+        var animateEvent = new AnimationEvent(netEntity, appearanceId, duration, easing, loop, flags, delay, chainAnim, turfId);
 
-        RaiseNetworkEvent(new AnimationEvent(entity, appearanceId, duration, easing, loop, flags, delay, chainAnim, turfId));
+        if (entity.IsValid())
+            RaiseNetworkEvent(animateEvent, Filter.Pvs(entity));
+        else
+            RaiseNetworkEvent(animateEvent); // TODO: Filter for non-entities
     }
 
     public void Flick(DreamObjectAtom atom, int iconId, string? iconState) {
-        RaiseNetworkEvent(new FlickEvent(_dreamManager.GetClientReference(atom), iconId, iconState));
+        var position = _atomManager.GetAtomPosition(atom);
+        var mapCoords = new MapCoordinates(position.X, position.Y, new(position.Z));
+        var clientRef = _dreamManager.GetClientReference(atom);
+        var flickEvent = new FlickEvent(clientRef, iconId, iconState);
+
+        RaiseNetworkEvent(flickEvent, Filter.Pvs(mapCoords));
     }
 }
 


### PR DESCRIPTION
There's no need to send `animate()` and `flick()` events to every client, they don't do anything if the client has no knowledge of the relevant entity.