### PR TITLE
Fixes mob/Logout providing a client to the mob

### DIFF
--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -45,8 +45,8 @@ public sealed partial class DreamConnection {
 
                 if (oldMob != null) {
                     oldMob.Key = null;
-                    oldMob.SpawnProc("Logout").Dispose();
                     oldMob.Connection = null;
+                    oldMob.SpawnProc("Logout").Dispose();
                 }
 
                 StatObj = new(value);


### PR DESCRIPTION
BYOND clears client before running Logout anyways, I don't really get the order of operations 