### PR TITLE
CFG Part 0 Slim Edition: ProcDecoder fixes

### DIFF
--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -61,6 +61,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DMReference.Type.ListIndex: return DMReference.ListIndex;
             case DMReference.Type.Caller: return DMReference.Caller;
             case DMReference.Type.Callee: return DMReference.Callee;
+            case DMReference.Type.NoRef: return new DMReference { RefType = DMReference.Type.NoRef };
             default: throw new Exception($"Invalid reference type {refType}");
         }
     }
@@ -287,7 +288,10 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                     or DreamProcOpcode.SwitchCase
                     or DreamProcOpcode.SwitchCaseRange
                     or DreamProcOpcode.Jump
-                    or DreamProcOpcode.JumpIfFalse, int jumpPosition):
+                    or DreamProcOpcode.JumpIfFalse
+                    or DreamProcOpcode.JumpIfNull
+                    or DreamProcOpcode.JumpIfNullNoPop
+                    or DreamProcOpcode.TryNoValue, int jumpPosition):
                 text.AppendFormat("0x{0:x}", jumpPosition);
                 break;
 
@@ -307,6 +311,34 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                     or DreamProcOpcode.JumpIfTrueReference
                     or DreamProcOpcode.JumpIfReferenceFalse, DMReference reference, int jumpPosition):
                 text.Append(reference.ToString());
+                text.AppendFormat(" 0x{0:x}", jumpPosition);
+                break;
+
+            case (DreamProcOpcode.Try, int jumpPosition, DMReference reference):
+                text.AppendFormat("0x{0:x}", jumpPosition);
+                text.Append(' ');
+                text.Append(reference.ToString());
+                break;
+
+            case (DreamProcOpcode.Enumerate, int enumeratorId, DMReference reference, int jumpPosition):
+                text.Append(enumeratorId);
+                text.Append(' ');
+                text.Append(reference.ToString());
+                text.AppendFormat(" 0x{0:x}", jumpPosition);
+                break;
+
+            case (DreamProcOpcode.EnumerateAssoc, int enumeratorId, DMReference assocReference,
+                DMReference outputReference, int jumpPosition):
+                text.Append(enumeratorId);
+                text.Append(' ');
+                text.Append(assocReference.ToString());
+                text.Append(' ');
+                text.Append(outputReference.ToString());
+                text.AppendFormat(" 0x{0:x}", jumpPosition);
+                break;
+
+            case (DreamProcOpcode.EnumerateNoAssign, int enumeratorId, int jumpPosition):
+                text.Append(enumeratorId);
                 text.AppendFormat(" 0x{0:x}", jumpPosition);
                 break;
 
@@ -426,6 +458,8 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                     or DreamProcOpcode.SwitchCaseRange
                     or DreamProcOpcode.Jump
                     or DreamProcOpcode.JumpIfFalse
+                    or DreamProcOpcode.JumpIfNull
+                    or DreamProcOpcode.JumpIfNullNoPop
                     or DreamProcOpcode.TryNoValue, int jumpPosition):
                 return jumpPosition;
             case (DreamProcOpcode.JumpIfFalseReference
@@ -437,9 +471,11 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                 return jumpPosition;
             case (DreamProcOpcode.Try, int jumpPosition, DMReference):
                 return jumpPosition;
-            case (DreamProcOpcode.Enumerate, DMReference, int jumpPosition):
+            case (DreamProcOpcode.Enumerate, int, DMReference, int jumpPosition):
                 return jumpPosition;
-            case (DreamProcOpcode.EnumerateAssoc, DMReference, DMReference, DMReference, int jumpPosition):
+            case (DreamProcOpcode.EnumerateAssoc, int, DMReference, DMReference, int jumpPosition):
+                return jumpPosition;
+            case (DreamProcOpcode.EnumerateNoAssign, int, int jumpPosition):
                 return jumpPosition;
             default:
                 return null;


### PR DESCRIPTION
It was [revealed to me in a dream](https://discord.com/channels/847318834952405042/1512879974258839582/1516386487883530330) that I could avoid clogging up the CFG with internally-generated dead blocks by simply flagging and ignoring them instead of overcomplicating codegen and trying to make it perfect at the cost of simplicity and performance as seen in the [previous PR](https://github.com/OpenDreamProject/OpenDream/pull/2561). Dealing with those dead blocks will come when the CFG actually ships. The max stack changes will also be split off into their own separate PR without the other expensive peephole optimizer changes.

Instead, this PR is just some of the minimum amount of prerequisite changes necessary to get the CFG working, which is some fixes to ProcDecoder for missing/incorrect opcodes. It is still the precursor to [CFG Part 1](https://github.com/OpenDreamProject/OpenDream/pull/2596) and should be merged prior to that PR.

It would be nice if we could prevent these sorts of issues but I'll leave that for a future PR.