### PR TITLE
Fix render order

### DIFF
--- a/OpenDreamClient/Rendering/RendererMetaData.cs
+++ b/OpenDreamClient/Rendering/RendererMetaData.cs
@@ -130,13 +130,6 @@ internal sealed class RendererMetaData : IComparable<RendererMetaData> {
             }
         }
 
-        // All else being the same, group them by icon.
-        // This allows Clyde to batch the draw calls more efficiently.
-        val = (MainIcon?.Appearance?.Icon ?? 0) - (other.MainIcon?.Appearance?.Icon ?? 0);
-        if (val != 0) {
-            return val;
-        }
-
         return TieBreaker.CompareTo(other.TieBreaker);
     }
 }


### PR DESCRIPTION
The order that appearances (such as overlays) are created matters for render order, so batching renders by texture is unfortunately not a valid optimization.

I lost ~6 fps, from 40 down to 34, observing /tg/ on my laptop. We can find other ways to make it up somewhere.

Fixes #2667
Fixes #2577
Fixes #2578