### PR TITLE
Implement CHILD's `show-splitter` and remove minimum 10% split

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -30,6 +30,7 @@ internal sealed class ControlChild(ControlDescriptor controlDescriptor, ControlW
 
         _splitter.Left = newLeftElement;
         _splitter.Right = newRightElement;
+        _splitter.ShowSplitter = ChildDescriptor.ShowSplitter.Value;
         _splitter.Vertical = ChildDescriptor.IsVert.Value;
         _splitter.SplitterPercentage = ChildDescriptor.Splitter.Value / 100f;
         _splitter.DragStyleBoxOverride = new StyleBoxColoredTexture {

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -31,6 +31,7 @@ public abstract class InterfaceControl : InterfaceElement {
 
         Window = window;
         UIElement = CreateUIElement();
+        UIElement.Name = ElementDescriptor.Id.AsRaw();
 
         SetProperty("size", ControlDescriptor.Size.AsRaw());
         SetProperty("pos", ControlDescriptor.Pos.AsRaw());

--- a/OpenDreamClient/Interface/Controls/UI/Splitter.cs
+++ b/OpenDreamClient/Interface/Controls/UI/Splitter.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Client.Graphics;
+﻿using JetBrains.Annotations;
+using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
@@ -10,11 +11,21 @@ namespace OpenDreamClient.Interface.Controls.UI;
 /// Equivalent to BYOND's CHILD control.
 /// </summary>
 /// <remarks>Do not add children directly! Use <see cref="Left"/> and <see cref="Right"/>.</remarks>
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 public sealed class Splitter : Container {
-    public float SplitterWidth {
-        get => _splitterWidth;
+    public bool ShowSplitter {
+        get;
         set {
-            _splitterWidth = value;
+            field = value;
+            _drag.Visible = field;
+            InvalidateMeasure();
+        }
+    }
+
+    public float SplitterWidth {
+        get;
+        set {
+            field = value;
             InvalidateMeasure();
         }
     }
@@ -54,17 +65,17 @@ public sealed class Splitter : Container {
     }
 
     public float SplitterPercentage {
-        get => _splitterPercentage;
+        get;
         set {
-            _splitterPercentage = Math.Clamp(value, 0.1f, 0.9f);
+            field = value;
             InvalidateMeasure();
         }
-    }
+    } = 0.5f;
 
     public bool Vertical {
-        get => _vertical;
+        get;
         set {
-            _vertical = value;
+            field = value;
             _drag.DefaultCursorShape = value ? CursorShape.HResize : CursorShape.VResize;
             InvalidateMeasure();
         }
@@ -77,9 +88,6 @@ public sealed class Splitter : Container {
 
     private readonly DragControl _drag = new();
 
-    private float _splitterWidth = 5f;
-    private float _splitterPercentage = 0.5f;
-    private bool _vertical;
     private bool _dragging;
     private Control? _left, _right;
 
@@ -141,6 +149,8 @@ public sealed class Splitter : Container {
     }
 
     private (UIBox2 LeftBox, UIBox2 DragBox, UIBox2 RightBox) CalculateSpace(Vector2 available) {
+        var splitterWidth = ShowSplitter ? SplitterWidth : 0f;
+
         if (_left != null && _right == null)
             return (UIBox2.FromDimensions(Vector2.Zero, available), default, default);
         if (_left == null && _right != null)
@@ -149,20 +159,22 @@ public sealed class Splitter : Container {
             return (default, default, default);
 
         var leftSize = Vertical
-            ? available with { X = available.X * SplitterPercentage - SplitterWidth/2 }
-            : available with { Y = available.Y * SplitterPercentage - SplitterWidth/2 };
+            ? available with { X = available.X * SplitterPercentage - splitterWidth/2 }
+            : available with { Y = available.Y * SplitterPercentage - splitterWidth/2 };
         var rightSize = Vertical
-            ? available with { X = available.X * (1f - SplitterPercentage) - SplitterWidth/2 }
-            : available with { Y = available.Y * (1f - SplitterPercentage) - SplitterWidth/2 };
-        var dragSize = Vertical
-            ? available with { X = SplitterWidth }
-            : available with { Y = SplitterWidth };
+            ? available with { X = available.X * (1f - SplitterPercentage) - splitterWidth/2 }
+            : available with { Y = available.Y * (1f - SplitterPercentage) - splitterWidth/2 };
+        var dragSize = ShowSplitter
+            ? Vertical
+                ? available with { X = splitterWidth }
+                : available with { Y = splitterWidth }
+            : Vector2.Zero;
         var dragPos = Vertical
             ? leftSize with { Y = 0f }
             : leftSize with { X = 0f };
         var rightPos = Vertical
-            ? new Vector2(leftSize.X + SplitterWidth, 0f)
-            : new Vector2(0f, leftSize.Y + SplitterWidth);
+            ? new Vector2(leftSize.X + splitterWidth, 0f)
+            : new Vector2(0f, leftSize.Y + splitterWidth);
 
         return (
             UIBox2.FromDimensions(Vector2.Zero, leftSize),

--- a/OpenDreamClient/OpenDreamClient.csproj
+++ b/OpenDreamClient/OpenDreamClient.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Work around https://github.com/dotnet/project-system/issues/4314 -->
     <TargetFramework>$(TargetFramework)</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>..\bin\Content.Client\</OutputPath>


### PR DESCRIPTION
Fixes some problems with the CHILD control that are apparent on newest /tg/.

Before (with the workaround mentioned in #2691):
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/70ccd5e3-9e45-44a6-bfa1-8a51212ea529" />
After:
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/ac5c6326-f69d-47c4-92ca-c89a8a1f4e8c" />