### PR TITLE
Makes `statusbar` skin parameter `true` by default

### DIFF
--- a/OpenDreamShared/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamShared/Interface/Descriptors/ControlDescriptors.cs
@@ -68,7 +68,7 @@ public sealed partial class WindowDescriptor : ControlDescriptor {
     [DataField("alpha")]
     public DMFPropertyNum Alpha = new(255);
     [DataField("statusbar")]
-    public DMFPropertyBool StatusBar = new(false);
+    public DMFPropertyBool StatusBar = new(true);
     [DataField("transparent-color")]
     public DMFPropertyColor TransparentColor = new(Color.Transparent);
     [DataField("can-close")]


### PR DESCRIPTION
It's the default according to DM ref and some downstreams don't specify it