### PR TITLE
Ignore the IDs on MAIN elements

### DIFF
--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -42,7 +42,7 @@ public abstract class InterfaceControl : InterfaceElement {
     protected abstract Control CreateUIElement();
 
     protected override void UpdateElementDescriptor() {
-        UIElement.Name = ControlDescriptor.Name.Value;
+        UIElement.Name = ControlDescriptor.Id.Value;
 
         //transparent is default because it's white with 0 alpha, and DMF color can't have none-255 alpha
         StyleBox? styleBox = (ControlDescriptor.BackgroundColor.Value != Color.Transparent)

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -254,7 +254,7 @@ public sealed class InterfaceMacro : InterfaceElement {
         ParsedKeybind parsedKeybind;
 
         try {
-            parsedKeybind = ParsedKeybind.Parse(ElementDescriptor.Name.AsRaw());
+            parsedKeybind = ParsedKeybind.Parse(descriptor.Name.AsRaw());
         } catch (Exception e) {
             Logger.GetSawmill("opendream.macro").Warning($"Invalid keybind for macro {Id}: {e.Message}");
             return;

--- a/OpenDreamClient/Interface/InterfaceMenu.cs
+++ b/OpenDreamClient/Interface/InterfaceMenu.cs
@@ -45,10 +45,12 @@ public sealed class InterfaceMenu : InterfaceElement {
         if (string.IsNullOrEmpty(elementDescriptor.Category.Value)) {
             element = new(elementDescriptor, this);
         } else {
-            if (!MenuElementsById.TryGetValue(elementDescriptor.Category.Value, out var parentMenu)) {
+            if (!MenuElementsById.TryGetValue(elementDescriptor.Category.Value, out var parentMenu) &&
+                !MenuElementsByName.TryGetValue(elementDescriptor.Category.Value, out parentMenu)) {
                 //if category is set but the parent element doesn't exist, create it
                 var parentMenuDescriptor = new MenuElementDescriptor {
-                    Id = elementDescriptor.Category
+                    Id = elementDescriptor.Category,
+                    Name = elementDescriptor.Category
                 };
 
                 parentMenu = new(parentMenuDescriptor, this);

--- a/OpenDreamClient/Interface/InterfaceMenu.cs
+++ b/OpenDreamClient/Interface/InterfaceMenu.cs
@@ -45,12 +45,10 @@ public sealed class InterfaceMenu : InterfaceElement {
         if (string.IsNullOrEmpty(elementDescriptor.Category.Value)) {
             element = new(elementDescriptor, this);
         } else {
-            if (!MenuElementsById.TryGetValue(elementDescriptor.Category.Value, out var parentMenu) &&
-                !MenuElementsByName.TryGetValue(elementDescriptor.Category.Value, out parentMenu)) {
+            if (!MenuElementsById.TryGetValue(elementDescriptor.Category.Value, out var parentMenu)) {
                 //if category is set but the parent element doesn't exist, create it
                 var parentMenuDescriptor = new MenuElementDescriptor {
-                    Id = elementDescriptor.Category,
-                    Name = elementDescriptor.Category
+                    Id = elementDescriptor.Category
                 };
 
                 parentMenu = new(parentMenuDescriptor, this);
@@ -63,7 +61,7 @@ public sealed class InterfaceMenu : InterfaceElement {
         }
 
         MenuElementsById.Add(element.Id.AsRaw(), element);
-        MenuElementsByName[element.ElementDescriptor.Name.AsRaw()] = element;
+        MenuElementsByName[element.MenuElementDescriptor.Name.AsRaw()] = element;
         CreateMenu(); // Update the menu to include the new child
     }
 
@@ -78,7 +76,7 @@ public sealed class InterfaceMenu : InterfaceElement {
                 continue;
 
             MenuBar.Menu menu = new() {
-                Title = menuElement.ElementDescriptor.Name.AsRaw()
+                Title = menuElement.MenuElementDescriptor.Name.AsRaw()
             };
 
             // TODO: Character after '&' becomes a selection shortcut
@@ -94,12 +92,12 @@ public sealed class InterfaceMenu : InterfaceElement {
     public sealed class MenuElement(MenuElementDescriptor data, InterfaceMenu menu) : InterfaceElement(data) {
         public readonly List<MenuElement> Children = new();
 
-        private MenuElementDescriptor MenuElementDescriptor => (MenuElementDescriptor) ElementDescriptor;
+        public MenuElementDescriptor MenuElementDescriptor => (MenuElementDescriptor) ElementDescriptor;
         public DMFPropertyString Category => MenuElementDescriptor.Category;
         public DMFPropertyString Command => MenuElementDescriptor.Command;
 
         public MenuBar.MenuEntry CreateMenuEntry() {
-            string text = ElementDescriptor.Name.AsRaw();
+            string text = MenuElementDescriptor.Name.AsRaw();
             text = text.Replace("&", string.Empty); // TODO: Character after '&' becomes a selection shortcut
 
             if(Children.Count > 0) {

--- a/OpenDreamShared/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamShared/Interface/Descriptors/ControlDescriptors.cs
@@ -115,8 +115,7 @@ public sealed partial class WindowDescriptor : ControlDescriptor {
             return null;
 
         if (elementTypeValue.Value == "MAIN") {
-            attributes.Remove("name");
-            attributes["name"] = new ValueDataNode(Name.Value);
+            attributes.Remove("id"); // Ignore the ID given to the MAIN element
 
             // Read the attributes into this descriptor
             serializationManager.Read(attributes, notNullableOverride: true, instanceProvider: () => this);

--- a/OpenDreamShared/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamShared/Interface/Descriptors/InterfaceDescriptor.cs
@@ -34,17 +34,9 @@ public partial class ElementDescriptor {
     [DataField("id")]
     protected DMFPropertyString _id;
 
-    [DataField("name")]
-    protected DMFPropertyString _name;
-
     public DMFPropertyString Id {
         get => string.IsNullOrEmpty(_id.Value) ? _id = new DMFPropertyString(Guid.NewGuid().ToString()) : _id; //ensure unique ID for all elements. Empty ID elements aren't addressible anyway.
         init => _id = value;
-    }
-
-    public DMFPropertyString Name {
-        get => new(_name.Value);
-        init => _name = value;
     }
 
     public DMFPropertyString Type {
@@ -71,6 +63,6 @@ public partial class ElementDescriptor {
     }
 
     public override string ToString() {
-        return $"{GetType().Name}(Type={Type},Name={Name})";
+        return $"{GetType().Name}(Type={Type},Id={Id})";
     }
 }

--- a/OpenDreamShared/Interface/Descriptors/MacroDescriptors.cs
+++ b/OpenDreamShared/Interface/Descriptors/MacroDescriptors.cs
@@ -38,6 +38,9 @@ public sealed partial class MacroSetDescriptor : ElementDescriptor {
 
 [UsedImplicitly]
 public sealed partial class MacroDescriptor : ElementDescriptor {
+    [DataField("name")]
+    public DMFPropertyString Name { get; private set; }
+
     [DataField("command")]
     public string Command { get; private set; } = default!;
 }

--- a/OpenDreamShared/Interface/Descriptors/MenuDescriptors.cs
+++ b/OpenDreamShared/Interface/Descriptors/MenuDescriptors.cs
@@ -38,8 +38,8 @@ public sealed partial class MenuDescriptor : ElementDescriptor {
 
 public sealed partial class MenuElementDescriptor : ElementDescriptor {
     [DataField("name")]
-    public DMFPropertyString Name { get; private set; }
-    
+    public DMFPropertyString Name { get; set; }
+
     [DataField("command")]
     public DMFPropertyString Command { get; private set; }
 

--- a/OpenDreamShared/Interface/Descriptors/MenuDescriptors.cs
+++ b/OpenDreamShared/Interface/Descriptors/MenuDescriptors.cs
@@ -37,8 +37,9 @@ public sealed partial class MenuDescriptor : ElementDescriptor {
 }
 
 public sealed partial class MenuElementDescriptor : ElementDescriptor {
-
-
+    [DataField("name")]
+    public DMFPropertyString Name { get; private set; }
+    
     [DataField("command")]
     public DMFPropertyString Command { get; private set; }
 
@@ -53,6 +54,7 @@ public sealed partial class MenuElementDescriptor : ElementDescriptor {
 
     [DataField("group")]
     public DMFPropertyString Group { get; private set; }
+
     [DataField("index")]
     public DMFPropertyNum Index { get; private set; }
 


### PR DESCRIPTION
The ID given to the window is always used in placed of the MAIN element's ID. Fixes #2691.

I also moved the `name` attribute to only be on `MacroDescriptor` and `MenuElementDescriptor`. The DM ref says only macros and menus have it, and the existence of both on every control was confusing.