### PR TITLE
Implements indexing paths, shares that behaviour with initial()

### DIFF
--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -15,6 +15,7 @@ using Robust.Server.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Exceptions;
+using Robust.Shared.Utility;
 using MethodImplAttribute = System.Runtime.CompilerServices.MethodImplAttribute;
 using MethodImplOptions = System.Runtime.CompilerServices.MethodImplOptions;
 
@@ -585,6 +586,28 @@ public sealed class TreeEntry {
         Name = (lastSlash != -1) ? path.Substring(lastSlash + 1) : path;
         Path = path;
         Id = id;
+    }
+
+    public bool TryGetTypeVar(string field, out DreamValue value) {
+        switch(field) {
+            case "parent_type":
+                value = new(ParentEntry);
+                return true;
+            case "type":
+                value = new(this);
+                return true;
+            case "vars":
+                // Unimplemented
+                value = DreamValue.Null;
+                return false;
+            default:
+                var success =
+                    (ObjectDefinition.Variables.TryGetValue(field, out value)) ||
+                    (ObjectDefinition.GlobalVariables.TryGetValue(field, out var globalIndex)) && ObjectDefinition.DreamManager.Globals.TryGetValue(globalIndex, out value);
+
+                value.IncRef(); // globals
+                return success;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -591,7 +591,10 @@ public sealed class TreeEntry {
     public bool TryGetTypeVar(string field, out DreamValue value) {
         switch(field) {
             case "parent_type":
-                value = new(ParentEntry);
+                if(ParentEntry == ObjectDefinition.ObjectTree.Root)
+                    value = DreamValue.Null;
+                else
+                    value = new(ParentEntry);
                 return true;
             case "type":
                 value = new(this);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -688,7 +688,7 @@ namespace OpenDreamRuntime.Procs {
                 throw new Exception("Invalid var for initial() call: " + key);
             }
 
-            DreamObjectDefinition objectDefinition;
+            TreeEntry treeEntry;
             if (owner.TryGetValueAsDreamObject(out var dreamObject)) {
                 switch (dreamObject) {
                     // Calling initial() on a null value just returns null
@@ -697,30 +697,23 @@ namespace OpenDreamRuntime.Procs {
                         return ProcStatus.Continue;
                     // initial(object.vars.foo) should act like initial(object.foo)
                     case DreamListVars varsList:
-                        objectDefinition = varsList.DreamObject.ObjectDefinition;
+                        treeEntry = varsList.DreamObject.ObjectDefinition.TreeEntry;
                         break;
                     default:
-                        objectDefinition = dreamObject.ObjectDefinition;
+                        treeEntry = dreamObject.ObjectDefinition.TreeEntry;
                         break;
                 }
             } else if (owner.TryGetValueAsType(out var ownerType)) {
-                objectDefinition = ownerType.ObjectDefinition;
+                treeEntry = ownerType;
             } else {
                 state.DreamManager.OptionalException<ArgumentException>(DMCompiler.Compiler.WarningCode.InitialVarOnPrimitiveException, "Initial() attempted to get the initial value of a variable on a primitive.");
                 state.Push(DreamValue.Null);
                 return ProcStatus.Continue;
             }
 
-            var result = property switch {
-                // parent_type and type aren't actual vars and need special treatment
-                "parent_type" =>
-                    (objectDefinition.Parent?.TreeEntry == null ||
-                     objectDefinition.Parent.TreeEntry == state.Proc.ObjectTree.Root)
-                        ? DreamValue.Null
-                        : new DreamValue(objectDefinition.Parent.TreeEntry),
-                "type" => new DreamValue(objectDefinition.TreeEntry),
-                _ => objectDefinition.Variables.TryGetValue(property, out var val) ? val : DreamValue.Null
-            };
+            if (!treeEntry.TryGetTypeVar(property, out DreamValue result)) {
+                result = DreamValue.Null;
+            }
 
             state.Push(result);
             return ProcStatus.Continue;

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -1055,7 +1055,7 @@ public sealed class DMProcState : ProcState {
                 ThrowInvalidAppearanceVar(field);
 
             return Proc.AtomManager.GetAppearanceVar(appearance, field);
-        } else if (owner.TryGetValueAsType(out var ownerType) && ownerType.ObjectDefinition.Variables.TryGetValue(field, out var val)) {
+        } else if (owner.TryGetValueAsType(out var ownerType) && ownerType.TryGetTypeVar(field, out var val)) {
             return val; // equivalent to initial()
         }
 


### PR DESCRIPTION
You can't do /path.vars:value, but this should arguably be optimized at compile time instead of handled at runtime though