### PR TITLE
Fix `<init>` proc for type trees compiled out of order

### DIFF
--- a/Content.Tests/DMProject/Tests/Tree/Override/override_init_out_of_order.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_init_out_of_order.dm
@@ -1,0 +1,12 @@
+/obj
+  var/list/type_list = null
+
+/obj/subtype/broken
+  type_list = null
+
+/obj/subtype
+  type_list = list(/datum, /atom, /obj,)
+
+/proc/RunTest()
+  var/obj/O = new /obj/subtype/broken()
+  ASSERT(isnull(O.type_list))

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -30,7 +30,7 @@ internal partial class DMCodeTree {
             return true;
         }
 
-        protected void SetVariableValue(DMCompiler compiler, DMObject dmObject, DMVariable variable, DMExpression value, bool isOverride) {
+        protected bool TrySetVariableValue(DMCompiler compiler, DMObject dmObject, DMVariable variable, DMExpression value, bool isOverride) {
             // Typechecking
             if (!variable.ValType.MatchesType(compiler, value.ValType) && !variable.ValType.IsUnimplemented && !variable.ValType.Type.HasFlag(DMValueType.NoConstFold)) {
                 if (value is Null && !isOverride) {
@@ -44,17 +44,20 @@ internal partial class DMCodeTree {
             if (value.TryAsConstant(compiler, out var constant)) {
                 variable.Value = constant;
 
+                // Overrides shouldn't succeed while the parent init proc is undefined
+                if (isOverride && dmObject.Parent?.InitializationProc == null && IsFirstPass) return false;
+
                 // We want to continue with putting this in the init proc if a base type initializes it to another value
                 if (!isOverride || !dmObject.IsRuntimeInitialized(variable.Name)) {
-                    return;
+                    return true;
                 }
             } else if (variable.IsConst) {
                 compiler.Emit(WarningCode.HardConstContext, value.Location, "Value of const var must be a constant");
-                return;
+                return false;
             } else if (!IsValidRightHandSide(compiler, dmObject, value)) {
                 compiler.Emit(WarningCode.BadExpression, value.Location,
                     $"Invalid initial value for \"{variable.Name}\"");
-                return;
+                return false;
             }
 
             var initLoc = value.Location;
@@ -63,6 +66,7 @@ internal partial class DMCodeTree {
 
             variable.Value = new Null(Location.Internal);
             dmObject.InitializationProcAssignments.Add((variable.Name, assign));
+            return true;
         }
 
         /// <returns>Whether the given value can be used as an instance variable's initial value</returns>
@@ -160,8 +164,7 @@ internal partial class DMCodeTree {
             dmObject.AddVariable(variable);
             _defined = true;
 
-            SetVariableValue(compiler, dmObject, variable, value, false);
-            return true;
+            return TrySetVariableValue(compiler, dmObject, variable, value, false);
         }
 
         private bool CheckCantDefine(DMCompiler compiler, DMObject dmObject) {
@@ -261,8 +264,7 @@ internal partial class DMCodeTree {
             dmObject.VariableOverrides[variable.Name] = variable;
             _finished = true;
 
-            SetVariableValue(compiler, dmObject, variable, value, true);
-            return true;
+            return TrySetVariableValue(compiler, dmObject, variable, value, true);
         }
 
         public override string ToString() {

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -53,7 +53,7 @@ internal partial class DMCodeTree {
                 }
             } else if (variable.IsConst) {
                 compiler.Emit(WarningCode.HardConstContext, value.Location, "Value of const var must be a constant");
-                return false;
+                return true;
             } else if (!IsValidRightHandSide(compiler, dmObject, value)) {
                 compiler.Emit(WarningCode.BadExpression, value.Location,
                     $"Invalid initial value for \"{variable.Name}\"");

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -57,7 +57,7 @@ internal partial class DMCodeTree {
             } else if (!IsValidRightHandSide(compiler, dmObject, value)) {
                 compiler.Emit(WarningCode.BadExpression, value.Location,
                     $"Invalid initial value for \"{variable.Name}\"");
-                return false;
+                return true;
             }
 
             var initLoc = value.Location;

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -44,8 +44,8 @@ internal partial class DMCodeTree {
             if (value.TryAsConstant(compiler, out var constant)) {
                 variable.Value = constant;
 
-                // Overrides shouldn't succeed while the parent init proc is undefined
-                if (isOverride && dmObject.Parent?.InitializationProc == null && IsFirstPass) return false;
+                // Overrides that are defined out of order need an opportunity for the parent to perform runtime initializations
+                if (isOverride && !dmObject.IsRuntimeInitialized(variable.Name) && IsFirstPass) return false;
 
                 // We want to continue with putting this in the init proc if a base type initializes it to another value
                 if (!isOverride || !dmObject.IsRuntimeInitialized(variable.Name)) {
@@ -99,7 +99,7 @@ internal partial class DMCodeTree {
     }
 
     private class ObjectVarNode(DreamPath owner, DMASTObjectVarDefinition varDef) : VarNode {
-        private string VarName => varDef.Name;
+        public string VarName => varDef.Name;
         private bool IsStatic => varDef.IsStatic;
 
         private bool _defined;
@@ -262,9 +262,9 @@ internal partial class DMCodeTree {
                     "var \"tag\" cannot be set to a value at compile-time");
 
             dmObject.VariableOverrides[variable.Name] = variable;
-            _finished = true;
+            _finished = TrySetVariableValue(compiler, dmObject, variable, value, true);
 
-            return TrySetVariableValue(compiler, dmObject, variable, value, true);
+            return _finished;
         }
 
         public override string ToString() {

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -45,7 +45,7 @@ internal partial class DMCodeTree {
                 variable.Value = constant;
 
                 // Overrides that are defined out of order need an opportunity for the parent to perform runtime initializations
-                if (isOverride && !dmObject.IsRuntimeInitialized(variable.Name) && IsFirstPass) return false;
+                if (isOverride && IsFirstPass && !dmObject.IsRuntimeInitialized(variable.Name)) return false;
 
                 // We want to continue with putting this in the init proc if a base type initializes it to another value
                 if (!isOverride || !dmObject.IsRuntimeInitialized(variable.Name)) {

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -99,7 +99,7 @@ internal partial class DMCodeTree {
     }
 
     private class ObjectVarNode(DreamPath owner, DMASTObjectVarDefinition varDef) : VarNode {
-        public string VarName => varDef.Name;
+        private string VarName => varDef.Name;
         private bool IsStatic => varDef.IsStatic;
 
         private bool _defined;


### PR DESCRIPTION
Fixes https://github.com/OpenDreamProject/OpenDream/issues/2630

This just effectively defers the `IsRuntimeInitialized()` check on the first pass if it's an override. Doesn't seem to horribly break anything?