### PR TITLE
Fixes num2text incorrectly interpreting 'a' as hex in r-10 case

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/text2num.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/text2num.dm
@@ -37,3 +37,8 @@
 
 	ASSERT(text2num("nan") == null)
 	ASSERT(text2num(" -nansomething") == null)
+
+	ASSERT(text2num("a") == null)
+	ASSERT(text2num("A") == null)
+	ASSERT(text2num("a", 11) == 10)
+	ASSERT(text2num("A", 11) == 10)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -468,7 +468,7 @@ internal static partial class DreamProcNativeHelpers {
             if (!char.IsAsciiDigit(c)) {
                 if (c >= 'A' && c < 'A' + letterDigitsVariety) {
                     digit -= 'A' - 10;
-                } else if (c >= 'a' && c <= 'a' + letterDigitsVariety) {
+                } else if (c >= 'a' && c < 'a' + letterDigitsVariety) {
                     digit -= 'a' - 10;
                 } else {
                     break;


### PR DESCRIPTION
Previous coder accidentally did `<=` instead of `<` when checking for hex digits, which made the compiler interpret 'a' as valid hex when radix == 10.