### PR TITLE
Fix some `::` const cases

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/scope_objectvar.dm
+++ b/Content.Tests/DMProject/Tests/Operators/scope_objectvar.dm
@@ -7,7 +7,9 @@ var/datum/a/global_var = /datum/a
 
 /datum/b
 	var/variable = global_var::constant
+	var/variable2 = global_var::constant / 5
 
 /proc/RunTest()
 	var/datum/b/B = new()
 	ASSERT(B.variable == 10)
+	ASSERT(B.variable2 == 2)

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -86,7 +86,6 @@ internal partial class DMCodeTree {
                 NewList => true,
                 NewPath => true,
                 Rgb => true,
-                ScopeReference => true,
                 // TODO: Check for circular reference loops here
                 // (Note that we do accidentally support global-field access somewhat when it gets const-folded by TryAsConstant before we get here)
                 GlobalField => false,

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -339,11 +339,6 @@ internal sealed class ScopeReference(DMObjectTree objectTree, Location location,
             return true;
         }
 
-        if (expression is not IConstantPath) {
-            constant = null;
-            return false;
-        }
-
         return dmVar.Value!.TryAsConstant(compiler, out constant);
     }
 }

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -339,6 +339,11 @@ internal sealed class ScopeReference(DMObjectTree objectTree, Location location,
             return true;
         }
 
-        return dmVar.Value!.TryAsConstant(compiler, out constant);
+        if (dmVar.IsConst || expression is IConstantPath) {
+            return dmVar.Value!.TryAsConstant(compiler, out constant);
+        }
+
+        constant = null;
+        return false;
     }
 }


### PR DESCRIPTION
Seems `::` doesn't need to be used directly on a path to be considered a constant in some cases.