### PR TITLE
Use `InvariantCulture` in the DMI and DMF parsers

### DIFF
--- a/OpenDreamShared/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamShared/Interface/DMF/IDMFProperty.cs
@@ -102,10 +102,10 @@ public struct DMFPropertyNum(float value) : IDMFProperty {
 
     public DMFPropertyNum(string value) : this(0) {
         try {
-            Value = float.Parse(value);
+            Value = float.Parse(value, CultureInfo.InvariantCulture);
         } catch {
             int lastValidPos = value.LastIndexOfAny("0123456789".ToCharArray());
-            Value = float.Parse(value.Substring(0, lastValidPos+1));
+            Value = float.Parse(value.Substring(0, lastValidPos + 1), CultureInfo.InvariantCulture);
             Logger.GetSawmill("opendream.interface").Warning($"Invalid value in DMFPropertyNum '{value}'. Parsed as '{Value}'. {lastValidPos}");
         }
     }
@@ -173,8 +173,8 @@ public struct DMFPropertyVec2 : IDMFProperty, IEquatable<DMFPropertyVec2> {
 
         string[] parts = value.Split([',', 'x', ' ']);
 
-        X = (int)float.Parse(parts[0]);
-        Y = (int)float.Parse(parts[1]);
+        X = (int)float.Parse(parts[0], CultureInfo.InvariantCulture);
+        Y = (int)float.Parse(parts[1], CultureInfo.InvariantCulture);
     }
 
     public DMFPropertyVec2(Vector2 value) {

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -384,10 +384,10 @@ public static class DMIParser {
                         // No need to care about this at the moment
                         break;
                     case "width":
-                        description.Width = int.Parse(value);
+                        description.Width = int.Parse(value, CultureInfo.InvariantCulture);
                         break;
                     case "height":
-                        description.Height = int.Parse(value);
+                        description.Height = int.Parse(value, CultureInfo.InvariantCulture);
                         break;
                     case "state":
                         string stateName = ParseString(value);
@@ -429,10 +429,10 @@ public static class DMIParser {
                         description.States.TryAdd(stateName, currentState);
                         break;
                     case "dirs":
-                        currentStateDirectionCount = int.Parse(value);
+                        currentStateDirectionCount = int.Parse(value, CultureInfo.InvariantCulture);
                         break;
                     case "frames":
-                        currentStateFrameCount = int.Parse(value);
+                        currentStateFrameCount = int.Parse(value, CultureInfo.InvariantCulture);
                         break;
                     case "delay":
                         string[] frameDelays = value.Split(",");
@@ -445,11 +445,15 @@ public static class DMIParser {
                         break;
                     case "loop":
                         if (currentState is null) break;
-                        currentState.Loop = (int.Parse(value) == 0);
+
+                        var loopValue = int.Parse(value, CultureInfo.InvariantCulture);
+                        currentState.Loop = (loopValue == 0);
                         break;
                     case "rewind":
                         if (currentState is null) break;
-                        currentState.Rewind = (int.Parse(value) == 1);
+
+                        var rewindValue = int.Parse(value, CultureInfo.InvariantCulture);
+                        currentState.Rewind = (rewindValue == 1);
                         break;
                     case "movement":
                         //TODO
@@ -460,8 +464,8 @@ public static class DMIParser {
                         if (hotspotValues.Length != 3)
                             throw new Exception($"Invalid hotspot value \"{value}\"");
 
-                        var hotspotX = int.Parse(hotspotValues[0]);
-                        var hotspotY = int.Parse(hotspotValues[1]);
+                        var hotspotX = int.Parse(hotspotValues[0], CultureInfo.InvariantCulture);
+                        var hotspotY = int.Parse(hotspotValues[1], CultureInfo.InvariantCulture);
                         // TODO: 3rd value? Something to do with what frames the hotspot applies to apparently
 
                         currentState.Hotspot = (hotspotX, hotspotY);


### PR DESCRIPTION
Keeps number parsing consistent. Fixes #2606.