### PR TITLE
Fixes var/icon_state having an incorrect default value

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -27,8 +27,8 @@
 	var/icon_w = 0 as opendream_unimplemented
 	var/icon_z = 0 as opendream_unimplemented
 
-	var/icon as icon|null
-	var/icon_state as text|null
+	var/icon = null as icon|null
+	var/icon_state = null as text|null
 	var/layer = 2.0
 	var/plane = 0
 	var/alpha = 255

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -27,8 +27,8 @@
 	var/icon_w = 0 as opendream_unimplemented
 	var/icon_z = 0 as opendream_unimplemented
 
-	var/icon = null
-	var/icon_state = ""
+	var/icon as icon|null
+	var/icon_state as text|null
 	var/layer = 2.0
 	var/plane = 0
 	var/alpha = 255


### PR DESCRIPTION
Also annotates its type along with var/icon because why not
Fixes #2632 