### PR TITLE
Fixes browse() pages allowing illegal characters in filenames

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -139,26 +139,28 @@ internal sealed partial class ControlBrowser : InterfaceControl {
             if (newUri is {Scheme: "http", Host: "127.0.0.1"}) {
                 Stream stream;
                 HttpStatusCode status;
-                var path = new ResPath(newUri.AbsolutePath);
-                if (!_dreamResource.EnsureCacheFile(newUri.AbsolutePath)) {
+                var resource = new ResPath(newUri.AbsolutePath);
+                var path = HttpUtility.UrlDecode(resource.CanonPath); // files are saved in decoded form
+
+                if (!_dreamResource.EnsureCacheFile(path)) {
                     stream = Stream.Null;
                     status = HttpStatusCode.NotFound;
                 } else {
                     try {
                         stream = _resourceManager.UserData.OpenRead(
-                            _dreamResource.GetCacheFilePath(newUri.AbsolutePath));
+                            _dreamResource.GetCacheFilePath(path));
                         status = HttpStatusCode.OK;
                     } catch (FileNotFoundException) {
                         stream = Stream.Null;
                         status = HttpStatusCode.NotFound;
                     } catch (Exception e) {
-                        _sawmill.Error($"Exception while loading file from {newUri}:\n{e}");
+                        _sawmill.Error($"Exception while loading file from {path}:\n{e}");
                         stream = Stream.Null;
                         status = HttpStatusCode.InternalServerError;
                     }
                 }
 
-                var mimeType = FileExtensionMimeTypes.GetValueOrDefault(path.Extension, "application/octet-stream");
+                var mimeType = FileExtensionMimeTypes.GetValueOrDefault(resource.Extension, "application/octet-stream");
                 context.DoRespondStream(stream, mimeType, status);
             }
         } catch (Exception e) {

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -229,7 +229,7 @@ internal sealed partial class DreamResourceManager : IDreamResourceManager {
         EnsureCacheDirectory();
 
         // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
-        var path = _cacheDirectory / new ResPath(Uri.EscapeDataString(filename)).Filename;
+        var path = _cacheDirectory / new ResPath(filename).Filename;
         _resourceManager.UserData.WriteAllText(path, data);
         return new ResPath(filename);
     }
@@ -238,7 +238,7 @@ internal sealed partial class DreamResourceManager : IDreamResourceManager {
         EnsureCacheDirectory();
 
         // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
-        var path = _cacheDirectory / new ResPath(Uri.EscapeDataString(filename)).Filename;
+        var path = _cacheDirectory / new ResPath(filename).Filename;
         _resourceManager.UserData.WriteAllBytes(path, data);
         return new ResPath(filename);
     }

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -229,7 +229,7 @@ internal sealed partial class DreamResourceManager : IDreamResourceManager {
         EnsureCacheDirectory();
 
         // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
-        var path = _cacheDirectory / new ResPath(filename).Filename;
+        var path = _cacheDirectory / new ResPath(Uri.EscapeDataString(filename)).Filename;
         _resourceManager.UserData.WriteAllText(path, data);
         return new ResPath(filename);
     }
@@ -238,7 +238,7 @@ internal sealed partial class DreamResourceManager : IDreamResourceManager {
         EnsureCacheDirectory();
 
         // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
-        var path = _cacheDirectory / new ResPath(filename).Filename;
+        var path = _cacheDirectory / new ResPath(Uri.EscapeDataString(filename)).Filename;
         _resourceManager.UserData.WriteAllBytes(path, data);
         return new ResPath(filename);
     }


### PR DESCRIPTION
Required for Baystation12 to function on OD