### PR TITLE
Adds `PreIncrement` & `PreDecrement` opcodes; fixes comparison operators

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/comparison2.dm
+++ b/Content.Tests/DMProject/Tests/Operators/comparison2.dm
@@ -1,0 +1,59 @@
+/proc/comparison_reference_proc_a()
+	return
+
+/proc/comparison_reference_proc_b()
+	return
+
+/proc/assert_left_preserving_comparisons(label, left, right)
+	var/result = left < right
+	if (result != left)
+		CRASH("[label] < expected the left operand, got [result]")
+
+	result = left <= right
+	if (result != left)
+		CRASH("[label] <= expected the left operand, got [result]")
+
+	result = left > right
+	if (result != left)
+		CRASH("[label] > expected the left operand, got [result]")
+
+	result = left >= right
+	if (result != left)
+		CRASH("[label] >= expected the left operand, got [result]")
+
+/proc/RunTest()
+	var/datum/datum_a = new
+	var/datum/datum_b = new
+	var/list/list_a = list(1)
+	var/list/list_b = list(1)
+	var/typepath_a = /datum
+	var/typepath_b = /atom
+	var/procpath_a = /proc/comparison_reference_proc_a
+	var/procpath_b = /proc/comparison_reference_proc_b
+	var/icon_a = icon()
+	var/icon_b = icon()
+	var/sound_a = sound()
+	var/sound_b = sound()
+	var/file_a = file("comparison_probe_a.tmp")
+	var/file_b = file("comparison_probe_b.tmp")
+
+	var/list/reference_names = list("datum", "list", "typepath", "procpath", "icon", "sound", "file")
+	var/list/reference_values = list(datum_a, list_a, typepath_a, procpath_a, icon_a, sound_a, file_a)
+	var/list/left_names = reference_names + list("num", "text", "null")
+	var/list/left_values = reference_values + list(1, "abc", null)
+
+	for (var/left_index in 1 to left_values.len)
+		for (var/right_index in 1 to reference_values.len)
+			assert_left_preserving_comparisons(
+				"[left_names[left_index]]_[reference_names[right_index]]",
+				left_values[left_index],
+				reference_values[right_index]
+			)
+
+	assert_left_preserving_comparisons("distinct datums", datum_a, datum_b)
+	assert_left_preserving_comparisons("distinct lists", list_a, list_b)
+	assert_left_preserving_comparisons("distinct typepaths", typepath_a, typepath_b)
+	assert_left_preserving_comparisons("distinct proc paths", procpath_a, procpath_b)
+	assert_left_preserving_comparisons("distinct icons", icon_a, icon_b)
+	assert_left_preserving_comparisons("distinct sounds", sound_a, sound_b)
+	assert_left_preserving_comparisons("distinct files", file_a, file_b)

--- a/Content.Tests/DMProject/Tests/Operators/pre_decrement.dm
+++ b/Content.Tests/DMProject/Tests/Operators/pre_decrement.dm
@@ -1,0 +1,9 @@
+/proc/RunTest()
+	var/text_value = "bad"
+	ASSERT(--text_value == -1)
+	
+	var/list/list_values = list("a","b","c")
+	ASSERT(--list_values[1] == -1)
+    
+	var/null_value = null
+	ASSERT(--null_value == -1)

--- a/Content.Tests/DMProject/Tests/Operators/pre_increment.dm
+++ b/Content.Tests/DMProject/Tests/Operators/pre_increment.dm
@@ -1,0 +1,9 @@
+/proc/RunTest()
+	var/text_value = "bad"
+	ASSERT(++text_value == 1)
+
+	var/list/list_values = list("a","b","c")
+	ASSERT(++list_values[1] == 1)
+
+	var/null_value = null
+	ASSERT(++null_value == 1)

--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -307,6 +307,10 @@ public enum DreamProcOpcode : byte {
     NPushFloatAssign = 0x9B,
     [OpcodeMetadata(0, OpcodeArgType.ArgType, OpcodeArgType.StackDelta)]
     Animate = 0x9C,
+    [OpcodeMetadata(1, OpcodeArgType.Reference)]
+    PreIncrement = 0x9D,
+    [OpcodeMetadata(1, OpcodeArgType.Reference)]
+    PreDecrement = 0x9E,
 }
 // ReSharper restore MissingBlankLines
 

