### PR TITLE
gitignore and byond parity test fixes

### DIFF
--- a/.github/assets/CIScripts/run_tests.sh
+++ b/.github/assets/CIScripts/run_tests.sh
@@ -55,6 +55,8 @@ while read -r file; do
 		sed -i '/^[[:space:]]*$/d' $basedir/errors.log
 		cat $basedir/errors.log
 		rm $basedir/errors.log
+		testsfailed=$((testsfailed + 1))
+		continue		
 	fi
 	if [ -s "$basedir/errors.log" ]; then
 		if [[ $first_line == "// RUNTIME ERROR"* || $first_line == "//RUNTIME ERROR"* ]]	then #expected runtime error, should compile but then fail to run

--- a/.github/workflows/check-test-parity.yml
+++ b/.github/workflows/check-test-parity.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check for test changes
         id: changed-files
         run: |
-            git diff --diff-filter=ACMR --name-only HEAD^1 HEAD Content.Tests/DMProject/Tests Content.Tests/DMProject/BrokenTests >> test_file_diffs
+            git diff --diff-filter=ACMR --name-only HEAD^1 HEAD Content.Tests/DMProject/Tests/**/*.dm Content.Tests/DMProject/BrokenTests/**/*.dm >> test_file_diffs
             echo "changed_files_count=$(wc -l < test_file_diffs)" >> $GITHUB_OUTPUT
 
       - name: Add Architecture

--- a/.gitignore
+++ b/.gitignore
@@ -265,6 +265,9 @@ __pycache__/
 .vscode/*
 !.vscode/extensions.json
 
+# Visual Studio Code C# extension cache files
+*.lscache
+
 # Release package files go here:
 release/
 


### PR DESCRIPTION
vscode's C# extension adds a bunch of cache files now, gitignore them

byond parity tests filter for just DM files and mark crashes as a test failure instead of a pass.