### PR TITLE
Supports the titlebar DMF attribute

### DIFF
--- a/OpenDreamClient/Interface/BrowsePopup.cs
+++ b/OpenDreamClient/Interface/BrowsePopup.cs
@@ -17,18 +17,19 @@ internal sealed class BrowsePopup {
     public BrowsePopup(
         string name,
         Vector2i size,
-        IClydeWindow ownerWindow) {
-        WindowDescriptor popupWindowDescriptor = new WindowDescriptor(name,
-            new() {
-                new ControlDescriptorBrowser {
-                    Id = new DMFPropertyString("browser"),
-                    Size = new DMFPropertySize(size),
-                    Anchor1 = new DMFPropertyPos(0, 0),
-                    Anchor2 = new DMFPropertyPos(100, 100)
-                }
-            }) {
-                Size = new DMFPropertySize(size)
-            };
+        IClydeWindow ownerWindow,
+        WindowDescriptor? descriptor = null) {
+
+        WindowDescriptor popupWindowDescriptor = descriptor ?? new WindowDescriptor(name) {
+            Size = new DMFPropertySize(size)
+        };
+
+        popupWindowDescriptor.ControlDescriptors.Add(new ControlDescriptorBrowser {
+            Id = new DMFPropertyString("browser"),
+            Size = new DMFPropertySize(size),
+            Anchor1 = new DMFPropertyPos(0, 0),
+            Anchor2 = new DMFPropertyPos(100, 100),
+        });
 
         WindowElement = new ControlWindow(popupWindowDescriptor);
         WindowElement.CreateChildControls();

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -1,9 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using OpenDreamShared.Interface.Descriptors;
+﻿using OpenDreamShared.Interface.Descriptors;
 using OpenDreamShared.Interface.DMF;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenDreamClient.Interface.Controls;
 
@@ -50,7 +50,7 @@ public sealed partial class ControlWindow : InterfaceControl {
             _menuContainer.Visible = false;
         }
 
-        if(!WindowDescriptor.IsPane.Value)
+        if (!WindowDescriptor.IsPane.Value)
             UpdateWindowAttributes(_myWindow);
 
         if (WindowDescriptor.IsDefault.Value) {
@@ -62,16 +62,16 @@ public sealed partial class ControlWindow : InterfaceControl {
     /// Closes the window if it is a child window. No effect if it is either a default window or a pane
     /// </summary>
     public void CloseChildWindow() {
-        if(_myWindow.osWindow is not null)
+        if (_myWindow.osWindow is not null)
             _myWindow.osWindow.Close();
     }
 
     public OSWindow CreateWindow() {
-        if(_myWindow.osWindow is not null)
+        if (_myWindow.osWindow is not null)
             return _myWindow.osWindow;
 
         OSWindow window = new();
-        if(UIElement.Parent is not null)
+        if (UIElement.Parent is not null)
             UIElement.Orphan();
         window.Children.Add(UIElement);
 
@@ -103,7 +103,7 @@ public sealed partial class ControlWindow : InterfaceControl {
 
     public void RegisterOnClydeWindow(IClydeWindow window) {
         // todo: listen for closed.
-        if(_myWindow.osWindow is not null){
+        if (_myWindow.osWindow is not null) {
             _myWindow.osWindow.Close();
             UIElement.Orphan();
         }
@@ -171,9 +171,9 @@ public sealed partial class ControlWindow : InterfaceControl {
         // Also update the anchor position for anything with a size of 0
         foreach (var child in ChildControls) {
             if (child.UIElement.SetWidth == 0)
-                child.AnchorPosition = child.AnchorPosition with {X = _canvas.PixelWidth + child.Size.X};
+                child.AnchorPosition = child.AnchorPosition with { X = _canvas.PixelWidth + child.Size.X };
             if (child.UIElement.SetHeight == 0)
-                child.AnchorPosition = child.AnchorPosition with {Y = _canvas.PixelHeight + child.Size.Y};
+                child.AnchorPosition = child.AnchorPosition with { Y = _canvas.PixelHeight + child.Size.Y };
         }
 
         UpdateAnchors();
@@ -184,7 +184,7 @@ public sealed partial class ControlWindow : InterfaceControl {
         var (osWindow, clydeWindow) = windowRoot;
 
         //if our window is null or closed, we need to create a new one. Otherwise we need to update the existing one.
-        if(osWindow == null && clydeWindow == null) {
+        if (osWindow == null && clydeWindow == null) {
             CreateWindow();
             return; //we return because CreateWindow() calls UpdateWindowAttributes() again.
         }
@@ -206,8 +206,10 @@ public sealed partial class ControlWindow : InterfaceControl {
 
         if (osWindow != null && osWindow.ClydeWindow != null) {
             osWindow.ClydeWindow.IsVisible = WindowDescriptor.IsVisible.Value;
+            osWindow.ClydeWindow.IsTitleBarVisible = WindowDescriptor.TitleBar.Value;
         } else if (clydeWindow != null) {
             clydeWindow.IsVisible = WindowDescriptor.IsVisible.Value;
+            clydeWindow.IsTitleBarVisible = WindowDescriptor.TitleBar.Value;
         }
     }
 
@@ -341,7 +343,7 @@ public sealed partial class ControlWindow : InterfaceControl {
     public override void SetProperty(string property, string value, bool manualWinset = false) {
         switch (property) {
             case "size":
-                if (_myWindow.osWindow is {ClydeWindow: not null}) {
+                if (_myWindow.osWindow is { ClydeWindow: not null }) {
                     var size = new DMFPropertySize(value);
                     var uiScale = _myWindow.osWindow.UIScale;
                     size.X = (int)(size.X * uiScale); // TODO: RT should probably do this itself

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -1,9 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using OpenDreamShared.Interface.Descriptors;
+﻿using OpenDreamShared.Interface.Descriptors;
 using OpenDreamShared.Interface.DMF;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenDreamClient.Interface.Controls;
 
@@ -22,7 +22,7 @@ public abstract class InterfaceControl : InterfaceElement {
     /// </summary>
     public Vector2i AnchorPosition = Vector2i.Zero;
 
-    protected ControlDescriptor ControlDescriptor => (ControlDescriptor) ElementDescriptor;
+    protected ControlDescriptor ControlDescriptor => (ControlDescriptor)ElementDescriptor;
     protected readonly ControlWindow? Window;
 
     [SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
@@ -45,7 +45,7 @@ public abstract class InterfaceControl : InterfaceElement {
 
         //transparent is default because it's white with 0 alpha, and DMF color can't have none-255 alpha
         StyleBox? styleBox = (ControlDescriptor.BackgroundColor.Value != Color.Transparent)
-            ? new StyleBoxFlat {BackgroundColor = ControlDescriptor.BackgroundColor.Value}
+            ? new StyleBoxFlat { BackgroundColor = ControlDescriptor.BackgroundColor.Value }
             : null;
 
         switch (UIElement) {

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -226,6 +226,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
 
                     DMFParser? parser;
                     WindowDescriptor? descriptor = null;
+                    (int x, int y) size = (480, 480);
 
                     // Handle using options to set the initial properties of the window
                     if (pBrowse.Options != null
@@ -242,13 +243,16 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                         descriptor = (WindowDescriptor?)_serializationManager.Read(typeof(WindowDescriptor), mappingElement);
 
                         if (descriptor?.Size.X == 0 || descriptor?.Size.Y == 0) {
-                            descriptor.Size.X = 480;
-                            descriptor.Size.Y = 480;
+                            descriptor.Size.X = size.x;
+                            descriptor.Size.Y = size.y;
+                        } else if (descriptor != null) {
+                            size.x = descriptor.Size.X;
+                            size.y = descriptor.Size.Y;
                         }
                     }
 
                     // Creating a new popup
-                    var popup = new BrowsePopup(pBrowse.Window, (480, 480), _clyde.MainWindow, descriptor);
+                    var popup = new BrowsePopup(pBrowse.Window, size, _clyde.MainWindow, descriptor);
                     popup.Closed += () => { Windows.Remove(pBrowse.Window); };
 
                     outputBrowser = popup.Browser;

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -1,28 +1,29 @@
-﻿using System.IO;
-using System.Text;
-using System.Globalization;
-using OpenDreamShared.Network.Messages;
-using OpenDreamClient.Interface.Controls;
-using OpenDreamShared.Interface.Descriptors;
-using OpenDreamShared.Interface.DMF;
+﻿using OpenDreamClient.Interface.Controls;
 using OpenDreamClient.Interface.Prompts;
 using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
 using OpenDreamShared.Dream;
+using OpenDreamShared.Interface.Descriptors;
+using OpenDreamShared.Interface.DMF;
+using OpenDreamShared.Network.Messages;
 using Robust.Client;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.ContentPack;
+using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
+using System.Globalization;
+using System.IO;
 using System.Linq;
-using Robust.Shared.Map;
+using System.Text;
 
 namespace OpenDreamClient.Interface;
 
@@ -203,7 +204,10 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                 browser.SetFileSource(null);
             }
         } else if (pBrowse.HtmlSource != null) {
-            var htmlFileName = $"browse_{pBrowse.Window}_{_random.Next()}"; // TODO: Possible collisions and explicit file names
+            // TODO: Possible collisions and explicit file names
+            // pBrowse contains options, which may contain the 'file' property. When this is explicitly declared, instead of
+            // using a random htmlFileName, we should instead use that file instead.
+            var htmlFileName = $"browse_{pBrowse.Window}_{_random.Next()}";
             ControlBrowser? outputBrowser = referencedElement as ControlBrowser;
 
             if (outputBrowser == null) {
@@ -219,8 +223,32 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                         break;
                     }
                 } else if (pBrowse.Window != null) {
+
+                    DMFParser? parser;
+                    WindowDescriptor? descriptor = null;
+
+                    // Handle using options to set the initial properties of the window
+                    if (pBrowse.Options != null
+                        && (parser = ParseDmfParams(pBrowse.Options, out var CheckParserErrors)) != null
+                        && parser.AttributesValues() is Dictionary<string, string> attributes
+                        && !CheckParserErrors()) {
+
+                        var mappingElement = new MappingDataNode();
+
+                        mappingElement.Add("id", pBrowse.Window);
+                        foreach (var attribute in attributes) {
+                            mappingElement.Add(attribute.Key, attribute.Value);
+                        }
+                        descriptor = (WindowDescriptor?)_serializationManager.Read(typeof(WindowDescriptor), mappingElement);
+
+                        if (descriptor?.Size.X == 0 || descriptor?.Size.Y == 0) {
+                            descriptor.Size.X = 480;
+                            descriptor.Size.Y = 480;
+                        }
+                    }
+
                     // Creating a new popup
-                    var popup = new BrowsePopup(pBrowse.Window, pBrowse.Size, _clyde.MainWindow);
+                    var popup = new BrowsePopup(pBrowse.Window, (480, 480), _clyde.MainWindow, descriptor);
                     popup.Closed += () => { Windows.Remove(pBrowse.Window); };
 
                     outputBrowser = popup.Browser;
@@ -264,7 +292,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
             MsgPromptResponse response = new() {
                 PromptId = message.PromptId,
                 Type = DreamValueType.Text,
-                Value = WinGet(message.ControlId, message.QueryValue, forceSnowflake:true)
+                Value = WinGet(message.ControlId, message.QueryValue, forceSnowflake: true)
             };
 
             _netManager.ClientSendMessage(response);
@@ -366,7 +394,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
             } else if (Menus.TryGetValue(windowId, out var menu)) {
                 if (menu.MenuElementsById.TryGetValue(elementId, out var menuElement))
                     return menuElement;
-            } else if(MacroSets.TryGetValue(windowId, out var macroSet)) {
+            } else if (MacroSets.TryGetValue(windowId, out var macroSet)) {
                 if (macroSet.Macros.TryGetValue(elementId, out var macroElement))
                     return macroElement;
             }
@@ -516,7 +544,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                                 var result = HandleEmbeddedWinget(null, currentArg.ToString(), out var hadWinget);
 
                                 // 64x64 or 64,64 gets split into two "64 64" args
-                                if (hadWinget && result.Split(['x', ',']) is {Length: 2} wingetSplit &&
+                                if (hadWinget && result.Split(['x', ',']) is { Length: 2 } wingetSplit &&
                                     float.TryParse(wingetSplit[0], out _) && float.TryParse(wingetSplit[1], out _)) {
                                     args.Add(wingetSplit[0]);
                                     args.Add(wingetSplit[1]);
@@ -535,7 +563,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                             var result = HandleEmbeddedWinget(null, currentArg.ToString(), out var hadWinget);
 
                             // 64x64 or 64,64 gets split into two "64 64" args
-                            if (hadWinget && result.Split(['x', ',']) is {Length: 2} wingetSplit &&
+                            if (hadWinget && result.Split(['x', ',']) is { Length: 2 } wingetSplit &&
                                 float.TryParse(wingetSplit[0], out _) && float.TryParse(wingetSplit[1], out _)) {
                                 args.Add(wingetSplit[0]);
                                 args.Add(wingetSplit[1]);
@@ -554,7 +582,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                         var result = HandleEmbeddedWinget(null, arg, out var hadWinget);
 
                         // 64x64 or 64,64 gets split into two "64 64" args
-                        if (hadWinget && result.Split(['x', ',']) is {Length: 2} wingetSplit &&
+                        if (hadWinget && result.Split(['x', ',']) is { Length: 2 } wingetSplit &&
                             float.TryParse(wingetSplit[0], out _) && float.TryParse(wingetSplit[1], out _)) {
                             args.Add(wingetSplit[0]);
                             args.Add(wingetSplit[1]);
@@ -614,35 +642,36 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
 
         string result = value;
         int startPos = result.IndexOf("[[", StringComparison.Ordinal);
-        while(startPos > -1){
+        while (startPos > -1) {
             int endPos = result.IndexOf("]]", startPos, StringComparison.Ordinal);
-            if(endPos == -1)
+            if (endPos == -1)
                 break;
-            string inner = result.Substring(startPos+2, endPos-startPos-2);
+            string inner = result.Substring(startPos + 2, endPos - startPos - 2);
             string[] elementSplit = inner.Split('.');
             string innerControlId = controlId ?? "";
-            if(elementSplit.Length > 1){
-                innerControlId = (string.IsNullOrEmpty(innerControlId) ? "" : innerControlId+".")+string.Join(".", elementSplit[..^1]);
+            if (elementSplit.Length > 1) {
+                innerControlId = (string.IsNullOrEmpty(innerControlId) ? "" : innerControlId + ".") + string.Join(".", elementSplit[..^1]);
                 inner = elementSplit[^1];
             }
 
             string innerResult = WinGet(innerControlId, inner);
             hadWinget = true;
-            result = result.Substring(0, startPos) + innerResult + result.Substring(endPos+2);
+            result = result.Substring(0, startPos) + innerResult + result.Substring(endPos + 2);
             startPos = result.IndexOf("[[", StringComparison.Ordinal);
         }
 
         return result;
     }
 
-    public void WinSet(string? controlId, string winsetParams) {
+    private DMFParser? ParseDmfParams(string dmfParams, out Func<bool> CheckErrors) {
+        CheckErrors = null!;
         DMFParser parser;
-        try{
-            var lexer = new DMFLexer(winsetParams);
+        try {
+            var lexer = new DMFLexer(dmfParams);
             parser = new DMFParser(lexer, _serializationManager);
         } catch (Exception e) {
             _sawmill.Error($"Error parsing winset: {e}");
-            return;
+            return null;
         }
 
         bool CheckParserErrors() {
@@ -654,6 +683,17 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
             }
 
             return true;
+        }
+
+        CheckErrors = CheckParserErrors;
+        return parser;
+    }
+
+    public void WinSet(string? controlId, string winsetParams) {
+        DMFParser? parser = ParseDmfParams(winsetParams, out var CheckParserErrors);
+
+        if (parser == null) {
+            return;
         }
 
         if (string.IsNullOrEmpty(controlId)) {
@@ -678,26 +718,26 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                         _sawmill.Error($"Invalid global winset \"{winsetParams}\"");
                     }
                 } else {
-                    if(winSet.TrueStatements is not null) {
+                    if (winSet.TrueStatements is not null) {
                         InterfaceElement? conditionalElement = FindElementWithId(elementId);
-                        if(conditionalElement is null)
+                        if (conditionalElement is null)
                             _sawmill.Error($"Invalid element on ternary condition \"{elementId}\"");
                         else
-                            if(conditionalElement.TryGetProperty(winSet.Attribute, out var conditionalCheckValue) && conditionalCheckValue.Equals(winSet.Value)) {
-                                foreach(DMFWinSet statement in winSet.TrueStatements) {
+                            if (conditionalElement.TryGetProperty(winSet.Attribute, out var conditionalCheckValue) && conditionalCheckValue.Equals(winSet.Value)) {
+                                foreach (DMFWinSet statement in winSet.TrueStatements) {
                                     string statementElementId = statement.Element ?? elementId;
                                     InterfaceElement? statementElement = FindElementWithId(statementElementId);
-                                    if(statementElement is not null) {
+                                    if (statementElement is not null) {
                                         statementElement.SetProperty(statement.Attribute, HandleEmbeddedWinget(statementElementId, statement.Value, out _), manualWinset: true);
                                     } else {
                                         _sawmill.Error($"Invalid element on ternary \"{statementElementId}\"");
                                     }
                                 }
-                            } else if (winSet.FalseStatements is not null){
-                                foreach(DMFWinSet statement in winSet.FalseStatements) {
+                            } else if (winSet.FalseStatements is not null) {
+                                foreach (DMFWinSet statement in winSet.FalseStatements) {
                                     string statementElementId = statement.Element ?? elementId;
                                     InterfaceElement? statementElement = FindElementWithId(statementElementId);
-                                    if(statementElement is not null) {
+                                    if (statementElement is not null) {
                                         statementElement.SetProperty(statement.Attribute, HandleEmbeddedWinget(statementElementId, statement.Value, out _), manualWinset: true);
                                     } else {
                                         _sawmill.Error($"Invalid element on ternary \"{statementElementId}\"");
@@ -750,16 +790,16 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
             //parse "as blah" from query if it's there
             string[] querySplit = query.Split(" as ");
             IDMFProperty propResult;
-            if(querySplit.Length != 2) //must be "thing as blah" or "thing". Anything else is invalid.
-                if(element.TryGetProperty(query, out propResult!)){
+            if (querySplit.Length != 2) //must be "thing as blah" or "thing". Anything else is invalid.
+                if (element.TryGetProperty(query, out propResult!)) {
                     result = forceJson ? propResult.AsJson() : forceSnowflake ? propResult.AsSnowflake() : propResult.AsRaw();
                     return true;
                 } else {
                     result = "";
                     return false;
                 }
-            else{
-                if(!element.TryGetProperty(querySplit[0], out propResult!)) {
+            else {
+                if (!element.TryGetProperty(querySplit[0], out propResult!)) {
                     result = "";
                     return false;
                 }
@@ -772,7 +812,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
                     return true;
                 }
 
-                switch(querySplit[1]){
+                switch (querySplit[1]) {
                     case "arg":
                         result = propResult.AsArg();
                         break;
@@ -812,12 +852,12 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
             }
 
             var multiQuery = queryValue.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if(multiQuery.Length > 1) {
+            if (multiQuery.Length > 1) {
                 var result = "";
-                foreach(var query in multiQuery) {
+                foreach (var query in multiQuery) {
                     if (!ParseAndTryGet(element, query, out var queryResult))
                         _sawmill.Error($"Could not winget property {query} on {element.Id}");
-                    result += query+"="+queryResult + ";";
+                    result += query + "=" + queryResult + ";";
                 }
 
                 return result.TrimEnd(';');
@@ -930,7 +970,7 @@ internal sealed partial class DreamInterfaceManager : IDreamInterfaceManager {
     private void Reset() {
         _uiManager.MainViewport.Visible = false;
         //close windows if they're open, and clear all child ui elements
-        foreach (var window in Windows.Values){
+        foreach (var window in Windows.Values) {
             window.CloseChildWindow();
             window.UIElement.RemoveAllChildren();
         }

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -1,6 +1,3 @@
-using System.Threading.Tasks;
-using System.Web;
-using DMCompiler.Bytecode;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Procs.Native;
@@ -11,6 +8,8 @@ using OpenDreamShared.Network.Messages;
 using Robust.Shared.Enums;
 using Robust.Shared.Player;
 using SpaceWizards.Sodium;
+using System.Threading.Tasks;
+using System.Web;
 
 namespace OpenDreamRuntime;
 
@@ -34,7 +33,8 @@ public sealed partial class DreamConnection {
     [ViewVariables] public DreamObjectClient? Client { get; private set; }
     [ViewVariables] public string Key { get; }
 
-    [ViewVariables] public DreamObjectMob? Mob {
+    [ViewVariables]
+    public DreamObjectMob? Mob {
         get => _mob;
         set {
             if (_mob != value) {
@@ -66,7 +66,8 @@ public sealed partial class DreamConnection {
         }
     }
 
-    [ViewVariables] public DreamObjectMovable? Eye {
+    [ViewVariables]
+    public DreamObjectMovable? Eye {
         get;
         set {
             value?.IncRef();
@@ -158,7 +159,8 @@ public sealed partial class DreamConnection {
                 }
 
                 return DreamValue.Null;
-            } finally {
+            }
+            finally {
                 _currentlyUpdatingStat = false;
             }
         }).Dispose();
@@ -448,7 +450,7 @@ public sealed partial class DreamConnection {
     }
 
     public void HandleBrowseResourceRequest(string filename) {
-        if(_permittedBrowseRscFiles.TryGetValue(filename, out var dreamResource)) {
+        if (_permittedBrowseRscFiles.TryGetValue(filename, out var dreamResource)) {
             var msg = new MsgBrowseResourceResponse() {
                 Filename = filename,
                 Data = dreamResource.ResourceData!, //honestly if this is null, something mega fucked up has happened and we should error hard
@@ -462,7 +464,8 @@ public sealed partial class DreamConnection {
 
     public void Browse(string? body, string? options) {
         string? window = null;
-        Vector2i size = (480, 480);
+
+        List<string> unhandledOptions = new List<string>();
 
         if (options != null) {
             foreach (string option in options.Split(',', ';', '&')) {
@@ -475,19 +478,17 @@ public sealed partial class DreamConnection {
 
                     if (key == "window") {
                         window = value;
-                    } else if (key == "size") {
-                        string[] sizeSeparated = value.Split("x", 2);
-
-                        size = (int.Parse(sizeSeparated[0]), int.Parse(sizeSeparated[1]));
+                    } else {
+                        unhandledOptions.Add(optionTrimmed);
                     }
                 }
             }
         }
 
         var msg = new MsgBrowse() {
-            Size = size,
             Window = window,
-            HtmlSource = body
+            HtmlSource = body,
+            Options = string.Join(';', unhandledOptions)
         };
 
         Session?.Channel.SendMessage(msg);

--- a/OpenDreamShared/Network/Messages/MsgBrowse.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowse.cs
@@ -1,5 +1,4 @@
 ﻿using Lidgren.Network;
-using Robust.Shared.Maths;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
@@ -9,33 +8,34 @@ namespace OpenDreamShared.Network.Messages {
 
         public string? Window;
         public string? HtmlSource;
-        public Vector2i Size;
+        public string? Options;
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
             var hasWindow = buffer.ReadBoolean();
             var hasHtml = buffer.ReadBoolean();
+            var hasOptions = buffer.ReadBoolean();
             buffer.ReadPadBits();
 
             if (hasWindow)
                 Window = buffer.ReadString();
             if (hasHtml)
                 HtmlSource = buffer.ReadString();
-
-            Size = (buffer.ReadUInt16(), buffer.ReadUInt16());
+            if (hasOptions)
+                Options = buffer.ReadString();
         }
 
         public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
             buffer.Write(Window != null);
             buffer.Write(HtmlSource != null);
+            buffer.Write(Options != null);
             buffer.WritePadBits();
 
             if (Window != null)
                 buffer.Write(Window);
             if (HtmlSource != null)
                 buffer.Write(HtmlSource);
-
-            buffer.Write((ushort) Size.X);
-            buffer.Write((ushort) Size.Y);
+            if (Options != null)
+                buffer.Write(Options);
         }
     }
 }


### PR DESCRIPTION
This PR implements the ability to create a borderless window in the Clyde window engine (Requires https://github.com/space-wizards/RobustToolbox/pull/6618), and implements the titlebar property, which hides the title bars when set to 0.

Because most TGUI windows set this property through browse(), I have also implemented support for passing options through to browse as right now only the size option is being handled.

These TGUI windows cannot yet be moved, as there is no support for moving windows from code in the Clyde engine, and I suspect that there may be some trouble getting that in if there are security concerns about having arbitrarily moving windows.

<img width="1066" height="749" alt="image" src="https://github.com/user-attachments/assets/2551d9a8-b965-4c56-8635-eae3d4b20e01" />

<img width="1141" height="960" alt="image" src="https://github.com/user-attachments/assets/c1db0b2b-06a2-4fdb-9128-863fc08f26aa" />
