### PR TITLE
Fixes HtmlParser handling of XML comments and values containing spaces

### DIFF
--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -1,6 +1,8 @@
 ﻿using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace OpenDreamClient.Interface.Html;
 
@@ -10,6 +12,9 @@ public static class HtmlParser {
 
     private static readonly ISawmill Sawmill;
     private static readonly HashSet<string> WarnedAttributes = new();
+
+    private static Regex? _attributeMatchRegex = null;
+    private static Regex AttributeMatchRegex => _attributeMatchRegex ??= new Regex(@"\w+(?:=(?:\w+|""[^""]*""|'[^']*'))?");
 
     static HtmlParser() {
         Sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("opendream.html_parser");
@@ -72,7 +77,10 @@ public static class HtmlParser {
                     }
 
                     string insideTag = currentText.ToString();
-                    string[] attributes = insideTag.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    string[] attributes = AttributeMatchRegex.Matches(insideTag)
+                        .Where(x => x.Length > 0)
+                        .Select(x => x.Value)
+                        .ToArray();
                     string tagType = attributes[0].ToLowerInvariant();
 
                     currentText.Clear();

--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -14,7 +14,7 @@ public static class HtmlParser {
     private static readonly HashSet<string> WarnedAttributes = new();
 
     private static Regex? _attributeMatchRegex = null;
-    private static Regex AttributeMatchRegex => _attributeMatchRegex ??= new Regex(@"\w+(?:=(?:\w+|""[^""]*""|'[^']*'))?");
+    private static Regex AttributeMatchRegex => _attributeMatchRegex ??= new Regex(@"[^ =]+(?:=(?:\w+|""[^""]*""|'[^']*'))?");
 
     static HtmlParser() {
         Sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("opendream.html_parser");

--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -1,6 +1,6 @@
-﻿using System.Text;
-using OpenDreamShared.Dream;
+﻿using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
+using System.Text;
 
 namespace OpenDreamClient.Interface.Html;
 
@@ -31,6 +31,11 @@ public static class HtmlParser {
 
             appendTo.AddText(currentText.ToString());
             currentText.Clear();
+        }
+
+        void SkipComment() {
+            while ((i - 2 < 0 || (text[i - 2] != '-' || text[i - 1] != '-' || text[i] != '>')) && text.Length > 2)
+                i++;
         }
 
         for (i = 0; i < text.Length; i++) {
@@ -98,6 +103,12 @@ public static class HtmlParser {
                         appendTo.Pop();
                         tags.Pop();
                     } else {
+                        // If a comment contained other HTML tags, we need to make sure those also
+                        // get skipped.
+                        if (tagType == "!--") {
+                            SkipComment();
+                            continue;
+                        }
                         if (!isSelfClosing) {
                             tags.Push(tagType);
                         }
@@ -123,7 +134,7 @@ public static class HtmlParser {
 
                     if (insideEntity.StartsWith('#')) {
                         if (int.TryParse(insideEntity.Substring(1), out int result)) {
-                            currentText.Append((char) result);
+                            currentText.Append((char)result);
                         }
                     } else {
                         switch (insideEntity) {

--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -13,7 +13,7 @@ public static class HtmlParser {
     private static readonly ISawmill Sawmill;
     private static readonly HashSet<string> WarnedAttributes = new();
 
-    private static Regex? _attributeMatchRegex = null;
+    private static Regex? _attributeMatchRegex;
     private static Regex AttributeMatchRegex => _attributeMatchRegex ??= new Regex(@"[^ =]+(?:=(?:\w+|""[^""]*""|'[^']*'))?");
 
     static HtmlParser() {


### PR DESCRIPTION
The HTML parser currently expects closing tags to match opening tags. This is a problem with comment nodes, as it pushes `!--` to the stack, and expects `!--/>`, while the closing tag for comments is actually `-->`.

When a comment tag is encountered, the reader will totally ignore it and it won't be pushed to the formatted message at all. By default, the reader will read the entire comment tag `<!-- this text will be included -->`, however if the comment tag contains the `>` symbol, it won't be fully captured so I added `SkipComment` to handle that scenario.

The result is that the warnings in the console no longer occur when parsing HTML with comments.

<img width="444" height="218" alt="image" src="https://github.com/user-attachments/assets/2d94d28a-d9fe-48d5-bb40-cfc5ce60db21" />

<img width="229" height="128" alt="image" src="https://github.com/user-attachments/assets/1ead9740-5965-4f0b-8d0b-cc4e2ef7a2c4" />

<img width="482" height="277" alt="image" src="https://github.com/user-attachments/assets/b7173a3d-6184-460c-a0bb-1a12c6db7475" />

(The empty nodes are new-line tags, which should probably be limited to a single one without <br /> tags, but that's a different issue).

Also handling the situation that might break it nicely:

<img width="429" height="224" alt="image" src="https://github.com/user-attachments/assets/509b5ff0-096b-46e3-9092-7b02c63f35cb" />

<img width="722" height="307" alt="image" src="https://github.com/user-attachments/assets/b7ea966b-9965-4204-9094-8fda5753680e" />

Since the chat uses a browser window anyway, this has no visible effect on the chat but it stops an error in the console and this might become more important for maptext parsing, which is where the custom HTML parsing will have the most impact I think.