### PR TITLE
Implement `alist.len`

### DIFF
--- a/Content.Tests/DMProject/Tests/List/alist/AListLen1.dm
+++ b/Content.Tests/DMProject/Tests/List/alist/AListLen1.dm
@@ -1,0 +1,5 @@
+
+/proc/RunTest()
+	var/alist/A = alist(1 = "a", 2 = "b")
+	ASSERT(A.len == 2)
+	ASSERT(A.len == length(A))

--- a/Content.Tests/DMProject/Tests/List/alist/AListLen2.dm
+++ b/Content.Tests/DMProject/Tests/List/alist/AListLen2.dm
@@ -1,0 +1,4 @@
+// RUNTIME ERROR
+/proc/RunTest()
+	var/alist/A = alist(1 = "a", 2 = "b")
+	A.len = 1

--- a/Content.Tests/DMProject/Tests/List/alist/AListLen3.dm
+++ b/Content.Tests/DMProject/Tests/List/alist/AListLen3.dm
@@ -1,0 +1,5 @@
+
+/proc/RunTest()
+	var/alist/A = alist(1 = "a", 2 = "b")
+	A.len = 0
+	ASSERT(length(A) == 0)

--- a/Content.Tests/DMProject/Tests/List/alist/AListLen4.dm
+++ b/Content.Tests/DMProject/Tests/List/alist/AListLen4.dm
@@ -1,0 +1,5 @@
+
+/proc/RunTest()
+	var/alist/A = alist(1 = "a", 2 = "b")
+	A.len = "e" // becomes 0
+	ASSERT(length(A) == 0)

--- a/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
@@ -137,6 +137,29 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
         return 0;
     }
 
+    protected override bool TryGetVar(string varName, out DreamValue value) {
+        if (varName == "len") {
+            value = new(GetLength());
+            return true;
+        }
+
+        return base.TryGetVar(varName, out value);
+    }
+
+    protected override void SetVar(string varName, DreamValue value) {
+        if (varName == "len") {
+            // Non-nums become 0 which is parity w/ BYOND
+            if (value.TryGetValueAsInteger(out var newLen) && newLen != 0) {
+                throw new Exception("length of strict associative list can only be set to 0");
+            }
+
+            // alists specifically will always either runtime or get set to 0 and cut
+            Cut();
+        } else {
+            base.SetVar(varName, value);
+        }
+    }
+
     public void Insert(int index, DreamValue value) {
         throw new Exception("insert not allowed for this list");
     }


### PR DESCRIPTION
Looks like this got missed at some point.

Setting `alist.len` to a non-number coalesces to `0`. Setting `alist.len` to a non-zero number is a runtime error, which is the only behavior difference I noticed compared to `list.len`.