--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -192,8 +192,10 @@ public enum DreamProcOpcode : byte {
     ModulusModulus = 0x60,
     [OpcodeMetadata(0, OpcodeArgType.Reference)]
     ModulusModulusReference = 0x61,
-    //0x62
-    //0x63
+    [OpcodeMetadata(1, OpcodeArgType.Reference)]
+    PreIncrement = 0x62,
+    [OpcodeMetadata(1, OpcodeArgType.Reference)]
+    PreDecrement = 0x63,
     [OpcodeMetadata(0, OpcodeArgType.Label)]
     JumpIfNull = 0x64,
     [OpcodeMetadata(0, OpcodeArgType.Label)]
@@ -307,10 +309,6 @@ public enum DreamProcOpcode : byte {
     NPushFloatAssign = 0x9B,
     [OpcodeMetadata(0, OpcodeArgType.ArgType, OpcodeArgType.StackDelta)]
     Animate = 0x9C,
-    [OpcodeMetadata(1, OpcodeArgType.Reference)]
-    PreIncrement = 0x9D,
-    [OpcodeMetadata(1, OpcodeArgType.Reference)]
-    PreDecrement = 0x9E,
 }
 // ReSharper restore MissingBlankLines
 

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -1016,8 +1016,18 @@ internal sealed class DMProc {
         WriteReference(reference);
     }
 
+    public void PreIncrement(DMReference reference) {
+        WriteOpcode(DreamProcOpcode.PreIncrement);
+        WriteReference(reference);
+    }
+
     public void Increment(DMReference reference) {
         WriteOpcode(DreamProcOpcode.Increment);
+        WriteReference(reference);
+    }
+
+    public void PreDecrement(DMReference reference) {
+        WriteOpcode(DreamProcOpcode.PreDecrement);
         WriteReference(reference);
     }
 

--- a/DMCompiler/DM/Expressions/Unary.cs
+++ b/DMCompiler/DM/Expressions/Unary.cs
@@ -85,8 +85,7 @@ internal abstract class AssignmentUnaryOp(Location location, DMExpression expr) 
 // ++x
 internal sealed class PreIncrement(Location location, DMExpression expr) : AssignmentUnaryOp(location, expr) {
     protected override void EmitOp(DMProc proc, DMReference reference) {
-        proc.PushFloat(1);
-        proc.Append(reference);
+        proc.PreIncrement(reference);
     }
 }
 
@@ -100,8 +99,7 @@ internal sealed class PostIncrement(Location location, DMExpression expr) : Assi
 // --x
 internal sealed class PreDecrement(Location location, DMExpression expr) : AssignmentUnaryOp(location, expr) {
     protected override void EmitOp(DMProc proc, DMReference reference) {
-        proc.PushFloat(1);
-        proc.Remove(reference);
+        proc.PreDecrement(reference);
     }
 }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1488,6 +1488,11 @@ namespace OpenDreamRuntime.Procs {
             using var second = state.Pop();
             using var first = state.Pop();
 
+            if (TryGetReferenceComparisonResult(first, second, out DreamValue referenceResult)) {
+                state.Push(referenceResult);
+                return ProcStatus.Continue;
+            }
+
             state.Push(new DreamValue(IsGreaterThan(first, second) ? 1 : 0));
             return ProcStatus.Continue;
         }
@@ -1497,7 +1502,9 @@ namespace OpenDreamRuntime.Procs {
             using var first = state.Pop();
             DreamValue result;
 
-            if (first.TryGetValueAsFloat(out float lhs) && lhs == 0.0 && second.IsNull) result = new DreamValue(1);
+            if (TryGetReferenceComparisonResult(first, second, out DreamValue referenceResult))
+                result = referenceResult;
+            else if (first.TryGetValueAsFloat(out float lhs) && lhs == 0.0 && second.IsNull) result = new DreamValue(1);
             else if (first.IsNull && second.TryGetValueAsFloat(out float rhs) && rhs == 0.0) result = new DreamValue(1);
             else if (first.IsNull && second.TryGetValueAsString(out var s) && s == "") result = new DreamValue(1);
             else result = new DreamValue((IsEqual(first, second) || IsGreaterThan(first, second)) ? 1 : 0);
@@ -1510,6 +1517,11 @@ namespace OpenDreamRuntime.Procs {
             using var second = state.Pop();
             using var first = state.Pop();
 
+            if (TryGetReferenceComparisonResult(first, second, out DreamValue referenceResult)) {
+                state.Push(referenceResult);
+                return ProcStatus.Continue;
+            }
+
             state.Push(new DreamValue(IsLessThan(first, second) ? 1 : 0));
             return ProcStatus.Continue;
         }
@@ -1519,7 +1531,9 @@ namespace OpenDreamRuntime.Procs {
             using var first = state.Pop();
             DreamValue result;
 
-            if (first.TryGetValueAsFloat(out float lhs) && lhs == 0.0 && second.IsNull) result = new DreamValue(1);
+            if (TryGetReferenceComparisonResult(first, second, out DreamValue referenceResult))
+                result = referenceResult;
+            else if (first.TryGetValueAsFloat(out float lhs) && lhs == 0.0 && second.IsNull) result = new DreamValue(1);
             else if (first.IsNull && second.TryGetValueAsFloat(out float rhs) && rhs == 0.0) result = new DreamValue(1);
             else if (first.IsNull && second.TryGetValueAsString(out var s) && s == "") result = new DreamValue(1);
             else result = new DreamValue((IsEqual(first, second) || IsLessThan(first, second)) ? 1 : 0);
@@ -2967,6 +2981,26 @@ namespace OpenDreamRuntime.Procs {
 
             // Behaviour is otherwise equivalent (pun intended) to ==
             return IsEqual(first, second);
+        }
+
+        private static bool TryGetReferenceComparisonResult(DreamValue first, DreamValue second,
+            out DreamValue result) {
+            // BYOND leaves the left operand untouched whenever the right operand is reference-like regardless of the left operand's runtime representation
+            // The reverse is a runtime error: reference <op> null
+            if (!second.IsNull && IsReferenceComparisonType(second.Type)) {
+                result = first;
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        private static bool IsReferenceComparisonType(DreamValue.DreamValueType type) {
+            return type is DreamValue.DreamValueType.DreamObject or
+                DreamValue.DreamValueType.DreamProc or
+                DreamValue.DreamValueType.DreamResource or
+                DreamValue.DreamValueType.DreamType;
         }
 
         private static bool IsGreaterThan(DreamValue first, DreamValue second) {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -927,24 +927,30 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public static ProcStatus Increment(DMProcState state) {
-            var reference = state.ReadReference();
-            using var value = state.GetReferenceValue(reference, peek: true);
+            return IncrementDecrement(state, 1, returnPrevious: true);
+        }
 
-            //If it's not a number, it turns into 1
-            state.AssignReference(reference, new(value.UnsafeGetValueAsFloat() + 1));
-
-            state.Push(value);
-            return ProcStatus.Continue;
+        public static ProcStatus PreIncrement(DMProcState state) {
+            return IncrementDecrement(state, 1, returnPrevious: false);
         }
 
         public static ProcStatus Decrement(DMProcState state) {
+            return IncrementDecrement(state, -1, returnPrevious: true);
+        }
+
+        public static ProcStatus PreDecrement(DMProcState state) {
+            return IncrementDecrement(state, -1, returnPrevious: false);
+        }
+
+        private static ProcStatus IncrementDecrement(DMProcState state, float adjustment, bool returnPrevious) {
             var reference = state.ReadReference();
             using var value = state.GetReferenceValue(reference, peek: true);
+            DreamValue result = new(value.UnsafeGetValueAsFloat() + adjustment);
 
-            //If it's not a number, it turns into -1
-            state.AssignReference(reference, new(value.UnsafeGetValueAsFloat() - 1));
+            // BYOND coerces every non-number including null to 0 for ++ and --
+            state.AssignReference(reference, result);
 
-            state.Push(value);
+            state.Push(returnPrevious ? value : result);
             return ProcStatus.Continue;
         }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2987,20 +2987,13 @@ namespace OpenDreamRuntime.Procs {
             out DreamValue result) {
             // BYOND leaves the left operand untouched whenever the right operand is reference-like regardless of the left operand's runtime representation
             // The reverse is a runtime error: reference <op> null
-            if (!second.IsNull && IsReferenceComparisonType(second.Type)) {
+            if (!second.IsNull && second.Type != DreamValue.DreamValueType.Float && second.Type != DreamValue.DreamValueType.String) {
                 result = first;
                 return true;
             }
 
             result = default;
             return false;
-        }
-
-        private static bool IsReferenceComparisonType(DreamValue.DreamValueType type) {
-            return type is DreamValue.DreamValueType.DreamObject or
-                DreamValue.DreamValueType.DreamProc or
-                DreamValue.DreamValueType.DreamResource or
-                DreamValue.DreamValueType.DreamType;
         }
 
         private static bool IsGreaterThan(DreamValue first, DreamValue second) {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -294,6 +294,8 @@ public sealed class DMProcState : ProcState {
         {DreamProcOpcode.PickWeighted, DMOpcodeHandlers.PickWeighted},
         {DreamProcOpcode.Increment, DMOpcodeHandlers.Increment},
         {DreamProcOpcode.Decrement, DMOpcodeHandlers.Decrement},
+        {DreamProcOpcode.PreIncrement, DMOpcodeHandlers.PreIncrement},
+        {DreamProcOpcode.PreDecrement, DMOpcodeHandlers.PreDecrement},
         {DreamProcOpcode.CompareEquivalent, DMOpcodeHandlers.CompareEquivalent},
         {DreamProcOpcode.CompareNotEquivalent, DMOpcodeHandlers.CompareNotEquivalent},
         {DreamProcOpcode.Throw, DMOpcodeHandlers.Throw},

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -115,6 +115,8 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.Combine:
             case DreamProcOpcode.Increment:
             case DreamProcOpcode.Decrement:
+            case DreamProcOpcode.PreIncrement:
+            case DreamProcOpcode.PreDecrement:
             case DreamProcOpcode.Mask:
             case DreamProcOpcode.MultiplyReference:
             case DreamProcOpcode.DivideReference:


### PR DESCRIPTION
The new unit tests passed in BYOND but not OpenDream. 

This fixes `++`/`--` the parity issue by creating dedicated `PreIncrement`/`PreDecrement` opcodes with matching behavior. Deduplicated the opcode handlers with a shared helper method.

This also fixes the greater than / less than comparison operators (and the "or equals to" variants) with some types.