### PR TITLE
Fix unimplemented `==` operations

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/equality_disparate_types.dm
+++ b/Content.Tests/DMProject/Tests/Operators/equality_disparate_types.dm
@@ -1,0 +1,27 @@
+// Comparing values of different types with == / != should never error;
+// disparate types are simply never equal.
+// Regression test for https://github.com/OpenDreamProject/OpenDream/issues/2675
+
+/datum/equality_test
+
+/proc/RunTest()
+	var/res = 'Shared/file.txt'
+	var/datum/equality_test/obj = new
+
+	// The exact case from the issue: number vs resource
+	ASSERT((0 == res) == FALSE)
+	ASSERT((0 != res) == TRUE)
+	ASSERT((res == 0) == FALSE)
+	ASSERT((res != 0) == TRUE)
+
+	// A resource is still equal to itself (compared by path)
+	ASSERT((res == res) == TRUE)
+	ASSERT((res != res) == FALSE)
+
+	// Other previously-unhandled cross-type comparisons
+	ASSERT(("str" == res) == FALSE)
+	ASSERT((res == "str") == FALSE)
+	ASSERT((obj == res) == FALSE)
+	ASSERT((res == obj) == FALSE)
+	ASSERT((/datum == res) == FALSE)
+	ASSERT((res == /datum) == FALSE)

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2882,49 +2882,32 @@ namespace OpenDreamRuntime.Procs {
 
                     switch (second.Type) {
                         case DreamValue.DreamValueType.DreamObject: return firstValue == second.MustGetValueAsDreamObject();
-                        case DreamValue.DreamValueType.Appearance:
-                        case DreamValue.DreamValueType.DreamProc:
-                        case DreamValue.DreamValueType.DreamType:
-                        case DreamValue.DreamValueType.String:
-                        case DreamValue.DreamValueType.Float: return false;
+                        default: return false;
                     }
-
-                    break;
                 }
                 case DreamValue.DreamValueType.Float: {
                     float firstValue = first.MustGetValueAsFloat();
 
                     switch (second.Type) {
                         case DreamValue.DreamValueType.Float: return firstValue == second.MustGetValueAsFloat();
-                        case DreamValue.DreamValueType.DreamType:
-                        case DreamValue.DreamValueType.DreamObject:
-                        case DreamValue.DreamValueType.String: return false;
+                        default: return false;
                     }
-
-                    break;
                 }
                 case DreamValue.DreamValueType.String: {
                     string firstValue = first.MustGetValueAsString();
 
                     switch (second.Type) {
                         case DreamValue.DreamValueType.String: return firstValue == second.MustGetValueAsString();
-                        case DreamValue.DreamValueType.DreamObject:
-                        case DreamValue.DreamValueType.Float: return false;
+                        default: return false;
                     }
-
-                    break;
                 }
                 case DreamValue.DreamValueType.DreamType: {
                     var firstValue = first.MustGetValueAsType();
 
                     switch (second.Type) {
                         case DreamValue.DreamValueType.DreamType: return firstValue.Equals(second.MustGetValueAsType());
-                        case DreamValue.DreamValueType.Float:
-                        case DreamValue.DreamValueType.DreamObject:
-                        case DreamValue.DreamValueType.String: return false;
+                        default: return false;
                     }
-
-                    break;
                 }
                 case DreamValue.DreamValueType.DreamProc: {
                     if (second.Type != DreamValue.DreamValueType.DreamProc)

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2882,7 +2882,8 @@ namespace OpenDreamRuntime.Procs {
                 case DreamValue.DreamValueType.Float: {
                     float firstValue = first.MustGetValueAsFloat();
 
-                    return firstValue.Equals(second.MustGetValueAsFloat());
+                    // ReSharper disable once CompareOfFloatsByEqualityOperator
+                    return firstValue == second.MustGetValueAsFloat();
                 }
                 case DreamValue.DreamValueType.String: {
                     string firstValue = first.MustGetValueAsString();

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2869,66 +2869,42 @@ namespace OpenDreamRuntime.Procs {
 
         #region Helpers
 
-        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public static bool IsEqual(DreamValue first, DreamValue second) {
-            // null should only ever be equal to null
-            if (first.IsNull) return second.IsNull;
-            if (second.IsNull) return false; // If this were ever true the above condition would have handled it
+            if (first.Type != second.Type)
+                return false;
 
-            // Now we don't have to worry about null for the rest of this method
             switch (first.Type) {
                 case DreamValue.DreamValueType.DreamObject: {
                     DreamObject? firstValue = first.MustGetValueAsDreamObject();
 
-                    switch (second.Type) {
-                        case DreamValue.DreamValueType.DreamObject: return firstValue == second.MustGetValueAsDreamObject();
-                        default: return false;
-                    }
+                    return firstValue == second.MustGetValueAsDreamObject();
                 }
                 case DreamValue.DreamValueType.Float: {
                     float firstValue = first.MustGetValueAsFloat();
 
-                    switch (second.Type) {
-                        case DreamValue.DreamValueType.Float: return firstValue == second.MustGetValueAsFloat();
-                        default: return false;
-                    }
+                    return firstValue.Equals(second.MustGetValueAsFloat());
                 }
                 case DreamValue.DreamValueType.String: {
                     string firstValue = first.MustGetValueAsString();
 
-                    switch (second.Type) {
-                        case DreamValue.DreamValueType.String: return firstValue == second.MustGetValueAsString();
-                        default: return false;
-                    }
+                    return firstValue == second.MustGetValueAsString();
                 }
                 case DreamValue.DreamValueType.DreamType: {
                     var firstValue = first.MustGetValueAsType();
 
-                    switch (second.Type) {
-                        case DreamValue.DreamValueType.DreamType: return firstValue.Equals(second.MustGetValueAsType());
-                        default: return false;
-                    }
+                    return firstValue.Equals(second.MustGetValueAsType());
                 }
-                case DreamValue.DreamValueType.DreamProc: {
-                    if (second.Type != DreamValue.DreamValueType.DreamProc)
-                        return false;
-
+                case DreamValue.DreamValueType.DreamProc:
                     return first.MustGetValueAsProc() == second.MustGetValueAsProc();
-                }
                 case DreamValue.DreamValueType.DreamResource: {
                     DreamResource firstValue = first.MustGetValueAsDreamResource();
 
-                    switch (second.Type) {
-                        case DreamValue.DreamValueType.DreamResource: return firstValue.ResourcePath == second.MustGetValueAsDreamResource().ResourcePath;
-                        default: return false;
-                    }
+                    return firstValue.ResourcePath == second.MustGetValueAsDreamResource().ResourcePath;
                 }
                 case DreamValue.DreamValueType.Appearance: {
-                    if (!second.TryGetValueAsAppearance(out var secondValue))
-                        return false;
-
                     MutableAppearance firstValue = first.MustGetValueAsAppearance();
-                    return firstValue.Equals(secondValue);
+
+                    return firstValue.Equals(second.MustGetValueAsAppearance());
                 }
             }
 


### PR DESCRIPTION
Fixes #2675

## Problem
Comparing a number with a resource (e.g. `0 == 'sound/weapons/metalhit.ogg'`)
threw `NotImplementedException: Equal comparison for 0 and '...' is not implemented`
at runtime instead of evaluating to `FALSE`.

## Fix
In DM, values of different types are never `==`-equal, so each inner switch now
falls back to `return false` (mirroring the existing `DreamResource`/`Appearance`
branches) instead of throwing. This covers the whole class of cross-type
comparisons, and `!=` / `~=` inherit the fix since they route through `IsEqual`.