### PR TITLE
fix test

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/ambiguous_ternary.dm
+++ b/Content.Tests/DMProject/Tests/Operators/ambiguous_ternary.dm
@@ -44,4 +44,4 @@ var/_f = new /datum(TRUE)
 	ASSERT( (FALSE?f():f()) == (f()) )
 
 	var/list/L = list(D)
-	ASSERT( (TRUE?(TRUE?L[1]:L[2]):()) == (L[1]) )
+	ASSERT( (TRUE?(TRUE?L[1]:L[2]):f()) == (L[1]) )


### PR DESCRIPTION
`()` is no longer supported syntax in BYOND, this just does a quick fix of that in one test