### PR TITLE
Add shared DMException for DM runtime errors

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -11,7 +11,6 @@ using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using Robust.Shared.Map;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
-using OpenDreamShared;
 namespace OpenDreamRuntime;
 
 public sealed partial class AtomManager {
@@ -330,12 +329,12 @@ public sealed partial class AtomManager {
                 value.TryGetValueAsInteger(out appearance.MouseOverPointer);
                 break;
             case "appearance":
-                throw new DMException("Cannot assign the appearance var on an appearance");
+                throw new Exception("Cannot assign the appearance var on an appearance");
 
             // These should be handled by the DreamObject if being accessed through that
             case "overlays":
             case "underlays":
-                throw new DMException($"Cannot assign the {varName} var on an appearance");
+                throw new Exception($"Cannot assign the {varName} var on an appearance");
 
             // TODO: filters
             //       It's handled separately by whatever is calling SetAppearanceVar currently
@@ -483,7 +482,7 @@ public sealed partial class AtomManager {
             DreamObjectTurf turf => turf.Appearance,
             DreamObjectMovable movable => movable.SpriteComponent.Appearance!,
             DreamObjectImage image => image.IsMutableAppearance ? AppearanceSystem!.AddAppearance(image.MutableAppearance!, registerAppearance: false) : image.SpriteComponent!.Appearance!,
-            _ => throw new DMException($"Cannot get appearance of {atom}")
+            _ => throw new Exception($"Cannot get appearance of {atom}")
         };
     }
 
@@ -764,7 +763,6 @@ public sealed partial class AtomManager {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static (int X, int Y, int) ThrowCantGetPosition(DreamObjectAtom atom) {
-        throw new DMException($"Cannot get the position of {atom}");
+        throw new Exception($"Cannot get the position of {atom}");
     }
 }
-

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using OpenDreamRuntime.Map;
@@ -11,7 +11,7 @@ using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using Robust.Shared.Map;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
-
+using OpenDreamShared;
 namespace OpenDreamRuntime;
 
 public sealed partial class AtomManager {
@@ -330,12 +330,12 @@ public sealed partial class AtomManager {
                 value.TryGetValueAsInteger(out appearance.MouseOverPointer);
                 break;
             case "appearance":
-                throw new Exception("Cannot assign the appearance var on an appearance");
+                throw new DMException("Cannot assign the appearance var on an appearance");
 
             // These should be handled by the DreamObject if being accessed through that
             case "overlays":
             case "underlays":
-                throw new Exception($"Cannot assign the {varName} var on an appearance");
+                throw new DMException($"Cannot assign the {varName} var on an appearance");
 
             // TODO: filters
             //       It's handled separately by whatever is calling SetAppearanceVar currently
@@ -483,7 +483,7 @@ public sealed partial class AtomManager {
             DreamObjectTurf turf => turf.Appearance,
             DreamObjectMovable movable => movable.SpriteComponent.Appearance!,
             DreamObjectImage image => image.IsMutableAppearance ? AppearanceSystem!.AddAppearance(image.MutableAppearance!, registerAppearance: false) : image.SpriteComponent!.Appearance!,
-            _ => throw new Exception($"Cannot get appearance of {atom}")
+            _ => throw new DMException($"Cannot get appearance of {atom}")
         };
     }
 
@@ -764,6 +764,7 @@ public sealed partial class AtomManager {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static (int X, int Y, int) ThrowCantGetPosition(DreamObjectAtom atom) {
-        throw new Exception($"Cannot get the position of {atom}");
+        throw new DMException($"Cannot get the position of {atom}");
     }
 }
+

--- a/OpenDreamRuntime/DMException.cs
+++ b/OpenDreamRuntime/DMException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace OpenDreamRuntime;
+
+/// <summary>
+/// Represents an error caused by invalid DM code execution.
+/// Unlike regular <see cref="Exception"/> instances, this exception is handled
+/// as a runtime error originating from DM code.
+/// </summary>
+public sealed class DMException : Exception {
+    public DMException(string message) : base(message) { }
+}

--- a/OpenDreamRuntime/DMException.cs
+++ b/OpenDreamRuntime/DMException.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenDreamRuntime;
 
 /// <summary>
@@ -7,6 +5,4 @@ namespace OpenDreamRuntime;
 /// Unlike regular <see cref="Exception"/> instances, this exception is handled
 /// as a runtime error originating from DM code.
 /// </summary>
-public sealed class DMException : Exception {
-    public DMException(string message) : base(message) { }
-}
+public sealed class DMException(string message) : Exception(message);

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -8,7 +8,7 @@ using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamShared.Dream;
-
+using OpenDreamShared;
 namespace OpenDreamRuntime {
     public enum ProcStatus {
         Continue,
@@ -91,7 +91,7 @@ namespace OpenDreamRuntime {
                     Logger.GetSawmill("opendream.dmproc").Warning("The 'hidden' field on verbs will always return null.");
                     return DreamValue.Null;
                 default:
-                    throw new Exception($"Cannot get field \"{field}\" from {OwningType}.{Name}()");
+                    throw new DMException($"Cannot get field \"{field}\" from {OwningType}.{Name}()");
             }
         }
 
@@ -493,9 +493,17 @@ namespace OpenDreamRuntime {
             AppendStackTrace(ErrorMessageBuilder);
             ErrorMessageBuilder.AppendLine();
 
-            ErrorMessageBuilder.AppendLine("=C# StackTrace=");
-            ErrorMessageBuilder.AppendLine(exception.ToString());
-            ErrorMessageBuilder.AppendLine();
+            #if DEBUG
+                    ErrorMessageBuilder.AppendLine("=C# StackTrace=");
+                    ErrorMessageBuilder.AppendLine(exception.ToString());
+                    ErrorMessageBuilder.AppendLine();
+            #else
+                    if (exception is not DMException) {
+                        ErrorMessageBuilder.AppendLine("=C# StackTrace=");
+                        ErrorMessageBuilder.AppendLine(exception.ToString());
+                        ErrorMessageBuilder.AppendLine();
+                    }
+            #endif
 
             var msg = ErrorMessageBuilder.ToString();
 
@@ -545,3 +553,4 @@ namespace OpenDreamRuntime {
         }
     }
 }
+

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -8,7 +8,7 @@ using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamShared.Dream;
-using OpenDreamShared;
+
 namespace OpenDreamRuntime {
     public enum ProcStatus {
         Continue,
@@ -553,4 +553,3 @@ namespace OpenDreamRuntime {
         }
     }
 }
-

--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -13,7 +13,6 @@ using Color = Robust.Shared.Maths.Color;
 using ParsedDMIDescription = OpenDreamShared.Resources.DMIParser.ParsedDMIDescription;
 using ParsedDMIState = OpenDreamShared.Resources.DMIParser.ParsedDMIState;
 using ParsedDMIFrame = OpenDreamShared.Resources.DMIParser.ParsedDMIFrame;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects;
 

--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using OpenDreamRuntime.Resources;
@@ -13,6 +13,7 @@ using Color = Robust.Shared.Maths.Color;
 using ParsedDMIDescription = OpenDreamShared.Resources.DMIParser.ParsedDMIDescription;
 using ParsedDMIState = OpenDreamShared.Resources.DMIParser.ParsedDMIState;
 using ParsedDMIFrame = OpenDreamShared.Resources.DMIParser.ParsedDMIFrame;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects;
 
@@ -405,7 +406,7 @@ public sealed class DreamIconOperationBlendImage : DreamIconOperationBlend {
         var resourceManager = IoCManager.Resolve<DreamResourceManager>();
 
         if (!resourceManager.TryLoadIcon(blending, out var blendingIcon)) {
-            throw new Exception($"Value {blending} is not a valid icon to blend");
+            throw new DMException($"Value {blending} is not a valid icon to blend");
         }
 
         _blending = blendingIcon.Texture;

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using OpenDreamRuntime.Procs;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -14,6 +14,7 @@ using Robust.Server.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects;
 
@@ -244,7 +245,7 @@ public class DreamObject {
             case "type":
             case "parent_type":
             case "vars":
-                throw new Exception($"Cannot set var \"{varName}\"");
+                throw new DMException($"Cannot set var \"{varName}\"");
             case "tag":
                 value.TryGetValueAsString(out var newTag);
 
@@ -252,9 +253,9 @@ public class DreamObject {
                 break;
             default:
                 if (ObjectDefinition.ConstVariables is not null && ObjectDefinition.ConstVariables.Contains(varName))
-                    throw new Exception($"Cannot set const var \"{varName}\" on {ObjectDefinition.Type}");
+                    throw new DMException($"Cannot set const var \"{varName}\" on {ObjectDefinition.Type}");
                 if (!ObjectDefinition.Variables.ContainsKey(varName))
-                    throw new Exception($"Cannot set var \"{varName}\" on {ObjectDefinition.Type}");
+                    throw new DMException($"Cannot set var \"{varName}\" on {ObjectDefinition.Type}");
 
                 SetVariableValue(varName, value);
                 break;

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -14,7 +14,6 @@ using Robust.Server.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects;
 

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Procs;
@@ -9,6 +9,7 @@ using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects;
 
@@ -153,7 +154,7 @@ public sealed class DreamObjectDefinition {
         if (TryGetProc(procName, out DreamProc? proc)) {
             return proc;
         } else {
-            throw new Exception("Object type '" + Type + "' does not have a proc named '" + procName + "'");
+            throw new DMException("Object type '" + Type + "' does not have a proc named '" + procName + "'");
         }
     }
 

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -9,7 +9,6 @@ using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects;
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -18,7 +18,6 @@ using Robust.Shared.Serialization.Manager.Exceptions;
 using Robust.Shared.Utility;
 using MethodImplAttribute = System.Runtime.CompilerServices.MethodImplAttribute;
 using MethodImplOptions = System.Runtime.CompilerServices.MethodImplOptions;
-using OpenDreamShared;
 
 
 namespace OpenDreamRuntime.Objects;

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -18,6 +18,8 @@ using Robust.Shared.Serialization.Manager.Exceptions;
 using Robust.Shared.Utility;
 using MethodImplAttribute = System.Runtime.CompilerServices.MethodImplAttribute;
 using MethodImplOptions = System.Runtime.CompilerServices.MethodImplOptions;
+using OpenDreamShared;
+
 
 namespace OpenDreamRuntime.Objects;
 
@@ -107,7 +109,7 @@ public sealed partial class DreamObjectTree {
 
     public TreeEntry GetTreeEntry(string path) {
         if (!_pathToType.TryGetValue(path, out TreeEntry? type)) {
-            throw new Exception($"Object '{path}' does not exist");
+            throw new DMException($"Object '{path}' does not exist");
         }
 
         return type;
@@ -184,9 +186,9 @@ public sealed partial class DreamObjectTree {
         if (type.ObjectDefinition.IsSubtypeOf(Particles))
             return new DreamObjectParticles(type.ObjectDefinition);
         if (type.ObjectDefinition.IsSubtypeOf(Client))
-            throw new Exception("Cannot create objects of type /client");
+            throw new DMException("Cannot create objects of type /client");
         if (type.ObjectDefinition.IsSubtypeOf(Turf))
-            throw new Exception("New turfs must be created by the map manager");
+            throw new DMException("New turfs must be created by the map manager");
         if (type.ObjectDefinition.IsSubtypeOf(Exception))
             return new DreamObjectException(type.ObjectDefinition);
         if (type.ObjectDefinition.IsSubtypeOf(Callee))

--- a/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using JetBrains.Annotations;
 using OpenDreamRuntime.Procs;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -62,11 +63,11 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
 
     public void Cut(int start = 1, int end = 0) {
         if (start != 1 && start != 0) {
-            throw new Exception($"Cut() was called with non-default start value of {start}.");
+            throw new DMException($"Cut() was called with non-default start value of {start}.");
         }
 
         if (end != 0) {
-            throw new Exception($"Cut() was called with non-default end value of {end}.");
+            throw new DMException($"Cut() was called with non-default end value of {end}.");
         }
 
         foreach (var value in _values) {
@@ -116,7 +117,7 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
 
     public IDreamList CreateCopy(int start = 1, int end = 0) {
         if (start != 1 || end != 0) {
-            throw new Exception("list index out of bounds");
+            throw new DMException("list index out of bounds");
         }
 
         var copyValues = new Dictionary<DreamValue, DreamValue>(_values);
@@ -150,7 +151,7 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
         if (varName == "len") {
             // Non-nums become 0 which is parity w/ BYOND
             if (value.TryGetValueAsInteger(out var newLen) && newLen != 0) {
-                throw new Exception("length of strict associative list can only be set to 0");
+                throw new DMException("length of strict associative list can only be set to 0");
             }
 
             // alists specifically will always either runtime or get set to 0 and cut
@@ -161,11 +162,11 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
     }
 
     public void Insert(int index, DreamValue value) {
-        throw new Exception("insert not allowed for this list");
+        throw new DMException("insert not allowed for this list");
     }
 
     public void Swap(int index1, int index2) {
-        throw new Exception("swap not allowed for this list");
+        throw new DMException("swap not allowed for this list");
     }
 
     public bool ContainsValue(DreamValue value) {
@@ -302,5 +303,3 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
         return DreamValue.True;
     }
 }
-
-

--- a/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using JetBrains.Annotations;
 using OpenDreamRuntime.Procs;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -8,7 +8,7 @@ using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Server.GameStates;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
-
+using OpenDreamShared;
 namespace OpenDreamRuntime.Objects.Types;
 
 [Virtual]
@@ -114,7 +114,7 @@ public class DreamList : DreamObject, IDreamList {
         if (start == 0) ++start; //start being 0 and start being 1 are equivalent
 
         var values = GetValues();
-        if (end > values.Count + 1 || start > values.Count + 1) throw new Exception("list index out of bounds");
+        if (end > values.Count + 1 || start > values.Count + 1) throw new DMException("list index out of bounds");
         if (end == 0) end = values.Count + 1;
         if (end <= start)
             return new DreamList(ObjectDefinition, 0);
@@ -590,22 +590,22 @@ internal sealed class DreamListVars(DreamObjectDefinition listDef, DreamObject d
                 return objectVar;
             }
 
-            throw new Exception($"Cannot get value of undefined var \"{key}\" on type {DreamObject.ObjectDefinition.Type}");
+            throw new DMException($"Cannot get value of undefined var \"{key}\" on type {DreamObject.ObjectDefinition.Type}");
         } else {
-            throw new Exception($"Invalid var index {key}");
+            throw new DMException($"Invalid var index {key}");
         }
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         if (key.TryGetValueAsString(out var varName)) {
             if (!DreamObject.HasVariable(varName)) {
-                throw new Exception(
+                throw new DMException(
                     $"Cannot set value of undefined var \"{varName}\" on type {DreamObject.ObjectDefinition.Type}");
             }
 
             DreamObject.SetVariable(varName, value);
         } else {
-            throw new Exception($"Invalid var index {key}");
+            throw new DMException($"Invalid var index {key}");
         }
     }
 
@@ -649,12 +649,12 @@ internal sealed class DreamGlobalVars(DreamObjectDefinition listDef) : DreamList
 
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsString(out var varName)) {
-            throw new Exception($"Invalid var index {key}");
+            throw new DMException($"Invalid var index {key}");
         }
 
         var root = ObjectTree.Root.ObjectDefinition;
         if (!root.GlobalVariables.TryGetValue(varName, out var globalId)) {
-            throw new Exception($"Invalid global {varName}");
+            throw new DMException($"Invalid global {varName}");
         }
 
         var value = DreamManager.Globals[globalId];
@@ -666,12 +666,12 @@ internal sealed class DreamGlobalVars(DreamObjectDefinition listDef) : DreamList
         if (key.TryGetValueAsString(out var varName)) {
             var root = ObjectTree.Root.ObjectDefinition;
             if (!root.GlobalVariables.TryGetValue(varName, out var globalId)) {
-                throw new Exception($"Cannot set value of undefined global \"{varName}\"");
+                throw new DMException($"Cannot set value of undefined global \"{varName}\"");
             }
 
             DreamManager.SetGlobal(globalId, value);
         } else {
-            throw new Exception($"Invalid var index {key}");
+            throw new DMException($"Invalid var index {key}");
         }
     }
 
@@ -702,9 +702,9 @@ public sealed class ClientVerbsList : DreamList {
 
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into verbs list: {key}");
+            throw new DMException($"Invalid index into verbs list: {key}");
         if (index < 1 || index > Verbs.Count)
-            throw new Exception($"Out of bounds index on verbs list: {index}");
+            throw new DMException($"Out of bounds index on verbs list: {index}");
 
         return new DreamValue(Verbs[index - 1]);
     }
@@ -726,12 +726,12 @@ public sealed class ClientVerbsList : DreamList {
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot set the values of a verbs list");
+        throw new DMException("Cannot set the values of a verbs list");
     }
 
     public override void AddValue(DreamValue value) {
         if (!value.TryGetValueAsProc(out var verb))
-            throw new Exception($"Cannot add {value} to verbs list");
+            throw new DMException($"Cannot add {value} to verbs list");
         if (Verbs.Contains(verb))
             return; // Even += won't add the verb if it's already in this list
 
@@ -776,11 +776,11 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
         if (VerbSystem == null)
             return DreamValue.Null;
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into verbs list: {key}");
+            throw new DMException($"Invalid index into verbs list: {key}");
 
         var verbs = GetVerbs();
         if (index < 1 || index > verbs.Length)
-            throw new Exception($"Out of bounds index on verbs list: {index}");
+            throw new DMException($"Out of bounds index on verbs list: {index}");
 
         return new DreamValue(VerbSystem.GetVerb(verbs[index - 1]));
     }
@@ -811,12 +811,12 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot set the values of a verbs list");
+        throw new DMException("Cannot set the values of a verbs list");
     }
 
     public override void AddValue(DreamValue value) {
         if (!value.TryGetValueAsProc(out var verb))
-            throw new Exception($"Cannot add {value} to verbs list");
+            throw new DMException($"Cannot add {value} to verbs list");
 
         atomManager.UpdateAppearance(atom, appearance => {
             if (!verb.VerbId.HasValue)
@@ -859,7 +859,7 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
     private int[] GetVerbs() {
         var appearance = atomManager.MustGetAppearance(atom);
         if (appearance == null)
-            throw new Exception("Atom has no appearance");
+            throw new DMException("Atom has no appearance");
 
         return appearance.Verbs;
     }
@@ -897,12 +897,12 @@ public sealed class DreamOverlaysList(DreamObjectDefinition listDef, DreamObject
 
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var overlayIndex) || overlayIndex < 1)
-            throw new Exception($"Invalid index into {(isUnderlays ? "underlays" : "overlays")} list: {key}");
+            throw new DMException($"Invalid index into {(isUnderlays ? "underlays" : "overlays")} list: {key}");
 
         ImmutableAppearance appearance = AtomManager.MustGetAppearance(owner);
         var overlaysList = GetOverlaysArray(appearance);
         if (overlayIndex > overlaysList.Length)
-            throw new Exception($"Atom only has {overlaysList.Length} {(isUnderlays ? "underlay" : "overlay")}(s), cannot index {overlayIndex}");
+            throw new DMException($"Atom only has {overlaysList.Length} {(isUnderlays ? "underlay" : "overlay")}(s), cannot index {overlayIndex}");
 
         if (appearanceSystem == null)
             return DreamValue.Null;
@@ -912,7 +912,7 @@ public sealed class DreamOverlaysList(DreamObjectDefinition listDef, DreamObject
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception($"Cannot write to an index of an {(isUnderlays ? "underlays" : "overlays")} list");
+        throw new DMException($"Cannot write to an index of an {(isUnderlays ? "underlays" : "overlays")} list");
     }
 
     public override void AddValue(DreamValue value) {
@@ -1013,9 +1013,9 @@ public sealed class DreamVisContentsList : DreamList {
 
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var visContentsIndex) || visContentsIndex < 1)
-            throw new Exception($"Invalid index into vis_contents list: {key}");
+            throw new DMException($"Invalid index into vis_contents list: {key}");
         if (visContentsIndex > _visContents.Count)
-            throw new Exception($"Atom only has {_visContents.Count} vis_contents element(s), cannot index {visContentsIndex}");
+            throw new DMException($"Atom only has {_visContents.Count} vis_contents element(s), cannot index {visContentsIndex}");
 
         var value = _visContents[visContentsIndex - 1];
         value.IncRef();
@@ -1023,7 +1023,7 @@ public sealed class DreamVisContentsList : DreamList {
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot write to an index of a vis_contents list");
+        throw new DMException("Cannot write to an index of a vis_contents list");
     }
 
     public override void AddValue(DreamValue value) {
@@ -1041,7 +1041,7 @@ public sealed class DreamVisContentsList : DreamList {
         } else if (value == DreamValue.Null) {
             return; // vis_contents cannot contain nulls
         } else {
-            throw new Exception($"Cannot add {value} to a vis_contents list");
+            throw new DMException($"Cannot add {value} to a vis_contents list");
         }
 
         // TODO: Only override the entity's visibility if its parent atom is visible
@@ -1115,7 +1115,7 @@ public sealed class DreamFilterList(DreamObjectDefinition listDef, DreamObject o
     public void SetFilter(int index, DreamFilter? filter) {
         AtomManager.UpdateAppearance(owner, appearance => {
             if (index < 1 || index > appearance.Filters.Count)
-                throw new Exception($"Cannot index {index} on filter list");
+                throw new DMException($"Cannot index {index} on filter list");
 
             DreamFilter oldFilter = appearance.Filters[index - 1];
 
@@ -1142,7 +1142,7 @@ public sealed class DreamFilterList(DreamObjectDefinition listDef, DreamObject o
 
         ImmutableAppearance appearance = GetAppearance();
         if (filterIndex < 1 || filterIndex > appearance.Filters.Length)
-            throw new Exception($"Atom only has {appearance.Filters.Length} filter(s), cannot index {filterIndex}");
+            throw new DMException($"Atom only has {appearance.Filters.Length} filter(s), cannot index {filterIndex}");
 
         DreamObjectFilter filterObject = ObjectTree.CreateObject<DreamObjectFilter>(ObjectTree.Filter);
         filterObject.Filter = appearance.Filters[filterIndex - 1];
@@ -1167,9 +1167,9 @@ public sealed class DreamFilterList(DreamObjectDefinition listDef, DreamObject o
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         if (!value.TryGetValueAsDreamObject<DreamObjectFilter>(out var filterObject) && !value.IsNull)
-            throw new Exception($"Cannot set value of filter list to {value}");
+            throw new DMException($"Cannot set value of filter list to {value}");
         if (!key.TryGetValueAsInteger(out var filterIndex) || filterIndex < 1)
-            throw new Exception($"Invalid index into filter list: {key}");
+            throw new DMException($"Invalid index into filter list: {key}");
 
         SetFilter(filterIndex, filterObject?.Filter);
     }
@@ -1178,7 +1178,7 @@ public sealed class DreamFilterList(DreamObjectDefinition listDef, DreamObject o
         if (value.IsNull) // "filters += null" is just ignored
             return;
         if (!value.TryGetValueAsDreamObject<DreamObjectFilter>(out var filterObject))
-            throw new Exception($"Cannot add {value} to filter list");
+            throw new DMException($"Cannot add {value} to filter list");
 
         //This is dynamic to prevent the compiler from optimising the SerializationManager.CreateCopy() call to the DreamFilter type
         //so we can preserve the subclass information. Setting it to DreamFilter instead will cause filter parameters to stop working.
@@ -1219,7 +1219,7 @@ public sealed class DreamFilterList(DreamObjectDefinition listDef, DreamObject o
     private ImmutableAppearance GetAppearance() {
         ImmutableAppearance? appearance = AtomManager.MustGetAppearance(owner);
         if (appearance == null)
-            throw new Exception("Atom has no appearance");
+            throw new DMException("Atom has no appearance");
 
         return appearance;
     }
@@ -1241,7 +1241,7 @@ public sealed class ClientScreenList(DreamObjectTree objectTree, ServerScreenOve
 
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var screenIndex) || screenIndex < 1 || screenIndex > _screenObjects.Count)
-            throw new Exception($"Invalid index into screen list: {key}");
+            throw new DMException($"Invalid index into screen list: {key}");
 
         var value = _screenObjects[screenIndex - 1];
         value.IncRef();
@@ -1257,7 +1257,7 @@ public sealed class ClientScreenList(DreamObjectTree objectTree, ServerScreenOve
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot write to an index of a screen list");
+        throw new DMException("Cannot write to an index of a screen list");
     }
 
     public override void AddValue(DreamValue value) {
@@ -1307,7 +1307,7 @@ public sealed class ClientImagesList(DreamObjectTree objectTree, ServerClientIma
 
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var imageIndex) || imageIndex < 1 || imageIndex > _imageObjects.Count)
-            throw new Exception($"Invalid index into client images list: {key}");
+            throw new DMException($"Invalid index into client images list: {key}");
 
         var value = _imageObjects[imageIndex - 1];
         value.IncRef();
@@ -1323,7 +1323,7 @@ public sealed class ClientImagesList(DreamObjectTree objectTree, ServerClientIma
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot write to an index of a client images list");
+        throw new DMException("Cannot write to an index of a client images list");
     }
 
     public override void AddValue(DreamValue value) {
@@ -1371,9 +1371,9 @@ public sealed class ClientImagesList(DreamObjectTree objectTree, ServerClientIma
 public sealed class WorldContentsList(DreamObjectDefinition listDef, AtomManager atomManager) : DreamList(listDef, 0) {
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into world contents list: {key}");
+            throw new DMException($"Invalid index into world contents list: {key}");
         if (index < 1 || index > atomManager.AtomCount)
-            throw new Exception($"Out of bounds index on world contents list: {index}");
+            throw new DMException($"Out of bounds index on world contents list: {index}");
 
         var element = atomManager.EnumerateAtoms().ElementAt(index - 1); // Ouch
         element.IncRef();
@@ -1389,15 +1389,15 @@ public sealed class WorldContentsList(DreamObjectDefinition listDef, AtomManager
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot set the value of world contents list");
+        throw new DMException("Cannot set the value of world contents list");
     }
 
     public override void AddValue(DreamValue value) {
-        throw new Exception("Cannot append to world contents list");
+        throw new DMException("Cannot append to world contents list");
     }
 
     public override void Cut(int start = 1, int end = 0) {
-        throw new Exception("Cannot cut world contents list");
+        throw new DMException("Cannot cut world contents list");
     }
 
     public override int GetLength() {
@@ -1421,9 +1421,9 @@ public sealed class TurfContentsList(DreamObjectDefinition listDef, DreamObjectT
 
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into turf contents list: {key}");
+            throw new DMException($"Invalid index into turf contents list: {key}");
         if (index < 1 || index > Cell.Movables.Count)
-            throw new Exception($"Out of bounds index on turf contents list: {index}");
+            throw new DMException($"Out of bounds index on turf contents list: {index}");
 
         var value = Cell.Movables[index - 1];
         value.IncRef();
@@ -1440,12 +1440,12 @@ public sealed class TurfContentsList(DreamObjectDefinition listDef, DreamObjectT
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot set an index of turf contents list");
+        throw new DMException("Cannot set an index of turf contents list");
     }
 
     public override void AddValue(DreamValue value) {
         if (!value.TryGetValueAsDreamObject<DreamObjectMovable>(out var movable))
-            throw new Exception($"Cannot add {value} to turf contents");
+            throw new DMException($"Cannot add {value} to turf contents");
 
         movable.SetLoc(Cell.Turf);
     }
@@ -1479,7 +1479,7 @@ public sealed class TurfContentsList(DreamObjectDefinition listDef, DreamObjectT
 public sealed class AreaContentsList(DreamObjectDefinition listDef, DreamObjectArea area) : DreamList(listDef, 0) {
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into area contents list: {key}");
+            throw new DMException($"Invalid index into area contents list: {key}");
 
         foreach (var turf in area.Turfs) {
             if (index < 1)
@@ -1501,7 +1501,7 @@ public sealed class AreaContentsList(DreamObjectDefinition listDef, DreamObjectA
             index -= contentsLength;
         }
 
-        throw new Exception($"Out of bounds index on turf contents list: {key}");
+        throw new DMException($"Out of bounds index on turf contents list: {key}");
     }
 
     public override List<DreamValue> GetValues() {
@@ -1518,19 +1518,19 @@ public sealed class AreaContentsList(DreamObjectDefinition listDef, DreamObjectA
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot set an index of area contents list");
+        throw new DMException("Cannot set an index of area contents list");
     }
 
     public override void AddValue(DreamValue value) {
         if (!value.TryGetValueAsDreamObject<DreamObjectTurf>(out var turf))
-            throw new Exception($"Cannot add {value} to area contents");
+            throw new DMException($"Cannot add {value} to area contents");
 
         turf.Cell.Area = area;
     }
 
     public override void RemoveValue(DreamValue value) {
         if (!value.TryGetValueAsDreamObject<DreamObjectTurf>(out var turf))
-            throw new Exception($"Cannot remove {value} from area contents");
+            throw new DMException($"Cannot remove {value} from area contents");
 
         turf.Cell.Area = DreamMapManager.DefaultArea;
     }
@@ -1571,9 +1571,9 @@ public sealed class AreaContentsList(DreamObjectDefinition listDef, DreamObjectA
 public sealed class MovableContentsList(DreamObjectDefinition listDef, DreamObjectMovable owner, TransformComponent transform) : DreamList(listDef, 0) {
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into movable contents list: {key}");
+            throw new DMException($"Invalid index into movable contents list: {key}");
         if (index < 1 || index > transform.ChildCount)
-            throw new Exception($"Out of bounds index on movable contents list: {index}");
+            throw new DMException($"Out of bounds index on movable contents list: {index}");
 
         using var childEnumerator = transform.ChildEnumerator;
         while (index >= 1) {
@@ -1584,13 +1584,13 @@ public sealed class MovableContentsList(DreamObjectDefinition listDef, DreamObje
                     childObject.IncRef();
                     return new DreamValue(childObject);
                 } else
-                    throw new Exception($"Invalid child in movable contents list: {child}");
+                    throw new DMException($"Invalid child in movable contents list: {child}");
             }
 
             index--;
         }
 
-        throw new Exception($"Out of bounds index on movable contents list after iterating: {key}");
+        throw new DMException($"Out of bounds index on movable contents list after iterating: {key}");
     }
 
     public override List<DreamValue> GetValues() {
@@ -1628,19 +1628,19 @@ public sealed class MovableContentsList(DreamObjectDefinition listDef, DreamObje
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-        throw new Exception("Cannot set an index of movable contents list");
+        throw new DMException("Cannot set an index of movable contents list");
     }
 
     public override void AddValue(DreamValue value) {
         if (!value.TryGetValueAsDreamObject<DreamObjectMovable>(out var dreamObject))
-            throw new Exception($"Cannot add {value} to movable contents");
+            throw new DMException($"Cannot add {value} to movable contents");
 
         dreamObject.SetLoc(owner);
     }
 
     public override void RemoveValue(DreamValue value) {
         if (!value.TryGetValueAsDreamObject<DreamObjectMovable>(out var movable))
-            throw new Exception($"Cannot remove {value} from movable contents");
+            throw new DMException($"Cannot remove {value} from movable contents");
         if (movable.Loc != owner)
             return; // This object wasn't in our contents to begin with
 
@@ -1667,9 +1667,9 @@ public sealed class MovableContentsList(DreamObjectDefinition listDef, DreamObje
 internal sealed class ProcArgsList(DreamObjectDefinition listDef, ProcState state) : DreamList(listDef, 0) {
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into args list: {key}");
+            throw new DMException($"Invalid index into args list: {key}");
         if (index < 1 || index > state.ArgumentCount)
-            throw new Exception($"Out of bounds index on args list: {index}");
+            throw new DMException($"Out of bounds index on args list: {index}");
 
         var value = state.GetArguments()[index - 1];
         value.IncRef();
@@ -1687,23 +1687,23 @@ internal sealed class ProcArgsList(DreamObjectDefinition listDef, ProcState stat
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index into args list: {key}");
+            throw new DMException($"Invalid index into args list: {key}");
         if (index < 1 || index > state.ArgumentCount)
-            throw new Exception($"Out of bounds index on args list: {index}");
+            throw new DMException($"Out of bounds index on args list: {index}");
 
         state.SetArgument(index - 1, value);
     }
 
     public override void AddValue(DreamValue value) {
-        throw new Exception("Cannot add new values to args list");
+        throw new DMException("Cannot add new values to args list");
     }
 
     public override void RemoveValue(DreamValue value) {
-        throw new Exception("Cannot remove values to args list");
+        throw new DMException("Cannot remove values to args list");
     }
 
     public override void Cut(int start = 1, int end = 0) {
-        throw new Exception("Cannot cut args list");
+        throw new DMException("Cannot cut args list");
     }
 
     public override int GetLength() {
@@ -1719,9 +1719,9 @@ internal sealed class ProcArgsList(DreamObjectDefinition listDef, ProcState stat
 public sealed class SavefileDirList(DreamObjectDefinition listDef, DreamObjectSavefile backedSaveFile) : DreamList(listDef, 0) {
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index on savefile dir list: {key}");
+            throw new DMException($"Invalid index on savefile dir list: {key}");
         if (index < 1 || index > backedSaveFile.CurrentDir.Count)
-            throw new Exception($"Out of bounds index on savefile dir list: {index}");
+            throw new DMException($"Out of bounds index on savefile dir list: {index}");
         return new DreamValue(backedSaveFile.CurrentDir.Keys.ElementAt(index - 1));
     }
 
@@ -1740,29 +1740,29 @@ public sealed class SavefileDirList(DreamObjectDefinition listDef, DreamObjectSa
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         if (!key.TryGetValueAsInteger(out var index))
-            throw new Exception($"Invalid index on savefile dir list: {key}");
+            throw new DMException($"Invalid index on savefile dir list: {key}");
         if (!value.TryGetValueAsString(out var valueStr))
-            throw new Exception($"Invalid value on savefile dir name: {value}");
+            throw new DMException($"Invalid value on savefile dir name: {value}");
         if (index < 1 || index > backedSaveFile.CurrentDir.Count)
-            throw new Exception($"Out of bounds index on savefile dir list: {index}");
+            throw new DMException($"Out of bounds index on savefile dir list: {index}");
 
         backedSaveFile.RenameSavefileValue(backedSaveFile.CurrentDir.Keys.ElementAt(index - 1), valueStr);
     }
 
     public override void AddValue(DreamValue value) {
         if (!value.TryGetValueAsString(out var valueStr))
-            throw new Exception($"Invalid value on savefile dir name: {value}");
+            throw new DMException($"Invalid value on savefile dir name: {value}");
         backedSaveFile.AddSavefileDir(valueStr);
     }
 
     public override void RemoveValue(DreamValue value) {
         if (!value.TryGetValueAsString(out var valueStr))
-            throw new Exception($"Invalid value on savefile dir name: {value}");
+            throw new DMException($"Invalid value on savefile dir name: {value}");
         backedSaveFile.RemoveSavefileValue(valueStr);
     }
 
     public override void Cut(int start = 1, int end = 0) {
-        throw new Exception("Cannot cut savefile dir list"); //BYOND actually throws undefined proc for this
+        throw new DMException("Cannot cut savefile dir list"); //BYOND actually throws undefined proc for this
     }
 
     public override int GetLength() {
@@ -1773,3 +1773,4 @@ public sealed class SavefileDirList(DreamObjectDefinition listDef, DreamObjectSa
         throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
     }
 }
+

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -8,7 +8,6 @@ using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Server.GameStates;
 using Dependency = Robust.Shared.IoC.DependencyAttribute;
-using OpenDreamShared;
 namespace OpenDreamRuntime.Objects.Types;
 
 [Virtual]
@@ -1773,4 +1772,3 @@ public sealed class SavefileDirList(DreamObjectDefinition listDef, DreamObjectSa
         throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
     }
 }
-

--- a/OpenDreamRuntime/Objects/Types/DreamObjectArea.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectArea.cs
@@ -1,4 +1,5 @@
-﻿using OpenDreamShared.Dream;
+using OpenDreamShared.Dream;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -80,7 +81,7 @@ public sealed class DreamObjectArea : DreamObjectAtom {
             case "x":
             case "y":
             case "z":
-                throw new Exception($"Cannot set coordinate var '{varName}' on an area");
+                throw new DMException($"Cannot set coordinate var '{varName}' on an area");
             case "contents":
                 // TODO
                 break;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectArea.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectArea.cs
@@ -1,5 +1,4 @@
 using OpenDreamShared.Dream;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
@@ -1,6 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using DMCompiler.Bytecode;
 using OpenDreamRuntime.Procs;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -22,7 +23,7 @@ public sealed class DreamObjectCallee(DreamObjectDefinition objectDefinition) : 
     protected override bool TryGetVar(string varName, out DreamValue value) {
         // TODO: This ProcState check doesn't match byond behavior?
         if (Expired)
-            throw new Exception("This callee has expired");
+            throw new DMException("This callee has expired");
 
         switch (varName) {
             case "proc":
@@ -78,7 +79,7 @@ public sealed class DreamObjectCallee(DreamObjectDefinition objectDefinition) : 
     }
 
     protected override void SetVar(string varName, DreamValue value) {
-        throw new Exception($"Cannot set var {varName} on /callee");
+        throw new DMException($"Cannot set var {varName} on /callee");
     }
 
     public override string GetDisplayName(StringFormatEncoder.FormatSuffix? suffix = null) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectCallee.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using DMCompiler.Bytecode;
 using OpenDreamRuntime.Procs;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -1,9 +1,10 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Text;
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -133,7 +134,7 @@ public sealed class DreamObjectClient : DreamObject {
             case "eye": {
                 value.TryGetValueAsDreamObject<DreamObjectAtom>(out var newEye);
                 if (newEye is not (DreamObjectMovable or null)) {
-                    throw new Exception($"Cannot set eye to non-movable {value}"); // TODO: You can set it to a turf
+                    throw new DMException($"Cannot set eye to non-movable {value}"); // TODO: You can set it to a turf
                 }
 
                 newEye?.IncRef();

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -4,7 +4,6 @@ using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectGenerator.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectGenerator.cs
@@ -1,6 +1,5 @@
 using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
-using OpenDreamShared;
 
 
 namespace OpenDreamRuntime.Objects.Types;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectGenerator.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectGenerator.cs
@@ -1,5 +1,7 @@
 using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
+using OpenDreamShared;
+
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -9,7 +11,7 @@ public sealed class DreamObjectGenerator(DreamObjectDefinition objectDefinition)
     public override void Initialize(DreamProcArguments args) {
         var type = args.GetArgument(0);
         if (!type.TryGetValueAsString(out var typeStr))
-            throw new Exception($"Invalid generator type {type}");
+            throw new DMException($"Invalid generator type {type}");
 
         var a = args.GetArgument(1);
         var b = args.GetArgument(2);
@@ -69,7 +71,7 @@ public sealed class DreamObjectGenerator(DreamObjectDefinition objectDefinition)
                 }
             }
             default:
-                throw new Exception($"Invalid generator type {type}");
+                throw new DMException($"Invalid generator type {type}");
         }
     }
 
@@ -90,4 +92,3 @@ public sealed class DreamObjectGenerator(DreamObjectDefinition objectDefinition)
         };
     }
 }
-

--- a/OpenDreamRuntime/Objects/Types/DreamObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectIcon.cs
@@ -1,4 +1,5 @@
-﻿using OpenDreamRuntime.Procs;
+using OpenDreamRuntime.Procs;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -25,7 +26,7 @@ public sealed class DreamObjectIcon : DreamObject {
                 Icon.CopyFrom(iconObj.Icon);
             } else {
                 if (!DreamResourceManager.TryLoadIcon(icon, out var iconRsc))
-                    throw new Exception($"Cannot create an icon from {icon}");
+                    throw new DMException($"Cannot create an icon from {icon}");
 
                 Icon.InsertStates(iconRsc, state, dir, frame, isConstructor: true);
             }

--- a/OpenDreamRuntime/Objects/Types/DreamObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectIcon.cs
@@ -1,5 +1,4 @@
 using OpenDreamRuntime.Procs;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMovable.cs
@@ -2,6 +2,7 @@ using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Shared.Map;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -138,7 +139,7 @@ public class DreamObjectMovable : DreamObjectAtom {
             }
             case "loc": {
                 if (!value.TryGetValueAsDreamObject<DreamObjectAtom>(out var newLoc) && !value.IsNull)
-                    throw new Exception($"Invalid loc {value}");
+                    throw new DMException($"Invalid loc {value}");
 
                 SetLoc(newLoc);
                 break;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMovable.cs
@@ -2,7 +2,6 @@ using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Shared.Map;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
@@ -1,6 +1,7 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.RegularExpressions;
 using OpenDreamRuntime.Procs;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -76,7 +77,7 @@ public sealed class DreamObjectRegex(DreamObjectDefinition objectDefinition) : D
 
             Regex = new Regex(newPatternBuilder.ToString(), options);
         } else {
-            throw new Exception("Invalid regex pattern " + pattern);
+            throw new DMException("Invalid regex pattern " + pattern);
         }
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using OpenDreamRuntime.Procs;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -7,6 +7,7 @@ using DMCompiler;
 using JetBrains.Annotations;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Resources;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -155,7 +156,7 @@ public sealed class DreamObjectSavefile : DreamObject {
         switch (varName) {
             case "cd":
                 if (!value.TryGetValueAsString(out var cdTo))
-                    throw new Exception($"Cannot change directory to {value}");
+                    throw new DMException($"Cannot change directory to {value}");
 
                 CurrentPath = cdTo;
                 break;
@@ -185,20 +186,20 @@ public sealed class DreamObjectSavefile : DreamObject {
 
                 break;
             default:
-                throw new Exception($"Cannot set var \"{varName}\" on savefiles");
+                throw new DMException($"Cannot set var \"{varName}\" on savefiles");
         }
     }
 
     public override DreamValue OperatorIndex(DreamValue index, DMProcState state) {
         if (!index.TryGetValueAsString(out var entryName))
-            throw new Exception($"Invalid savefile index {index}");
+            throw new DMException($"Invalid savefile index {index}");
 
         return GetSavefileValue(entryName);
     }
 
     public override void OperatorIndexAssign(DreamValue index, DMProcState state, DreamValue value) {
         if (!index.TryGetValueAsString(out var entryName))
-            throw new Exception($"Invalid savefile index {index}");
+            throw new DMException($"Invalid savefile index {index}");
 
         if (entryName == ".") {
             SetSavefileValue(null, value);

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -7,7 +7,6 @@ using DMCompiler;
 using JetBrains.Annotations;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Resources;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
@@ -1,6 +1,7 @@
-﻿using OpenDreamRuntime.Map;
+using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -30,7 +31,7 @@ public sealed class DreamObjectTurf : DreamObjectAtom {
 
     public void SetTurfType(DreamObjectDefinition objectDefinition) {
         if (!objectDefinition.IsSubtypeOf(ObjectTree.Turf))
-            throw new Exception($"Cannot set turf's type to {objectDefinition.Type}");
+            throw new DMException($"Cannot set turf's type to {objectDefinition.Type}");
 
         ObjectDefinition = objectDefinition;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
@@ -1,7 +1,6 @@
 using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectVector.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectVector.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using OpenDreamRuntime.Procs;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectVector.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectVector.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using OpenDreamRuntime.Procs;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -85,7 +86,7 @@ public sealed class DreamObjectVector(DreamObjectDefinition definition) : DreamO
         }
 
         // TODO: Allow pixloc as an arg
-        throw new Exception($"Bad vector arguments {args.ToString()}");
+        throw new DMException($"Bad vector arguments {args.ToString()}");
     }
 
     #region Operators
@@ -261,20 +262,20 @@ public sealed class DreamObjectVector(DreamObjectDefinition definition) : DreamO
                 return true;
             default:
                 // Hide the base vars
-                throw new Exception($"Invalid vector variable \"{varName}\"");
+                throw new DMException($"Invalid vector variable \"{varName}\"");
         }
     }
 
     protected override void SetVar(string varName, DreamValue value) {
         switch (varName) {
             case "type":
-                throw new Exception("Cannot set type var");
+                throw new DMException("Cannot set type var");
             case "len":
                 var newLen = value.UnsafeGetValueAsFloat();
 
                 // Something like 2.3 actually isn't valid here; it doesn't cast to an int
                 if (!newLen.Equals(2f) && !newLen.Equals(3f)) {
-                    throw new Exception($"Invalid vector len {value}");
+                    throw new DMException($"Invalid vector len {value}");
                 }
 
                 Is3D = newLen.Equals(3f);
@@ -293,7 +294,7 @@ public sealed class DreamObjectVector(DreamObjectDefinition definition) : DreamO
                 break;
             default:
                 // Hide the base vars
-                throw new Exception($"Invalid vector variable \"{varName}\"");
+                throw new DMException($"Invalid vector variable \"{varName}\"");
         }
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -9,7 +9,6 @@ using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Sockets;
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Resources;
@@ -9,6 +9,7 @@ using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -310,7 +311,7 @@ public sealed partial class DreamObjectWorld : DreamObject {
                 break;
 
             default:
-                throw new Exception($"Cannot set var \"{varName}\" on world");
+                throw new DMException($"Cannot set var \"{varName}\" on world");
         }
     }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.CallExt.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.CallExt.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Api = OpenDreamRuntime.ByondApi.ByondApi;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs;
 
@@ -10,11 +11,11 @@ internal static partial class DMOpcodeHandlers {
         DreamValue source,
         DMProcState.DMStackArgumentInfo argumentsInfo) {
         if(!source.TryGetValueAsString(out var dllName))
-            throw new Exception($"{source} is not a valid DLL");
+            throw new DMException($"{source} is not a valid DLL");
 
         using var popProc = state.Pop();
         if(!popProc.TryGetValueAsString(out var procName)) {
-            throw new Exception($"{popProc} is not a valid proc name");
+            throw new DMException($"{popProc} is not a valid proc name");
         }
 
         DreamProcArguments arguments = state.PopProcArguments(null, argumentsInfo);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.CallExt.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.CallExt.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Api = OpenDreamRuntime.ByondApi.ByondApi;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs;
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -17,6 +17,7 @@ using OpenDreamShared.Dream;
 using Robust.Shared.Random;
 using FormatSuffix = DMCompiler.Bytecode.StringFormatEncoder.FormatSuffix;
 using BlendType = OpenDreamRuntime.Objects.DreamIconOperationBlend.BlendType;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs {
     internal static partial class DMOpcodeHandlers {
@@ -181,7 +182,7 @@ namespace OpenDreamRuntime.Procs {
             var enumeratorId = state.ReadInt();
             using var typeValue = state.Pop();
             if (!typeValue.TryGetValueAsType(out var type)) {
-                throw new Exception($"Cannot create a type enumerator with type {typeValue}");
+                throw new DMException($"Cannot create a type enumerator with type {typeValue}");
             }
 
             if (type == state.Proc.ObjectTree.Client) {
@@ -201,7 +202,7 @@ namespace OpenDreamRuntime.Procs {
                 return ProcStatus.Continue;
             }
 
-            throw new Exception($"Type enumeration of {type} is not supported");
+            throw new DMException($"Type enumeration of {type} is not supported");
         }
 
         public static ProcStatus CreateRangeEnumerator(DMProcState state) {
@@ -211,11 +212,11 @@ namespace OpenDreamRuntime.Procs {
             using var rangeStart = state.Pop();
 
             if (!step.TryGetValueAsFloat(out var stepValue))
-                throw new Exception($"Invalid step {step}, must be a number");
+                throw new DMException($"Invalid step {step}, must be a number");
             if (!rangeEnd.TryGetValueAsFloat(out var rangeEndValue))
-                throw new Exception($"Invalid end {rangeEnd}, must be a number");
+                throw new DMException($"Invalid end {rangeEnd}, must be a number");
             if (!rangeStart.TryGetValueAsFloat(out var rangeStartValue))
-                throw new Exception($"Invalid start {rangeStart}, must be a number");
+                throw new DMException($"Invalid start {rangeStart}, must be a number");
 
             state.Enumerators[enumeratorId] = new DreamValueRangeEnumerator(rangeStartValue, rangeEndValue, stepValue);
             return ProcStatus.Continue;
@@ -300,17 +301,17 @@ namespace OpenDreamRuntime.Procs {
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidTurfLoc(DreamValue loc) {
-            throw new Exception($"Invalid turf loc {loc}");
+            throw new DMException($"Invalid turf loc {loc}");
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowCannotCreateObjectFromInvalid(DreamValue val) {
-            throw new Exception($"Cannot create object from invalid type {val}");
+            throw new DMException($"Cannot create object from invalid type {val}");
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowCannotCreateUnknownObject(DreamValue val) {
-            throw new Exception($"Cannot create unknown object {val}");
+            throw new DMException($"Cannot create unknown object {val}");
         }
 
         public static ProcStatus DestroyEnumerator(DMProcState state) {
@@ -686,7 +687,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             if (!key.TryGetValueAsString(out string? property)) {
-                throw new Exception("Invalid var for initial() call: " + key);
+                throw new DMException("Invalid var for initial() call: " + key);
             }
 
             TreeEntry treeEntry;
@@ -872,7 +873,7 @@ namespace OpenDreamRuntime.Procs {
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInvalidAddOperation(DreamValue first, DreamValue second) {
-            throw new Exception("Invalid add operation on " + first + " and " + second);
+            throw new DMException("Invalid add operation on " + first + " and " + second);
         }
 
         public static ProcStatus Append(DMProcState state) {
@@ -916,7 +917,7 @@ namespace OpenDreamRuntime.Procs {
                         result = new DreamValue(first.MustGetValueAsString() + second.MustGetValueAsString());
                         break;
                     default:
-                        throw new Exception("Invalid append operation on " + first + " and " + second);
+                        throw new DMException("Invalid append operation on " + first + " and " + second);
                 }
             } else {
                 result = first;
@@ -1037,12 +1038,12 @@ namespace OpenDreamRuntime.Procs {
                         state.Push(new DreamValue(first.MustGetValueAsInteger() | second.MustGetValueAsInteger()));
                         break;
                     default:
-                        throw new Exception("Invalid or operation on " + first + " and " + second);
+                        throw new DMException("Invalid or operation on " + first + " and " + second);
                 }
             } else if (first.TryGetValueAsInteger(out int firstInt)) {
                 state.Push(new DreamValue(firstInt));
             } else {
-                throw new Exception("Invalid or operation on " + first + " and " + second);
+                throw new DMException("Invalid or operation on " + first + " and " + second);
             }
 
             return ProcStatus.Continue;
@@ -1063,7 +1064,7 @@ namespace OpenDreamRuntime.Procs {
                     state.Push(new DreamValue(first.MustGetValueAsInteger()));
                     break;
                 default:
-                    throw new Exception($"Invalid bit shift left operation on {first} and {second}");
+                    throw new DMException($"Invalid bit shift left operation on {first} and {second}");
             }
 
             return ProcStatus.Continue;
@@ -1086,7 +1087,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(first.MustGetValueAsInteger());
                     break;
                 default:
-                    throw new Exception($"Invalid bit shift left operation on {first} and {second}");
+                    throw new DMException($"Invalid bit shift left operation on {first} and {second}");
             }
 
             state.AssignReference(reference, result);
@@ -1109,7 +1110,7 @@ namespace OpenDreamRuntime.Procs {
                     state.Push(new DreamValue(first.MustGetValueAsInteger()));
                     break;
                 default:
-                    throw new Exception($"Invalid bit shift right operation on {first} and {second}");
+                    throw new DMException($"Invalid bit shift right operation on {first} and {second}");
             }
 
             return ProcStatus.Continue;
@@ -1132,7 +1133,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(first.MustGetValueAsInteger());
                     break;
                 default:
-                    throw new Exception($"Invalid bit shift right operation on {first} and {second}");
+                    throw new DMException($"Invalid bit shift right operation on {first} and {second}");
             }
 
             state.AssignReference(reference, result);
@@ -1213,12 +1214,12 @@ namespace OpenDreamRuntime.Procs {
                 } else if (first.IsNull) {
                     result = second;
                 } else {
-                    throw new Exception("Invalid combine operation on " + first + " and " + second);
+                    throw new DMException("Invalid combine operation on " + first + " and " + second);
                 }
             } else if (first.Type == DreamValue.DreamValueType.Float) {
                 result = first;
             } else {
-                throw new Exception("Invalid combine operation on " + first + " and " + second);
+                throw new DMException("Invalid combine operation on " + first + " and " + second);
             }
 
             state.AssignReference(reference, result);
@@ -1235,11 +1236,11 @@ namespace OpenDreamRuntime.Procs {
                     state.Push(new DreamValue(0));
                     break;
                 case DreamValue.DreamValueType.Float when second.IsNull:
-                    throw new Exception($"Attempted to divide {first} by null");
+                    throw new DMException($"Attempted to divide {first} by null");
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
                     var secondFloat = second.MustGetValueAsFloat();
                     if (secondFloat == 0) {
-                        throw new Exception("Division by zero");
+                        throw new DMException("Division by zero");
                     }
 
                     state.Push(new DreamValue(first.MustGetValueAsFloat() / secondFloat));
@@ -1251,7 +1252,7 @@ namespace OpenDreamRuntime.Procs {
                     result.Dispose();
                     break;
                 default:
-                    throw new Exception($"Invalid divide operation on {first} and {second}");
+                    throw new DMException($"Invalid divide operation on {first} and {second}");
             }
 
             return ProcStatus.Continue;
@@ -1273,7 +1274,7 @@ namespace OpenDreamRuntime.Procs {
                 state.AssignReference(reference, result);
                 state.Push(result);
             } else {
-                throw new Exception($"Invalid divide operation on {first} and {second}");
+                throw new DMException($"Invalid divide operation on {first} and {second}");
             }
 
             return ProcStatus.Continue;
@@ -1303,7 +1304,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(0);
                     break;
                 default:
-                    throw new Exception("Invalid mask operation on " + first + " and " + second);
+                    throw new DMException("Invalid mask operation on " + first + " and " + second);
             }
 
             state.AssignReference(reference, result);
@@ -1361,7 +1362,7 @@ namespace OpenDreamRuntime.Procs {
 
                 state.Push(result);
             } else {
-                throw new Exception($"Invalid multiply operation on {first} and {second}");
+                throw new DMException($"Invalid multiply operation on {first} and {second}");
             }
 
             return ProcStatus.Continue;
@@ -1382,7 +1383,7 @@ namespace OpenDreamRuntime.Procs {
             } else if (first.TryGetValueAsDreamObject<DreamObject>(out var firstDreamObject)) {
                 result = firstDreamObject.OperatorMultiplyRef(second, state);
             } else {
-                throw new Exception($"Invalid multiply operation on {first} and {second}");
+                throw new DMException($"Invalid multiply operation on {first} and {second}");
             }
 
             state.AssignReference(reference, result);
@@ -1404,7 +1405,7 @@ namespace OpenDreamRuntime.Procs {
             using var first = state.Pop();
 
             if (!first.TryGetValueAsFloat(out var floatFirst) && !first.IsNull)
-                throw new Exception($"Invalid power operation on {first} and {second}");
+                throw new DMException($"Invalid power operation on {first} and {second}");
 
             var floatSecond = second.UnsafeGetValueAsFloat(); // Non-numbers treated as 0 here
 
@@ -1435,7 +1436,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(first.UnsafeGetValueAsFloat() - second.UnsafeGetValueAsFloat());
                     break;
                 default:
-                    throw new Exception($"Invalid remove operation on {first} and {second}");
+                    throw new DMException($"Invalid remove operation on {first} and {second}");
             }
 
             state.AssignReference(reference, result);
@@ -1460,7 +1461,7 @@ namespace OpenDreamRuntime.Procs {
                 state.Push(output);
                 output.Dispose();
             } else {
-                throw new Exception($"Invalid subtract operation on {first} and {second}");
+                throw new DMException($"Invalid subtract operation on {first} and {second}");
             }
 
             return ProcStatus.Continue;
@@ -1663,7 +1664,7 @@ namespace OpenDreamRuntime.Procs {
                 case DMReference.Type.SrcProc: {
                     instance = state.Instance;
                     if (!instance.TryGetProc(state.ResolveString(procRef.Value), out proc))
-                        throw new Exception($"Type {instance.ObjectDefinition.Type} has no proc called \"{state.ResolveString(procRef.Value)}\"");
+                        throw new DMException($"Type {instance.ObjectDefinition.Type} has no proc called \"{state.ResolveString(procRef.Value)}\"");
 
                     break;
                 }
@@ -1701,7 +1702,7 @@ namespace OpenDreamRuntime.Procs {
                         return state.Call(proc, dreamObject, arguments);
                     }
 
-                    throw new Exception($"Invalid proc ({procId} on {dreamObject})");
+                    throw new DMException($"Invalid proc ({procId} on {dreamObject})");
                 }
                 case DreamValue.DreamValueType.DreamProc: {
                     var proc = source.MustGetValueAsProc();
@@ -1715,7 +1716,7 @@ namespace OpenDreamRuntime.Procs {
                     return CallExt(state, source, argumentsInfo);
 
                 default:
-                    throw new Exception($"Call statement has an invalid source ({source})");
+                    throw new DMException($"Call statement has an invalid source ({source})");
             }
         }
 
@@ -2083,7 +2084,7 @@ namespace OpenDreamRuntime.Procs {
             } else if (argumentInfo.Type == DMCallArgumentsType.FromArgumentList) {
                 using var argListStack = state.Pop();
                 if (!argListStack.TryGetValueAsDreamList(out var argList))
-                    throw new Exception("Invalid gradient() arguments");
+                    throw new DMException("Invalid gradient() arguments");
 
                 var argListValues = argList.GetValues();
 
@@ -2120,7 +2121,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             if (gradientIndex == default)
-                throw new Exception("No gradient index given");
+                throw new DMException("No gradient index given");
 
             state.Push(CalculateGradient(gradientValues, gradientColorSpace, gradientIndex));
             gradientColorSpace.Dispose();
@@ -2134,7 +2135,7 @@ namespace OpenDreamRuntime.Procs {
 
             var argumentsArray = arguments.ToArray();
             if (argumentsArray.Length is < 3 or > 5)
-                throw new Exception("Expected 3 to 5 arguments for rgb()");
+                throw new DMException("Expected 3 to 5 arguments for rgb()");
 
             var values = new (string?, float?)[arguments.Count];
             for (int i = 0; i < argumentsArray.Length; i++) {
@@ -2204,7 +2205,7 @@ namespace OpenDreamRuntime.Procs {
 
                 if (!objArg.TryGetValueAsDreamObject<DreamObject>(out var obj)) {
                     if (state.Thread.LastAnimatedObject is null || state.Thread.LastAnimatedObject.Value.IsNull) {
-                        throw new Exception("animate() called without an object and no previous object to animate");
+                        throw new DMException("animate() called without an object and no previous object to animate");
                     } else if (!state.Thread.LastAnimatedObject.Value.TryGetValueAsDreamObject<DreamObject>(out obj)) {
                         state.Push(DreamValue.Null);
                         return ProcStatus.Continue;
@@ -2447,7 +2448,7 @@ namespace OpenDreamRuntime.Procs {
                 }
 
                 if (values.Count == 0)
-                    throw new Exception("pick() from empty list");
+                    throw new DMException("pick() from empty list");
 
                 state.Push(values[state.DreamManager.Random.Next(0, values.Count)]);
             } else {
@@ -2491,7 +2492,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             if (!key.TryGetValueAsString(out string? property)) {
-                throw new Exception($"Invalid var for issaved() call: {key}");
+                throw new DMException($"Invalid var for issaved() call: {key}");
             }
 
             if (owner.TryGetValueAsDreamObject(out DreamObject dreamObject)) {
@@ -2505,7 +2506,7 @@ namespace OpenDreamRuntime.Procs {
             } else if (owner.TryGetValueAsType(out var type)) {
                 objectDefinition = type.ObjectDefinition;
             } else {
-                throw new Exception($"Invalid owner for issaved() call {owner}");
+                throw new DMException($"Invalid owner for issaved() call {owner}");
             }
 
             if (objectDefinition.GlobalVariables.ContainsKey(property)
@@ -2617,7 +2618,7 @@ namespace OpenDreamRuntime.Procs {
             } else if (receiver == state.DreamManager.WorldInstance) {
                 clients = state.DreamManager.Connections;
             } else {
-                throw new Exception($"Invalid browse() recipient: expected mob, client, or world, got {receiver}");
+                throw new DMException($"Invalid browse() recipient: expected mob, client, or world, got {receiver}");
             }
 
             string? browseValue;
@@ -2626,7 +2627,7 @@ namespace OpenDreamRuntime.Procs {
             } else if (bodyStack.TryGetValueAsString(out browseValue) || bodyStack.IsNull) {
                 // Got it.
             } else {
-                throw new Exception($"Invalid browse() body: expected resource or string, got {bodyStack}");
+                throw new DMException($"Invalid browse() body: expected resource or string, got {bodyStack}");
             }
 
             foreach (DreamConnection client in clients) {
@@ -2658,7 +2659,7 @@ namespace OpenDreamRuntime.Procs {
             } else if (receiver is DreamObjectClient receiverClient) {
                 connection = receiverClient.Connection;
             } else {
-                throw new Exception("Invalid browse_rsc() recipient");
+                throw new DMException("Invalid browse_rsc() recipient");
             }
 
             connection?.BrowseResource(file, filename.IsNull ? Path.GetFileName(file.ResourcePath) : filename.GetValueAsString());
@@ -2711,7 +2712,7 @@ namespace OpenDreamRuntime.Procs {
                 }
             } else {
                 // TODO: BYOND's behavior is to ignore rather than throw here
-                throw new Exception($"Invalid output() recipient: {receiver}");
+                throw new DMException($"Invalid output() recipient: {receiver}");
             }
 
             return ProcStatus.Continue;
@@ -2773,11 +2774,11 @@ namespace OpenDreamRuntime.Procs {
             DreamConnection? connection = receiver switch {
                 DreamObjectMob receiverMob => receiverMob.Connection,
                 DreamObjectClient receiverClient => receiverClient.Connection,
-                _ => throw new Exception("Invalid link() recipient")
+                _ => throw new DMException("Invalid link() recipient")
             };
 
             if (!url.TryGetValueAsString(out var urlStr)) {
-                throw new Exception($"Invalid link() url: {url}");
+                throw new DMException($"Invalid link() url: {url}");
             } else if (string.IsNullOrWhiteSpace(urlStr)) {
                 return ProcStatus.Continue;
             }
@@ -2799,7 +2800,7 @@ namespace OpenDreamRuntime.Procs {
             } else if (receiver is DreamObjectClient receiverClient) {
                 connection = receiverClient.Connection;
             } else {
-                throw new Exception("Invalid ftp() recipient");
+                throw new DMException("Invalid ftp() recipient");
             }
 
             if (!file.TryGetValueAsDreamResource(out var resource)) {
@@ -2811,7 +2812,7 @@ namespace OpenDreamRuntime.Procs {
                 } else if (file.TryGetValueAsDreamObject<DreamObjectIcon>(out var icon)) {
                     resource = icon.Icon.GenerateDMI();
                 } else {
-                    throw new Exception($"{file} is not a valid file");
+                    throw new DMException($"{file} is not a valid file");
                 }
             }
 
@@ -2880,9 +2881,9 @@ namespace OpenDreamRuntime.Procs {
             using var obj = state.Pop();
 
             if (!obj.TryGetValueAsDreamObject(out var instance) || instance == null)
-                throw new Exception($"Cannot dereference proc \"{name}\" from {obj}");
+                throw new DMException($"Cannot dereference proc \"{name}\" from {obj}");
             if (!instance.TryGetProc(name, out var proc))
-                throw new Exception($"Type {instance.ObjectDefinition.Type} has no proc called \"{name}\"");
+                throw new DMException($"Type {instance.ObjectDefinition.Type} has no proc called \"{name}\"");
 
             return state.Call(proc, instance, arguments.ToProcArguments(proc));
         }
@@ -3013,7 +3014,7 @@ namespace OpenDreamRuntime.Procs {
                         if (second.IsNull) return false;
                     }
 
-                    throw new Exception("Invalid greater than comparison on " + first + " and " + second);
+                    throw new DMException("Invalid greater than comparison on " + first + " and " + second);
                 }
             }
         }
@@ -3033,7 +3034,7 @@ namespace OpenDreamRuntime.Procs {
                         if (second.IsNull) return false;
                     }
 
-                    throw new Exception("Invalid less than comparison between " + first + " and " + second);
+                    throw new DMException("Invalid less than comparison between " + first + " and " + second);
                 }
             }
         }
@@ -3075,7 +3076,7 @@ namespace OpenDreamRuntime.Procs {
                 case DreamValue.DreamValueType.Float when second.IsNull:
                     return new DreamValue(first.MustGetValueAsInteger());
                 default:
-                    throw new Exception($"Invalid xor operation on {first} and {second}");
+                    throw new DMException($"Invalid xor operation on {first} and {second}");
             }
         }
 
@@ -3086,7 +3087,7 @@ namespace OpenDreamRuntime.Procs {
                 }
             }
 
-            throw new Exception($"Invalid modulus operation on {first} and {second}");
+            throw new DMException($"Invalid modulus operation on {first} and {second}");
         }
 
         private static DreamValue ModulusModulusValues(DreamValue first, DreamValue second) {
@@ -3098,13 +3099,13 @@ namespace OpenDreamRuntime.Procs {
                 return new DreamValue(fraction * secondFloat);
             }
 
-            throw new Exception("Invalid modulusmodulus operation on " + first + " and " + second);
+            throw new DMException("Invalid modulusmodulus operation on " + first + " and " + second);
         }
 
         private static DreamValue CalculateGradient(List<DreamValue> gradientValues, DreamValue colorSpaceValue, DreamValue indexValue) {
             if (gradientValues.Count == 1) {
                 if (!gradientValues[0].TryGetValueAsDreamList(out var gradientList))
-                    throw new Exception("Invalid gradient() values; expected either a list or at least 2 values");
+                    throw new DMException("Invalid gradient() values; expected either a list or at least 2 values");
 
                 gradientValues = gradientList.GetValues();
             }
@@ -3244,7 +3245,7 @@ namespace OpenDreamRuntime.Procs {
             var iconObj = state.Proc.ObjectTree.CreateObject<DreamObjectIcon>(state.Proc.ObjectTree.Icon);
             if (!state.Proc.DreamResourceManager.TryLoadIcon(icon, out var from)) {
                 iconObj.DecRef();
-                throw new Exception($"Failed to create an icon from {from}");
+                throw new DMException($"Failed to create an icon from {from}");
             }
 
             iconObj.Icon.InsertStates(from, DreamValue.Null, DreamValue.Null, DreamValue.Null);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -17,7 +17,6 @@ using OpenDreamShared.Dream;
 using Robust.Shared.Random;
 using FormatSuffix = DMCompiler.Bytecode.StringFormatEncoder.FormatSuffix;
 using BlendType = OpenDreamRuntime.Objects.DreamIconOperationBlend.BlendType;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs {
     internal static partial class DMOpcodeHandlers {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -14,6 +14,7 @@ using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs;
 
@@ -790,7 +791,7 @@ public sealed class DMProcState : ProcState {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowInvalidReferenceType(DMReference.Type type) {
-        throw new Exception($"Invalid reference type {type}");
+        throw new DMException($"Invalid reference type {type}");
     }
 
     public DMStackArgumentInfo ReadProcArguments() {
@@ -890,27 +891,27 @@ public sealed class DMProcState : ProcState {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotAssignReferenceType(DreamReference reference) {
-        throw new Exception($"Cannot assign to reference type {reference.Type}");
+        throw new DMException($"Cannot assign to reference type {reference.Type}");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotAssignListIndex(DreamValue index, DreamValue indexing) {
-        throw new Exception($"Cannot assign to index {index} of {indexing}");
+        throw new DMException($"Cannot assign to index {index} of {indexing}");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void ThrowCannotAssignFieldOn(DreamReference reference, DreamValue owner) {
-        throw new Exception($"Cannot assign field \"{ResolveString(reference.Value)}\" on {owner}");
+        throw new DMException($"Cannot assign field \"{ResolveString(reference.Value)}\" on {owner}");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotAssignSrcTo(DreamValue value) {
-        throw new Exception($"Cannot assign src to {value}");
+        throw new DMException($"Cannot assign src to {value}");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotAssignUsrTo(DreamValue value) {
-        throw new Exception($"Cannot assign usr to {value}");
+        throw new DMException($"Cannot assign usr to {value}");
     }
 
     [MustDisposeResource]
@@ -997,17 +998,17 @@ public sealed class DMProcState : ProcState {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotGetValueOfReferenceType(DreamReference reference) {
-        throw new Exception($"Cannot get value of reference type {reference.Type}");
+        throw new DMException($"Cannot get value of reference type {reference.Type}");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotGetFieldSrcGlobalProc(string fieldName) {
-        throw new Exception($"Cannot get field src.{fieldName} in global proc");
+        throw new DMException($"Cannot get field src.{fieldName} in global proc");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void ThrowTypeHasNoField(string fieldName) {
-        throw new Exception($"Type {Instance!.ObjectDefinition.Type} has no field called \"{fieldName}\"");
+        throw new DMException($"Type {Instance!.ObjectDefinition.Type} has no field called \"{fieldName}\"");
     }
 
     public void PopReference(DreamReference reference) {
@@ -1040,7 +1041,7 @@ public sealed class DMProcState : ProcState {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowPopInvalidType(DMReference.Type type) {
-        throw new Exception($"Cannot pop stack values of reference type {type}");
+        throw new DMException($"Cannot pop stack values of reference type {type}");
     }
 
     [MustDisposeResource]
@@ -1067,17 +1068,17 @@ public sealed class DMProcState : ProcState {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotGetFieldFromOwner(DreamValue owner, string field) {
-        throw new Exception($"Cannot get field \"{field}\" from {owner}");
+        throw new DMException($"Cannot get field \"{field}\" from {owner}");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowInvalidAppearanceVar(string field) {
-        throw new Exception($"Invalid appearance var \"{field}\"");
+        throw new DMException($"Invalid appearance var \"{field}\"");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowTypeHasNoField(string field, DreamObject ownerObj) {
-        throw new Exception($"Type {ownerObj.ObjectDefinition.Type} has no field called \"{field}\"");
+        throw new DMException($"Type {ownerObj.ObjectDefinition.Type} has no field called \"{field}\"");
     }
 
     [MustDisposeResource]
@@ -1104,12 +1105,12 @@ public sealed class DMProcState : ProcState {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowCannotGetIndex(DreamValue indexing, DreamValue index) {
-        throw new Exception($"Cannot get index {index} of {indexing}");
+        throw new DMException($"Cannot get index {index} of {indexing}");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowAttemptedToIndexString(DreamValue index) {
-        throw new Exception($"Attempted to index string with {index}");
+        throw new DMException($"Attempted to index string with {index}");
     }
 
     #endregion References
@@ -1239,7 +1240,7 @@ public sealed class DMProcState : ProcState {
                     return new DreamProcArguments(_state.GetArguments());
                 case DMCallArgumentsType.FromStackKeyed: {
                     if (proc == null)
-                        throw new Exception("Cannot use named arguments here");
+                        throw new DMException("Cannot use named arguments here");
 
                     // new /mutable_appearance(...) always uses /image/New()'s arguments, despite any overrides
                     if (proc.OwningType == _state.Proc.ObjectTree.MutableAppearance && proc.Name == "New")
@@ -1270,7 +1271,7 @@ public sealed class DMProcState : ProcState {
                             string argumentName = key.MustGetValueAsString();
                             int argumentIndex = proc.ArgumentNames.IndexOf(argumentName);
                             if (argumentIndex == -1)
-                                throw new Exception($"{proc} has no argument named \"{argumentName}\"");
+                                throw new DMException($"{proc} has no argument named \"{argumentName}\"");
 
                             arguments[argumentIndex] = value;
                         }
@@ -1280,7 +1281,7 @@ public sealed class DMProcState : ProcState {
                 }
                 case DMCallArgumentsType.FromArgumentList: {
                     if (proc == null)
-                        throw new Exception("Cannot use an arglist here");
+                        throw new DMException("Cannot use an arglist here");
                     if (!_values[0].TryGetValueAsDreamList(out var argList))
                         return new DreamProcArguments(); // Using a non-list gives you no arguments
 
@@ -1300,11 +1301,11 @@ public sealed class DMProcState : ProcState {
 
                         if (argList.ContainsKey(value)) { //Named argument
                             if (!value.TryGetValueAsString(out var argumentName))
-                                throw new Exception("List contains a non-string key, and cannot be used as an arglist");
+                                throw new DMException("List contains a non-string key, and cannot be used as an arglist");
 
                             int argumentIndex = proc.ArgumentNames.IndexOf(argumentName);
                             if (argumentIndex == -1)
-                                throw new Exception($"{proc} has no argument named \"{argumentName}\"");
+                                throw new DMException($"{proc} has no argument named \"{argumentName}\"");
 
                             arguments[argumentIndex] = argList.GetValue(value);
                         } else { //Ordered argument
@@ -1328,7 +1329,7 @@ public sealed class DMProcState : ProcState {
                     return procArgs;
                 }
                 default:
-                    throw new Exception($"Invalid arguments type {_info.Type}");
+                    throw new DMException($"Invalid arguments type {_info.Type}");
             }
         }
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -14,7 +14,6 @@ using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs;
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeGenerator.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeGenerator.cs
@@ -2,7 +2,6 @@ using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamShared.Dream;
 using Robust.Shared.Random;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeGenerator.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeGenerator.cs
@@ -1,7 +1,8 @@
-﻿using OpenDreamRuntime.Objects;
+using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamShared.Dream;
 using Robust.Shared.Random;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 
@@ -24,7 +25,7 @@ internal static class DreamProcNativeGenerator {
                 return new DreamValue(resultObj);
             }
             default:
-                throw new Exception($"Invalid generator for Rand: {genObj}");
+                throw new DMException($"Invalid generator for Rand: {genObj}");
         }
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using OpenDreamRuntime.Objects.Types;
 using System.Text;
 using OpenDreamRuntime.Map;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 
@@ -160,7 +161,7 @@ internal static partial class DreamProcNativeHelpers {
             } else if (arg.TryGetValueAsString(out var distString)) {
                 range = new ViewRange(distString);
             } else if (!arg.IsNull) { // null range arg is handled by DefaultView above
-                throw new Exception($"Invalid argument: {arg}");
+                throw new DMException($"Invalid argument: {arg}");
             }
         }
 
@@ -514,7 +515,7 @@ internal static partial class DreamProcNativeHelpers {
             return null;
 
         if (radix < 2 || radix > 36)
-            throw new Exception($"Invalid radix: {radix}");
+            throw new DMException($"Invalid radix: {radix}");
 
         bool negative = value[0] == '-';
         if (negative || value[0] == '+')

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using OpenDreamRuntime.Objects.Types;
 using System.Text;
 using OpenDreamRuntime.Map;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -6,6 +6,7 @@ using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using BlendType = OpenDreamRuntime.Objects.DreamIconOperationBlend.BlendType;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native {
     internal static class DreamProcNativeIcon {
@@ -40,7 +41,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             var resourceManager = IoCManager.Resolve<DreamResourceManager>();
             if (!resourceManager.TryLoadIcon(newIcon, out var iconRsc))
-                throw new Exception($"Cannot insert {newIcon}");
+                throw new DMException($"Cannot insert {newIcon}");
 
             ((DreamObjectIcon)src!).Icon.InsertStates(iconRsc, iconState, dir, frame); // TODO: moving & delay
             return DreamValue.Null;
@@ -49,7 +50,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static void Blend(DreamIcon icon, DreamValue blend, BlendType function, int x, int y) {
             if (blend.TryGetValueAsString(out var colorStr)) {
                 if (!ColorHelpers.TryParseColor(colorStr, out var color))
-                    throw new Exception($"Invalid color {colorStr}");
+                    throw new DMException($"Invalid color {colorStr}");
 
                 icon.ApplyOperation(new DreamIconOperationBlendColor(function, x, y, color));
             } else {
@@ -72,7 +73,7 @@ namespace OpenDreamRuntime.Procs.Native {
             bundle.GetArgument(3, "y").TryGetValueAsInteger(out var y);
 
             if (!function.TryGetValueAsInteger(out var functionValue))
-                throw new Exception($"Invalid 'function' argument {function}");
+                throw new DMException($"Invalid 'function' argument {function}");
 
             Blend(((DreamObjectIcon)src!).Icon, icon, (BlendType)functionValue, x, y);
             return DreamValue.Null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -6,7 +6,6 @@ using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using BlendType = OpenDreamRuntime.Objects.DreamIconOperationBlend.BlendType;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native {
     internal static class DreamProcNativeIcon {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
@@ -1,7 +1,8 @@
-﻿using System.Text;
+using System.Text;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native {
     internal static class DreamProcNativeList {
@@ -76,7 +77,7 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamList list = (DreamList)src!;
 
             if (index <= 0) index = list.GetLength() + 1;
-            if (bundle.Arguments.Length < 2) throw new Exception("No value given to insert");
+            if (bundle.Arguments.Length < 2) throw new DMException("No value given to insert");
 
             for (var i = 1; i < bundle.Arguments.Length; i++) {
                 var item = bundle.Arguments[i];
@@ -185,7 +186,7 @@ namespace OpenDreamRuntime.Procs.Native {
             int end = bundle.GetArgument(1, "End").MustGetValueAsInteger(); //1-indexed
             IDreamList list = (IDreamList)src!;
             if (list is DreamAssocList) {
-                throw new Exception("special list may not be spliced");
+                throw new DMException("special list may not be spliced");
             }
 
             list.Cut(startIndex, end);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
@@ -2,7 +2,6 @@ using System.Text;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native {
     internal static class DreamProcNativeList {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -1,6 +1,7 @@
-﻿using OpenDreamRuntime.Objects;
+using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 
@@ -17,7 +18,7 @@ internal static class DreamProcNativeMatrix {
         }
 
         // On invalid input, throw runtime
-        throw new Exception($"Invalid matrix for addition: {possibleMatrix.ToString()}");
+        throw new DMException($"Invalid matrix for addition: {possibleMatrix.ToString()}");
     }
 
     [DreamProc("Invert")]
@@ -82,7 +83,7 @@ internal static class DreamProcNativeMatrix {
         }
 
         // On invalid input, throw runtime
-        throw new Exception($"Invalid matrix for subtraction: {possibleMatrix.ToString()}");
+        throw new DMException($"Invalid matrix for subtraction: {possibleMatrix.ToString()}");
     }
 
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -1,7 +1,6 @@
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -25,7 +25,6 @@ using DreamValueType = OpenDreamRuntime.DreamValue.DreamValueType;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
 using Robust.Server;
 using Robust.Shared.Asynchronous;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -25,6 +25,7 @@ using DreamValueType = OpenDreamRuntime.DreamValue.DreamValueType;
 using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
 using Robust.Server;
 using Robust.Shared.Asynchronous;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs.Native;
 
@@ -80,7 +81,7 @@ internal static class DreamProcNativeRoot {
     public static DreamValue NativeProc_ascii2text(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
         DreamValue ascii = bundle.GetArgument(0, "N");
         if (!ascii.TryGetValueAsInteger(out int asciiValue))
-            throw new Exception($"{ascii} is not a number");
+            throw new DMException($"{ascii} is not a number");
 
         return new DreamValue(char.ConvertFromUtf32(asciiValue));
     }
@@ -259,17 +260,17 @@ internal static class DreamProcNativeRoot {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ClampLowerBoundNotANumber() {
-        throw new Exception("Lower bound is not a number");
+        throw new DMException("Lower bound is not a number");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ClampUpperBoundNotANumber() {
-        throw new Exception("Upper bound is not a number");
+        throw new DMException("Upper bound is not a number");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ClampUnexpectedType() {
-        throw new Exception("Clamp expects a number or list");
+        throw new DMException("Clamp expects a number or list");
     }
 
     [DreamProc("cmptext")]
@@ -384,12 +385,12 @@ internal static class DreamProcNativeRoot {
         }
 
         if (srcFile?.ResourceData == null) {
-            throw new Exception($"Bad src file {arg1}");
+            throw new DMException($"Bad src file {arg1}");
         }
 
         var arg2 = bundle.GetArgument(1, "Dst");
         if (!arg2.TryGetValueAsString(out var dst)) {
-            throw new Exception($"Bad dst file {arg2}");
+            throw new DMException($"Bad dst file {arg2}");
         }
 
         return new DreamValue(bundle.ResourceManager.CopyFile(srcFile, dst) ? 1 : 0);
@@ -425,7 +426,7 @@ internal static class DreamProcNativeRoot {
         if (file.TryGetValueAsDreamResource(out var resource)) {
             filePath = resource.ResourcePath;
         } else if(!file.TryGetValueAsString(out filePath)) {
-            throw new Exception($"{file} is not a valid file");
+            throw new DMException($"{file} is not a valid file");
         }
 
         bool successful = filePath.EndsWith("/") ? bundle.ResourceManager.DeleteDirectory(filePath) : bundle.ResourceManager.DeleteFile(filePath);
@@ -462,7 +463,7 @@ internal static class DreamProcNativeRoot {
             return path;
         }
 
-        throw new Exception("Invalid path argument");
+        throw new DMException("Invalid path argument");
     }
 
     [DreamProc("file2text")]
@@ -826,7 +827,7 @@ internal static class DreamProcNativeRoot {
             return new DreamValue((fi.LastWriteTime - new DateTime(2000, 1, 1)).TotalMilliseconds / 100);
         }
 
-        throw new Exception("Invalid path argument");
+        throw new DMException("Invalid path argument");
     }
 
     [DreamProc("get_step_to")]
@@ -964,7 +965,7 @@ internal static class DreamProcNativeRoot {
         } else if (arg.IsNull) {
             return DreamValue.Null;
         } else {
-            throw new Exception($"Bad icon {arg}");
+            throw new DMException($"Bad icon {arg}");
         }
     }
 
@@ -1214,7 +1215,7 @@ internal static class DreamProcNativeRoot {
                 return new DreamValue(jsonElement.GetString() ?? ""); // it shouldn't be null but it was throwing a warning
             case JsonValueKind.Number:
                 if (!jsonElement.TryGetSingle(out float floatValue)) {
-                    throw new Exception("Invalid number " + jsonElement);
+                    throw new DMException("Invalid number " + jsonElement);
                 }
 
                 return new DreamValue(floatValue);
@@ -1225,7 +1226,7 @@ internal static class DreamProcNativeRoot {
             case JsonValueKind.Null:
                 return DreamValue.Null;
             default:
-                throw new Exception("Invalid ValueKind " + jsonElement.ValueKind);
+                throw new DMException("Invalid ValueKind " + jsonElement.ValueKind);
         }
     }
 
@@ -1314,7 +1315,7 @@ internal static class DreamProcNativeRoot {
         } else if (value.TryGetValueAsDreamResource(out var dreamResource)) {
             writer.WriteStringValue(dreamResource.ResourcePath);
         } else {
-            throw new Exception($"Cannot json_encode {value}");
+            throw new DMException($"Cannot json_encode {value}");
         }
     }
 
@@ -1323,7 +1324,7 @@ internal static class DreamProcNativeRoot {
     [MustDisposeResource]
     public static DreamValue NativeProc_json_decode(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
         if (!bundle.GetArgument(0, "JSON").TryGetValueAsString(out var jsonString)) {
-            throw new Exception("Unknown value");
+            throw new DMException("Unknown value");
         }
 
         JsonElement jsonRoot = JsonSerializer.Deserialize<JsonElement>(jsonString);
@@ -1363,7 +1364,7 @@ internal static class DreamProcNativeRoot {
             return new DreamValue(0);
         }
 
-        throw new Exception($"Cannot check length of {value}");
+        throw new DMException($"Cannot check length of {value}");
     }
 
     [DreamProc("length_char")]
@@ -1383,7 +1384,7 @@ internal static class DreamProcNativeRoot {
         DreamValue valFactor = bundle.GetArgument(2, "factor");
 
         if (!valFactor.TryGetValueAsFloatCoerceNull(out var factor))
-            throw new Exception($"lerp factor {valFactor} is not a num");
+            throw new DMException($"lerp factor {valFactor} is not a num");
 
         // TODO: Support non-num arguments like vectors
         if (valA.TryGetValueAsFloatCoerceNull(out var floatA) && valB.TryGetValueAsFloatCoerceNull(out var floatB)) {
@@ -1620,7 +1621,7 @@ internal static class DreamProcNativeRoot {
             else if (max.TryGetValueAsString(out var rString) && string.Compare(lString, rString, StringComparison.Ordinal) > 0)
                 max = value;
         } else {
-            throw new Exception($"Cannot compare {max} and {value}");
+            throw new DMException($"Cannot compare {max} and {value}");
         }
 
         return max;
@@ -1660,7 +1661,7 @@ internal static class DreamProcNativeRoot {
     [DreamProc("md5")]
     [DreamProcParameter("T", Type = DreamValueTypeFlag.String | DreamValueTypeFlag.DreamResource)]
     public static DreamValue NativeProc_md5(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if(bundle.Arguments.Length > 1) throw new Exception("md5() only takes one argument");
+        if(bundle.Arguments.Length > 1) throw new DMException("md5() only takes one argument");
         DreamValue arg = bundle.GetArgument(0, "T");
 
         byte[] bytes;
@@ -1701,7 +1702,7 @@ internal static class DreamProcNativeRoot {
             else if (min.TryGetValueAsString(out var rString) && string.Compare(lString, rString, StringComparison.Ordinal) <= 0)
                 min = value;
         } else {
-            throw new Exception($"Cannot compare {min} and {value}");
+            throw new DMException($"Cannot compare {min} and {value}");
         }
 
         return min;
@@ -2173,7 +2174,7 @@ internal static class DreamProcNativeRoot {
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void Rgb2NumBadColor() {
-        throw new Exception("bad color");
+        throw new DMException("bad color");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -2209,22 +2210,22 @@ internal static class DreamProcNativeRoot {
                 string[] diceList = diceInput.Split('d');
                 if (diceList.Length < 2) {
                     if (!int.TryParse(diceList[0], out sides))
-                        throw new Exception($"Invalid dice value: {diceInput}");
+                        throw new DMException($"Invalid dice value: {diceInput}");
                 } else {
                     if (!int.TryParse(diceList[0], out dice))
-                        throw new Exception($"Invalid dice value: {diceInput}");
+                        throw new DMException($"Invalid dice value: {diceInput}");
 
                     if (!int.TryParse(diceList[1], out sides)) {
                         string[] sideList = diceList[1].Split('+');
 
                         if (!int.TryParse(sideList[0], out sides) || !int.TryParse(sideList[1], out modifier))
-                            throw new Exception($"Invalid dice value: {diceInput}");
+                            throw new DMException($"Invalid dice value: {diceInput}");
                     }
                 }
             } else if (arg.IsNull) {
                 return new DreamValue(1);
             } else if (!arg.TryGetValueAsInteger(out sides)) {
-                throw new Exception($"Invalid dice value: {arg}");
+                throw new DMException($"Invalid dice value: {arg}");
             }
         } else if (!bundle.GetArgument(0, "ndice").TryGetValueAsInteger(out dice) || !bundle.GetArgument(1, "sides").TryGetValueAsInteger(out sides)) {
             return new DreamValue(0);
@@ -2241,7 +2242,7 @@ internal static class DreamProcNativeRoot {
     [DreamProc("sha1")]
     [DreamProcParameter("T", Type = DreamValueTypeFlag.String | DreamValueTypeFlag.DreamResource)]
     public static DreamValue NativeProc_sha1(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if (bundle.Arguments.Length > 1) throw new Exception("sha1() only takes one argument");
+        if (bundle.Arguments.Length > 1) throw new DMException("sha1() only takes one argument");
         DreamValue arg = bundle.GetArgument(0, "T");
         byte[] bytes;
 
@@ -2286,7 +2287,7 @@ internal static class DreamProcNativeRoot {
     [DreamProc("sign")]
     [DreamProcParameter("A", Type = DreamValueTypeFlag.Float)]
     public static DreamValue NativeProc_sign(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if (bundle.Arguments.Length != 1) throw new Exception($"expected 1 argument (found {bundle.Arguments.Length})");
+        if (bundle.Arguments.Length != 1) throw new DMException($"expected 1 argument (found {bundle.Arguments.Length})");
         DreamValue arg = bundle.GetArgument(0, "A");
 
         // Any non-num returns 0
@@ -2471,7 +2472,7 @@ internal static class DreamProcNativeRoot {
             end = Math.Min(end + text.Length + 1, text.Length);
 
         if(start == 0 || start > text.Length || start > end)
-            throw new Exception("bad text or out of bounds");
+            throw new DMException("bad text or out of bounds");
 
         string result = text.Remove(start - 1, (end-start)).Insert(start - 1, insertText);
 
@@ -2507,7 +2508,7 @@ internal static class DreamProcNativeRoot {
             end = Math.Min(end + textElements.LengthInTextElements + 1, textElements.LengthInTextElements);
 
         if(start == 0 || start > textElements.LengthInTextElements || start > end)
-            throw new Exception("bad text or out of bounds");
+            throw new DMException("bad text or out of bounds");
 
         string result = textElements.SubstringByTextElements(0, start - 1);
         result += insertText;
@@ -2730,7 +2731,7 @@ internal static class DreamProcNativeRoot {
         } else if (value.IsNull) {
             return DreamValue.Null;
         } else {
-            throw new Exception($"Invalid argument to text2num: {value}");
+            throw new DMException($"Invalid argument to text2num: {value}");
         }
     }
 
@@ -2876,7 +2877,7 @@ internal static class DreamProcNativeRoot {
 
         // If Dir is not an integer, throw
         if (!dirArg.TryGetValueAsInteger(out int possibleDir)) {
-            throw new Exception("expected icon, matrix or integer");
+            throw new DMException("expected icon, matrix or integer");
         }
 
         AtomDirection dir = (AtomDirection)possibleDir;
@@ -3020,7 +3021,7 @@ internal static class DreamProcNativeRoot {
     [DreamProcParameter("Max", Type = DreamValueTypeFlag.Float)]
     [DreamProcParameter("inclusive", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
     public static DreamValue NativeProc_values_cut_over(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if (bundle.Arguments.Length < 2 || bundle.Arguments.Length > 3) throw new Exception($"expected 2-3 arguments (found {bundle.Arguments.Length})");
+        if (bundle.Arguments.Length < 2 || bundle.Arguments.Length > 3) throw new DMException($"expected 2-3 arguments (found {bundle.Arguments.Length})");
 
         DreamValue argList = bundle.GetArgument(0, "Alist");
         DreamValue argMax = bundle.GetArgument(1, "Max");
@@ -3034,7 +3035,7 @@ internal static class DreamProcNativeRoot {
     [DreamProcParameter("Min", Type = DreamValueTypeFlag.Float)]
     [DreamProcParameter("inclusive", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
     public static DreamValue NativeProc_values_cut_under(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if (bundle.Arguments.Length < 2 || bundle.Arguments.Length > 3) throw new Exception($"expected 2-3 arguments (found {bundle.Arguments.Length})");
+        if (bundle.Arguments.Length < 2 || bundle.Arguments.Length > 3) throw new DMException($"expected 2-3 arguments (found {bundle.Arguments.Length})");
 
         DreamValue argList = bundle.GetArgument(0, "Alist");
         DreamValue argMin = bundle.GetArgument(1, "Min");
@@ -3097,7 +3098,7 @@ internal static class DreamProcNativeRoot {
     [DreamProcParameter("A", Type = DreamValueTypeFlag.DreamObject)]
     [DreamProcParameter("B", Type = DreamValueTypeFlag.DreamObject)]
     public static DreamValue NativeProc_values_dot(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if (bundle.Arguments.Length != 2) throw new Exception("expected 2 arguments");
+        if (bundle.Arguments.Length != 2) throw new DMException("expected 2 arguments");
 
         DreamValue argA = bundle.GetArgument(0, "A");
         DreamValue argB = bundle.GetArgument(1, "B");
@@ -3125,7 +3126,7 @@ internal static class DreamProcNativeRoot {
     [DreamProc("values_product")]
     [DreamProcParameter("Alist", Type = DreamValueTypeFlag.DreamObject)]
     public static DreamValue NativeProc_values_product(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if (bundle.Arguments.Length != 1) throw new Exception("expected 1 argument");
+        if (bundle.Arguments.Length != 1) throw new DMException("expected 1 argument");
 
         DreamValue arg = bundle.GetArgument(0, "Alist");
 
@@ -3144,7 +3145,7 @@ internal static class DreamProcNativeRoot {
     [DreamProc("values_sum")]
     [DreamProcParameter("Alist", Type = DreamValueTypeFlag.DreamObject)]
     public static DreamValue NativeProc_values_sum(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-        if (bundle.Arguments.Length != 1) throw new Exception("expected 1 argument");
+        if (bundle.Arguments.Length != 1) throw new DMException("expected 1 argument");
 
         DreamValue arg = bundle.GetArgument(0, "Alist");
 
@@ -3333,7 +3334,7 @@ internal static class DreamProcNativeRoot {
         }
 
         if (connection == null) {
-            throw new Exception($"Invalid client {player}");
+            throw new DMException($"Invalid client {player}");
         }
 
         return await connection.WinExists(controlId);
@@ -3357,7 +3358,7 @@ internal static class DreamProcNativeRoot {
         }
 
         if (connection == null) {
-            throw new Exception($"Invalid client {player}");
+            throw new DMException($"Invalid client {player}");
         }
 
         if (string.IsNullOrEmpty(controlId) && paramsValue == "hwmode") {

--- a/OpenDreamRuntime/Procs/NativeProc.cs
+++ b/OpenDreamRuntime/Procs/NativeProc.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Resources;
 using OpenDreamRuntime.Map;
+using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs;
 
@@ -30,7 +31,7 @@ public sealed unsafe class NativeProc : DreamProc {
                     int intValue => new(intValue),
                     float floatValue => new(floatValue),
                     string stringValue => new(stringValue),
-                    _ => throw new Exception($"Invalid default value {parameterAttribute.DefaultValue}")
+                    _ => throw new DMException($"Invalid default value {parameterAttribute.DefaultValue}")
                 };
 
                 defaultArgumentValues.Add(parameterAttribute.Name, defaultValue);

--- a/OpenDreamRuntime/Procs/NativeProc.cs
+++ b/OpenDreamRuntime/Procs/NativeProc.cs
@@ -5,7 +5,6 @@ using JetBrains.Annotations;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Resources;
 using OpenDreamRuntime.Map;
-using OpenDreamShared;
 
 namespace OpenDreamRuntime.Procs;
 

--- a/OpenDreamRuntime/Procs/NativeProc.cs
+++ b/OpenDreamRuntime/Procs/NativeProc.cs
@@ -31,7 +31,7 @@ public sealed unsafe class NativeProc : DreamProc {
                     int intValue => new(intValue),
                     float floatValue => new(floatValue),
                     string stringValue => new(stringValue),
-                    _ => throw new DMException($"Invalid default value {parameterAttribute.DefaultValue}")
+                    _ => throw new Exception($"Invalid default value {parameterAttribute.DefaultValue}")
                 };
 
                 defaultArgumentValues.Add(parameterAttribute.Name, defaultValue);

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -1,9 +1,9 @@
-﻿using System.IO;
+using System.IO;
 // ReSharper disable once RedundantUsingDirective
 using System.Runtime.CompilerServices;
 using System.Text;
 using OpenDreamShared.Dream;
-
+using OpenDreamShared;
 namespace OpenDreamRuntime.Resources;
 
 [Virtual]
@@ -77,7 +77,7 @@ public class DreamResource(int id, string? filePath, string? resourcePath) {
         if (value.IsNull) {
             text = string.Empty;
         } else if (!value.TryGetValueAsString(out text)) {
-            throw new Exception($"Invalid output operation '{ResourcePath}' << {value}");
+            throw new DMException($"Invalid output operation '{ResourcePath}' << {value}");
         }
 
         // Prune any remaining formatting

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using OpenDreamShared.Dream;
-using OpenDreamShared;
 namespace OpenDreamRuntime.Resources;
 
 [Virtual]

--- a/OpenDreamShared/DMException.cs
+++ b/OpenDreamShared/DMException.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace OpenDreamShared;
+
+public sealed class DMException : Exception {
+    public DMException(string message) : base(message) { }
+}

--- a/OpenDreamShared/DMException.cs
+++ b/OpenDreamShared/DMException.cs
@@ -1,7 +1,0 @@
-using System;
-
-namespace OpenDreamShared;
-
-public sealed class DMException : Exception {
-    public DMException(string message) : base(message) { }
-}


### PR DESCRIPTION
## Context

While investigating the use of generic `Exception` in the DM runtime, I found that this is substantially larger than a single-file change.

`throw new Exception(...)` is used across OpenDream for several different categories of failures: DM-facing runtime errors, runtime/VM invariants, resource handling, compiler/bytecode validation, and other internal errors. Determining which cases should become `DMException` therefore requires distinguishing DM-originated failures from OpenDream implementation failures.

I initially focused on `DMOpcodeHandlers`, where several cases were straightforward DM errors. I also verified this behavior with faulty DM programs: for example, invalid arithmetic operations and division by zero now produce `OpenDreamShared.DMException` while preserving the existing DM error message and behavior.

## Current change

This PR introduces the shared `DMException` type and applies it to the confirmed DM-facing cases in `DMOpcodeHandlers`.

The intention here is **not** to change how these errors behave, but to give DM-originated runtime failures a distinct exception type.

## Question about the intended design

Before expanding this conversion further, I'd like to confirm the intended architecture.

Once `DMException` exists, should it:

1. Simply replace generic `Exception` at DM-facing failure sites while being handled by the existing runtime exception path?
2. Have dedicated handling somewhere in the runtime, such as catching `DMException` and converting it into a DM-visible runtime error?
3. Be handled differently from ordinary C# exceptions at a higher level?
4. Follow another pattern already used elsewhere in OpenDream?

The distinction matters because there are many additional `throw new Exception(...)` sites, and some are clearly DM-facing while others appear to represent OpenDream/VM invariants. Converting everything mechanically could incorrectly classify internal failures as DM errors.

I'd therefore appreciate guidance on the intended handling and boundary for `DMException` before continuing with the remaining cases.

If the intended approach is confirmed, I think the remaining conversion would be better split into smaller, independently reviewable changes rather than making one very large cross-cutting PR.
