### PR TITLE
Fixes LocalCount being off by one, breaking spawn()

### DIFF
--- a/Content.Tests/RuntimeTests.cs
+++ b/Content.Tests/RuntimeTests.cs
@@ -54,10 +54,10 @@ public sealed class RuntimeTests {
 
             using (Assert.EnterMultipleScope()) {
                 Assert.That(tests["ProcWithNothing"].MaxVariableId, Is.Zero);
-                Assert.That(tests["ProcWithNoScope"].MaxVariableId, Is.EqualTo(5));
-                Assert.That(tests["ProcWithOnlyScope"].MaxVariableId, Is.EqualTo(5));
-                Assert.That(tests["ProcWithFullOuterScope"].MaxVariableId, Is.EqualTo(3));
-                Assert.That(tests["ProcWithFullInnerScope"].MaxVariableId, Is.EqualTo(4));
+                Assert.That(tests["ProcWithNoScope"].MaxVariableId, Is.EqualTo(6));
+                Assert.That(tests["ProcWithOnlyScope"].MaxVariableId, Is.EqualTo(6));
+                Assert.That(tests["ProcWithFullOuterScope"].MaxVariableId, Is.EqualTo(4));
+                Assert.That(tests["ProcWithFullInnerScope"].MaxVariableId, Is.EqualTo(5));
             }
         }
     }

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -92,7 +92,7 @@ internal sealed class DMProc {
 
     private readonly List<string> _localVariableNames = new();
     private int _localVariableIdCounter;
-    private int _localVariableHighestId; // 0 is a valid alloc index, which will clip procs with no localvars but that shouldn't matter
+    private int _localVariableHighestId;
 
     private readonly List<SourceInfoJson> _sourceInfo = new();
     private string? _lastSourceFile;
@@ -149,8 +149,8 @@ internal sealed class DMProc {
         WriteLocalVariable(name);
 
         int variableId = _localVariableIdCounter++;
-        if(variableId > _localVariableHighestId) {
-            _localVariableHighestId = variableId;
+        if(_localVariableIdCounter > _localVariableHighestId) {
+            _localVariableHighestId = _localVariableIdCounter;
         }
 
         return variableId;


### PR DESCRIPTION
I really did think it wouldn't matter.

Tests as of commit 8cacb1c7757465b06e07cf684944be7b88732067:
<img width="385" height="198" alt="image" src="https://github.com/user-attachments/assets/75b77a3a-2900-429d-b1f3-c846c014cbff" />
