### PR TITLE
Error on a proc override that shares a path with an existing type

### DIFF
--- a/Content.Tests/DMProject/Tests/Procs/final_proc2.dm
+++ b/Content.Tests/DMProject/Tests/Procs/final_proc2.dm
@@ -1,15 +1,18 @@
 /proc/RunTest()
     return
-    
+
+// "final" is only a keyword directly after "proc"; below it's an ordinary name.
+// The procs named "final" have to come before /datum/test/final exists as a type, otherwise BYOND
+// reads the override as a redefinition of that type (issue 2648).
 /datum/proc/foo()
 	return
 /datum/test/foo()
 	return
-/datum/test/final/foo()
-	return
-/datum/test/again/foo()
-	return
 /datum/proc/final()
 	return
 /datum/test/final()
+	return
+/datum/test/final/foo()
+	return
+/datum/test/again/foo()
 	return

--- a/Content.Tests/DMProject/Tests/Tree/type_proc_conflict.dm
+++ b/Content.Tests/DMProject/Tests/Tree/type_proc_conflict.dm
@@ -1,0 +1,16 @@
+// COMPILE ERROR OD2102
+
+//# issue 2648
+
+/datum/proc/beep()
+	return
+
+// "beep" is already a type here, so BYOND reads this as a duplicate definition rather than an override
+/datum/test/beep
+	var/thing = 1
+
+/datum/test/beep()
+	return
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Tree/type_proc_no_conflict.dm
+++ b/Content.Tests/DMProject/Tests/Tree/type_proc_no_conflict.dm
@@ -1,0 +1,40 @@
+//# issue 2648
+
+// Only the override form of a proc definition shares a path with a type.
+// Everything below compiles in BYOND.
+
+/datum/proc/beep()
+	return 1
+
+/datum/test/proc/boop()
+	return 2
+
+// A type sharing its name with a proc of the parent type
+/datum/test/beep
+	var/thing = 1
+
+// A type sharing its name with a proc of its own type
+/datum/test/boop
+	var/thing = 2
+
+// A type declared after the override that shares its path.
+// BYOND doesn't error here, though it does do something strange with the type's vars, so don't test those.
+/datum/other/beep()
+	return 3
+
+/datum/other/beep
+	var/thing = 3
+
+/proc/RunTest()
+	var/datum/test/t = new
+	ASSERT(t.beep() == 1)
+	ASSERT(t.boop() == 2)
+
+	var/datum/other/o = new
+	ASSERT(o.beep() == 3)
+
+	var/datum/test/beep/b = new
+	ASSERT(b.thing == 1)
+
+	var/datum/test/boop/p = new
+	ASSERT(p.thing == 2)

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -48,6 +48,7 @@ public enum WarningCode {
     ScopeOperandNamedType = 2001, // Scope operator is used on a var named type or parent_type, maybe unintentionally
     DuplicateVariable = 2100,
     DuplicateProcDefinition = 2101,
+    TypeProcConflict = 2102, // A proc override whose path was already declared as a type
     PointlessParentCall = 2205,
     PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
     SuspiciousMatrixCall = 2207, // Calling matrix() with seemingly the wrong arguments
@@ -149,6 +150,7 @@ public struct CompilerEmission {
         {WarningCode.ScopeOperandNamedType, ErrorLevel.Warning},
         {WarningCode.DuplicateVariable, ErrorLevel.Warning},
         {WarningCode.DuplicateProcDefinition, ErrorLevel.Error},
+        {WarningCode.TypeProcConflict, ErrorLevel.Error},
         {WarningCode.PointlessParentCall, ErrorLevel.Warning},
         {WarningCode.PointlessBuiltinCall, ErrorLevel.Warning},
         {WarningCode.SuspiciousMatrixCall, ErrorLevel.Warning},

--- a/DMCompiler/DM/Builders/DMCodeTreeBuilder.cs
+++ b/DMCompiler/DM/Builders/DMCodeTreeBuilder.cs
@@ -44,27 +44,27 @@ internal class DMCodeTreeBuilder(DMCompiler compiler) {
             case DMASTNullStatement:
                 break;
             case DMASTObjectDefinition objectDefinition:
-                CodeTree.AddType(objectDefinition.Path);
+                CodeTree.AddType(objectDefinition.Path, objectDefinition.Location);
                 if (objectDefinition.InnerBlock != null)
                     ProcessBlockInner(objectDefinition.InnerBlock, objectDefinition.Path);
                 break;
             case DMASTObjectVarDefinition varDefinition:
-                CodeTree.AddType(varDefinition.ObjectPath);
+                CodeTree.AddType(varDefinition.ObjectPath, varDefinition.Location);
                 CodeTree.AddObjectVar(varDefinition.ObjectPath, varDefinition);
                 break;
             case DMASTObjectVarOverride varOverride:
-                CodeTree.AddType(varOverride.ObjectPath);
+                CodeTree.AddType(varOverride.ObjectPath, varOverride.Location);
                 CodeTree.AddObjectVarOverride(varOverride.ObjectPath, varOverride);
                 break;
             case DMASTProcDefinition procDefinition:
                 var procOwner = currentType.Combine(procDefinition.ObjectPath);
 
-                CodeTree.AddType(procOwner);
+                CodeTree.AddType(procOwner, procDefinition.Location);
                 CodeTree.AddProc(procOwner, procDefinition);
                 break;
             case DMASTMultipleObjectVarDefinitions multipleVarDefinitions: {
                 foreach (DMASTObjectVarDefinition varDefinition in multipleVarDefinitions.VarDefinitions) {
-                    CodeTree.AddType(varDefinition.ObjectPath);
+                    CodeTree.AddType(varDefinition.ObjectPath, varDefinition.Location);
                     CodeTree.AddObjectVar(varDefinition.ObjectPath, varDefinition);
                 }
 

--- a/DMCompiler/DM/DMCodeTree.Procs.cs
+++ b/DMCompiler/DM/DMCodeTree.Procs.cs
@@ -127,7 +127,16 @@ internal partial class DMCodeTree {
     }
 
     public void AddProc(DreamPath owner, DMASTProcDefinition procDef) {
-        var node = GetDMObjectNode(owner);
+        var node = GetDMObjectNode(owner, procDef.Location);
+
+        // An override is written without a "proc" keyword, giving it the exact same path as a type would have.
+        // BYOND resolves that path to whatever was declared first, so a type already sitting there is a conflict.
+        // Note that the reverse order is fine; declaring the type after the override compiles in BYOND.
+        if (procDef.IsOverride && TryGetTypeNode(owner.AddToPath(procDef.Name), out var conflictingType)) {
+            _compiler.Emit(WarningCode.TypeProcConflict, procDef.Location,
+                $"Cannot define proc \"{procDef.Name}()\": {conflictingType.Path} is already defined as a type at {conflictingType.Location}");
+        }
+
         var procNode = new ProcNode(this, owner, procDef);
 
         if (procDef is { Name: "New", IsOverride: false })

--- a/DMCompiler/DM/DMCodeTree.cs
+++ b/DMCompiler/DM/DMCodeTree.cs
@@ -39,6 +39,11 @@ internal partial class DMCodeTree {
     }
 
     private class ObjectNode(DMCodeTree codeTree, string name, DreamPath type) : TypeNode(name) {
+        public DreamPath Path => type;
+
+        /// <summary>The location that first caused this type to be added to the tree</summary>
+        public Location Location { get; init; } = Location.Unknown;
+
         private bool _defined;
         private ProcsNode? _procs;
 
@@ -144,8 +149,8 @@ internal partial class DMCodeTree {
         _root = new(this, "/", DreamPath.Root);
     }
 
-    public void AddType(DreamPath type) {
-        GetDMObjectNode(type); // Add it to our tree
+    public void AddType(DreamPath type, Location location) {
+        GetDMObjectNode(type, location); // Add it to our tree
     }
 
     public DreamPath? UpwardSearch(DMObject start, DreamPath search) {
@@ -196,7 +201,7 @@ internal partial class DMCodeTree {
         }
     }
 
-    private ObjectNode GetDMObjectNode(DreamPath path) {
+    private ObjectNode GetDMObjectNode(DreamPath path, Location location = default) {
         var node = _root;
 
         for (int i = 0; i < path.Elements.Length; i++) {
@@ -205,7 +210,7 @@ internal partial class DMCodeTree {
                 var creating = path.FromElements(0, i + 1);
 
                 _compiler.VerbosePrint($"Adding {creating} to the code tree");
-                childNode = new ObjectNode(this, element, creating);
+                childNode = new ObjectNode(this, element, creating) { Location = location };
                 node.Children.Add(childNode);
                 _waitingNodes.Add(childNode);
             }
@@ -217,6 +222,30 @@ internal partial class DMCodeTree {
         }
 
         return node;
+    }
+
+    /// <summary>
+    /// Looks for a type that's already been declared, without adding anything to the tree
+    /// </summary>
+    private bool TryGetTypeNode(DreamPath path, [NotNullWhen(true)] out ObjectNode? type) {
+        return TryGetTypeNode(_root, path, out type) ||
+               (_dmStandardRoot != null && TryGetTypeNode(_dmStandardRoot, path, out type));
+    }
+
+    private static bool TryGetTypeNode(ObjectNode root, DreamPath path, [NotNullWhen(true)] out ObjectNode? type) {
+        var node = root;
+
+        foreach (var element in path.Elements) {
+            if (!node.TryGetChild(element, out var child) || child is not ObjectNode objectNode) {
+                type = null;
+                return false;
+            }
+
+            node = objectNode;
+        }
+
+        type = node;
+        return true;
     }
 
     private IEnumerable<INode> TraverseNodes(TypeNode from) {


### PR DESCRIPTION
BYOND makes no distinction between the path of a type and the path of a proc override, since an override is written without a "proc" keyword. Declaring /datum/test/beep and then defining /datum/test/beep() is a duplicate definition there, while OpenDream happily accepted both.

Verified against BYOND 516.1685 that this only applies to the override form and only when the type comes first: "/datum/test/proc/beep()" next to a "/datum/test/beep" type compiles either way, and so does an override followed by the type declaration.

Tests/Procs/final_proc2.dm had this exact conflict and does not compile in BYOND, so its procs named "final" are moved above the point where /datum/test/final becomes a type.

Fixes #2648