### PR TITLE
Fix default transform getting overwritten

### DIFF
--- a/OpenDreamShared/Dream/ImmutableAppearance.cs
+++ b/OpenDreamShared/Dream/ImmutableAppearance.cs
@@ -531,8 +531,10 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         result.Filters.AddRange(Filters);
         result.Verbs.AddRange(Verbs);
 
-        if (Transform != MutableAppearance.Default.Transform)
+        if (Transform != MutableAppearance.Default.Transform) {
+            result.Transform = new float[6];
             Array.Copy(Transform, result.Transform, 6);
+        }
 
         return result;
     }

--- a/OpenDreamShared/Dream/MutableAppearance.cs
+++ b/OpenDreamShared/Dream/MutableAppearance.cs
@@ -157,7 +157,13 @@ public sealed class MutableAppearance : IEquatable<MutableAppearance>, IDisposab
         VisContents.AddRange(appearance.VisContents);
         Filters.AddRange(appearance.Filters);
         Verbs.AddRange(appearance.Verbs);
-        Array.Copy(appearance.Transform, Transform, 6);
+
+        if (appearance.Transform == Default.Transform) {
+            Transform = Default.Transform;
+        } else {
+            Transform = new float[6];
+            Array.Copy(appearance.Transform, Transform, 6);
+        }
     }
 
     public override bool Equals(object? obj) => obj is MutableAppearance appearance && Equals(appearance);


### PR DESCRIPTION
The `MutableAppearance.Default.Transform` array could end up getting overwritten with new values in some cases.

This fixes some extreme rendering bugs in newest /tg/.