### PR TITLE
Define `/client/var/authenticate`

### DIFF
--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -34,6 +34,7 @@
 	var/connection
 	var/computer_id = 0
 	var/tick_lag = 0 as opendream_unimplemented
+	var/authenticate = TRUE as opendream_unimplemented // TODO: auth.mode CVar
 
 	var/timezone
 


### PR DESCRIPTION
We were missing a var, and it was causing BeeStation to error.