### PR TITLE
Coloured console errors

### DIFF
--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -224,6 +224,7 @@ public struct CompilerEmission {
             ErrorLevel.Error => ConsoleColor.Red,
             _ => null
         };
+        
         if (usedColor is null) {
             return;
         }
@@ -233,5 +234,4 @@ public struct CompilerEmission {
         Console.ResetColor();
         Console.WriteLine($" at {Location.ToString()}: {Message}");
     }
-
 }

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -227,6 +227,7 @@ public struct CompilerEmission {
         if (usedColor is null) {
             return;
         }
+        
         Console.ForegroundColor = usedColor.Value;
         Console.Write($"{Level.ToString()} OD{(int)Code:d4}");
         Console.ResetColor();

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -213,4 +213,24 @@ public struct CompilerEmission {
         ErrorLevel.Error => $"Error OD{(int)Code:d4} at {Location.ToString()}: {Message}",
         _ => ""
     };
+
+    /// <summary>
+    /// Write to the console with coloured formatting.
+    /// </summary>
+    public void WriteConsole() {
+        ConsoleColor? usedColor = Level switch {
+            ErrorLevel.Notice => ConsoleColor.Cyan,
+            ErrorLevel.Warning => ConsoleColor.Yellow,
+            ErrorLevel.Error => ConsoleColor.Red,
+            _ => null
+        };
+        if (usedColor is null) {
+            return;
+        }
+        Console.ForegroundColor = usedColor.Value;
+        Console.Write($"{Level.ToString()} OD{(int)Code:d4}");
+        Console.ResetColor();
+        Console.WriteLine($" at {Location.ToString()}: {Message}");
+    }
+
 }

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -226,7 +226,7 @@ public class DMCompiler {
                 CompilerMessages.Add(new CompilerEmission(ErrorLevel.Warning, null, "No longer storing error messages due to excessive error counts.").ToString());
             }
         UniqueEmissions.Add(emission.Code);
-        Console.WriteLine(emission);
+        emission.WriteConsole();
         return level == ErrorLevel.Error;
     }
 
@@ -235,7 +235,7 @@ public class DMCompiler {
     /// Completely ignores the warning configuration. Use wisely!
     /// </summary>
     public void ForcedError(Location loc, string message) {
-        Console.WriteLine(new CompilerEmission(ErrorLevel.Error, loc, message).ToString());
+        new CompilerEmission(ErrorLevel.Error, loc, message).WriteConsole();
         _errorCount++;
     }
 
@@ -244,13 +244,13 @@ public class DMCompiler {
     /// Completely ignores the warning configuration. Use wisely!
     /// </summary>
     public void ForcedWarning(string message) {
-        Console.WriteLine(new CompilerEmission(ErrorLevel.Warning, Location.Internal, message).ToString());
+        new CompilerEmission(ErrorLevel.Warning, Location.Internal, message).WriteConsole();
         _warningCount++;
     }
 
     /// <inheritdoc cref="ForcedWarning(string)"/>
     public void ForcedWarning(Location loc, string message) {
-        Console.WriteLine(new CompilerEmission(ErrorLevel.Warning, loc, message).ToString());
+        new CompilerEmission(ErrorLevel.Warning, loc, message).WriteConsole();
         _warningCount++;
     }
 
@@ -358,7 +358,7 @@ public class DMCompiler {
             compiledDream.GlobalProcs = DMObjectTree.GlobalProcs.Values.ToArray();
         }
 
-        if(_errorCount == 0) {
+        if (_errorCount == 0) {
             return compiledDream;
         }
 
@@ -398,6 +398,7 @@ public struct DMCompilerSettings {
     public bool Verbose = false;
     public bool PrintCodeTree = false;
     public bool StoreMessages = false;
+
     public Dictionary<string, string>? MacroDefines = null;
 
     /// <summary> The value of the DM_VERSION macro </summary>


### PR DESCRIPTION
Creates a new helper function on emission which prints to the console, applying foreground colour for the warning/error/notice part of the message.

Replaces console writes of emissions with this new method.

While console colours aren't going to appear in most contexts (mainly, if you are running from the VS code extension), they will appear when you are running from the command line.

<img width="1269" height="917" alt="image" src="https://github.com/user-attachments/assets/9cebff82-e244-44a4-a927-3969ad90a537" />
