### PR TITLE
Fixes /atom/var/color having an incorrect initial value

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -32,7 +32,7 @@
 	var/layer = 2.0
 	var/plane = 0
 	var/alpha = 255
-	var/color = null as text|null
+	var/color = null as /list|text|null
 	var/invisibility = 0
 	var/mouse_opacity = 1
 	var/infra_luminosity = 0 as opendream_unimplemented

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -32,7 +32,7 @@
 	var/layer = 2.0
 	var/plane = 0
 	var/alpha = 255
-	var/color = "#FFFFFF"
+	var/color = null as text|null
 	var/invisibility = 0
 	var/mouse_opacity = 1
 	var/infra_luminosity = 0 as opendream_unimplemented


### PR DESCRIPTION
I feel like we should have some kind of system to automatically insert appearance vars into types so we only need to do this in one place