### PR TITLE
Less Strict InvalidVarType

### DIFF
--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -36,7 +36,7 @@ internal partial class DMCodeTree {
                 if (value is Null && !isOverride) {
                     compiler.Emit(WarningCode.ImplicitNullType, value.Location, $"{dmObject.Path}.{variable.Name}: Variable is null but not explicitly typed as nullable, append \"|null\" to \"as\". Implicitly treating as nullable.");
                     variable.ValType |= DMValueType.Null;
-                } else if (!variable.ValType.IsAnything) {
+                } else if (compiler.Settings.SkipAnythingTypeCheck && !variable.ValType.IsAnything || !compiler.Settings.SkipAnythingTypeCheck) {
                     compiler.Emit(WarningCode.InvalidVarType, value.Location, $"{dmObject.Path}.{variable.Name}: Invalid var value type {value.ValType}, expected {variable.ValType}");
                 }
             }

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -36,7 +36,7 @@ internal partial class DMCodeTree {
                 if (value is Null && !isOverride) {
                     compiler.Emit(WarningCode.ImplicitNullType, value.Location, $"{dmObject.Path}.{variable.Name}: Variable is null but not explicitly typed as nullable, append \"|null\" to \"as\". Implicitly treating as nullable.");
                     variable.ValType |= DMValueType.Null;
-                } else {
+                } else if (!variable.ValType.IsAnything) {
                     compiler.Emit(WarningCode.InvalidVarType, value.Location, $"{dmObject.Path}.{variable.Name}: Invalid var value type {value.ValType}, expected {variable.ValType}");
                 }
             }

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -36,7 +36,7 @@ internal partial class DMCodeTree {
                 if (value is Null && !isOverride) {
                     compiler.Emit(WarningCode.ImplicitNullType, value.Location, $"{dmObject.Path}.{variable.Name}: Variable is null but not explicitly typed as nullable, append \"|null\" to \"as\". Implicitly treating as nullable.");
                     variable.ValType |= DMValueType.Null;
-                } else if (compiler.Settings.SkipAnythingTypeCheck && !variable.ValType.IsAnything || !compiler.Settings.SkipAnythingTypeCheck) {
+                } else if (compiler.Settings.SkipAnythingTypecheck && !variable.ValType.IsAnything || !compiler.Settings.SkipAnythingTypecheck) {
                     compiler.Emit(WarningCode.InvalidVarType, value.Location, $"{dmObject.Path}.{variable.Name}: Invalid var value type {value.ValType}, expected {variable.ValType}");
                 }
             }

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -36,7 +36,7 @@ internal partial class DMCodeTree {
                 if (value is Null && !isOverride) {
                     compiler.Emit(WarningCode.ImplicitNullType, value.Location, $"{dmObject.Path}.{variable.Name}: Variable is null but not explicitly typed as nullable, append \"|null\" to \"as\". Implicitly treating as nullable.");
                     variable.ValType |= DMValueType.Null;
-                } else if (compiler.Settings.SkipAnythingTypecheck && !variable.ValType.IsAnything || !compiler.Settings.SkipAnythingTypecheck) {
+                } else if (!compiler.Settings.SkipAnythingTypecheck || !variable.ValType.IsAnything) {
                     compiler.Emit(WarningCode.InvalidVarType, value.Location, $"{dmObject.Path}.{variable.Name}: Invalid var value type {value.ValType}, expected {variable.ValType}");
                 }
             }


### PR DESCRIPTION
InvalidVarType is essentially useless as a top level error otherwise, since it's not possible to static type icons. I would have expected it to be more useful if I was permitted to opt-in to it by declaring types for vars rather than globally checking every dynamic typed var. 

As an aside, it's seemingly not possible for me to correct icons not being statically typed anyways.

<img width="1517" height="515" alt="image" src="https://github.com/user-attachments/assets/8fee2c90-5743-467b-8410-de8c816b0ded" />

<img width="408" height="27" alt="image" src="https://github.com/user-attachments/assets/f641bcdc-a847-4479-a75b-6e317e9ee498" />
