### PR TITLE
Implement Remaining /icon.Blend() functions

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -321,6 +321,7 @@ public class DreamIconOperationBlend : IDreamIconOperation {
         Rgba32 dst = pixels[dstPixelPosition];
 
         switch (_type) {
+            case BlendType.And: // Byond for reasons known only to God does And as a copy of Add.
             case BlendType.Add: {
                 pixels[dstPixelPosition].R = (byte)Math.Min(dst.R + src.R, byte.MaxValue);
                 pixels[dstPixelPosition].G = (byte)Math.Min(dst.G + src.G, byte.MaxValue);
@@ -366,15 +367,6 @@ public class DreamIconOperationBlend : IDreamIconOperation {
                 byte highAlpha = Math.Max(dst.A, src.A);
                 byte lowAlpha = Math.Min(dst.A, src.A);
                 pixels[dstPixelPosition].A = (byte) (highAlpha + (highAlpha * lowAlpha / 255));
-                break;
-            }
-
-            case BlendType.And: {
-                pixels[dstPixelPosition].R = (byte)(dst.R & src.R);
-                pixels[dstPixelPosition].G = (byte)(dst.G & src.G);
-                pixels[dstPixelPosition].B = (byte)(dst.B & src.B);
-
-                pixels[dstPixelPosition].A = (byte)(dst.A & src.A);
                 break;
             }
 

--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -309,9 +309,6 @@ public class DreamIconOperationBlend : IDreamIconOperation {
         _type = type;
         _xOffset = xOffset;
         _yOffset = yOffset;
-
-        if (_type is not BlendType.Overlay and not BlendType.Underlay and not BlendType.Multiply and not BlendType.Add and not BlendType.Subtract)
-            throw new NotImplementedException($"\"{_type}\" blending is not implemented");
     }
 
     public virtual void OnApply(DreamIcon icon) { }
@@ -371,6 +368,25 @@ public class DreamIconOperationBlend : IDreamIconOperation {
                 pixels[dstPixelPosition].A = (byte) (highAlpha + (highAlpha * lowAlpha / 255));
                 break;
             }
+
+            case BlendType.And: {
+                pixels[dstPixelPosition].R = (byte)(dst.R & src.R);
+                pixels[dstPixelPosition].G = (byte)(dst.G & src.G);
+                pixels[dstPixelPosition].B = (byte)(dst.B & src.B);
+
+                pixels[dstPixelPosition].A = (byte)(dst.A & src.A);
+                break;
+            }
+
+            case BlendType.Or: {
+                pixels[dstPixelPosition].R = (byte)(dst.R | src.R);
+                pixels[dstPixelPosition].G = (byte)(dst.G | src.G);
+                pixels[dstPixelPosition].B = (byte)(dst.B | src.B);
+
+                pixels[dstPixelPosition].A = (byte)(dst.A | src.A);
+                break;
+            }
+
             case BlendType.Underlay: {
                 // Opposite of overlay
                 (dst, src) = (src, dst);


### PR DESCRIPTION
As a follow up to #141 

/icon.Blend() now supports ICON_AND and ICON_OR.