### PR TITLE
Sort integration test files

### DIFF
--- a/Content.IntegrationTests/SetupCompileDM.cs
+++ b/Content.IntegrationTests/SetupCompileDM.cs
@@ -20,7 +20,10 @@ public sealed class SetupCompileDm {
     [OneTimeSetUp]
     public void Compile() {
         DMCompiler.DMCompiler compiler = new();
-        List<string> files = [DmEnvironment, .. Directory.EnumerateFiles(TestFilesDirectory, "*.dm")];
+        List<string> files = [
+            DmEnvironment,
+            .. Directory.EnumerateFiles(TestFilesDirectory, "*.dm").Order(StringComparer.Ordinal),
+        ];
         bool successfulCompile = compiler.Compile(new() {
             Files = files,
             DumpPreprocessor = true,


### PR DESCRIPTION
Integration test files were not sorted deterministically so spurious failures such as this one could happen: https://github.com/OpenDreamProject/OpenDream/actions/runs/31660207801/job/94323265328

The cause was move.dm running before bounds_dist.dm. The former caused the latter to fail because it changed world dimensions to be smaller than what the latter required.

I feel like it's still a fragile system if these kinds of dependencies are possible but at least now it's consistently fragile, and I guess the proper way to fix it would be to reset the world before each run, but that might make things slower. I haven't explored that.