### PR TITLE
`image()` requires at least 1 arg

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/image_no_args.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/image_no_args.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR OD0013
+
+/proc/RunTest()
+	return image() // requires 1+ args

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2755,6 +2755,14 @@ namespace DMCompiler.Compiler.DM {
 
                         return new DMASTRgb(identifier.Location, callParameters);
                     }
+                    case "image": {
+                        if (callParameters.Length < 1)
+                            Emit(WarningCode.InvalidArgumentCount, callLoc,
+                                "Expected at least 1 argument for image()");
+
+                        return new DMASTProcCall(callLoc,
+                            new DMASTCallableProcIdentifier(callLoc, identifier.Identifier), callParameters);
+                    }
                     case "animate": {
                         if (callParameters.Length is < 1)
                             Emit(WarningCode.InvalidArgumentCount, callLoc,

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2760,8 +2760,7 @@ namespace DMCompiler.Compiler.DM {
                             Emit(WarningCode.InvalidArgumentCount, callLoc,
                                 "Expected at least 1 argument for image()");
 
-                        return new DMASTProcCall(callLoc,
-                            new DMASTCallableProcIdentifier(callLoc, identifier.Identifier), callParameters);
+                        goto default;
                     }
                     case "animate": {
                         if (callParameters.Length is < 1)


### PR DESCRIPTION
BYOND errors on zero-arg `image()`. I checked to see if there was an upper limit past the ref's 5 args but it took 8 args just fine.